### PR TITLE
perf(scan): cache + parallel I/O + skip list (Phase 1)

### DIFF
--- a/.codecityignore
+++ b/.codecityignore
@@ -1,0 +1,12 @@
+# Per-project skip list for the codecity scanner. Augments the
+# hardcoded ALWAYS_SKIP set (node_modules, .venv, .git, etc.).
+#
+# Format:
+#   - Bare names match any dir/file with that name in the tree.
+#   - Lines containing '/' are relative-path matches anchored to repo root.
+#   - Lines starting with '#' are comments. Blank lines ignored.
+
+# Synthetic benchmark fixtures — gitignored, but surface under
+# `Show all files`. Hide them so the city stays focused on the codebase.
+codecity/tests/fixtures/large-repo
+codecity/tests/fixtures/sample-repo

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ docs/superpowers/
 # Generated test fixtures
 #   run `bash codecity/tests/fixtures/setup.sh` to regenerate
 codecity/tests/fixtures/sample-repo/
+#   run `bash codecity/tests/fixtures/large-repo-setup.sh` to regenerate
+codecity/tests/fixtures/large-repo/
 
 # OS
 .DS_Store

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,6 @@
 - [ ] display images and videos as billboards? let users click to play billboard video
 - [ ] identify and add something special to test files
 - [ ] python cli make it more professional
-- [ ] add back gitignore flag -- make it a user facing config option
+- [x] add back gitignore flag -- make it a user facing config option
 
 ## Pending Agent Prompts

--- a/codecity/cache.py
+++ b/codecity/cache.py
@@ -1,0 +1,203 @@
+"""Persistent on-disk caches for the scanner.
+
+Two caches with shared infrastructure:
+  - Files: per-file (size, mtime) -> (lines, binary, ext) so warm
+    re-scans skip _is_binary + _line_count for unchanged files.
+  - Git history: per-repo HEAD-keyed (created_map, modified_map) so
+    polling doesn't re-walk git log on every cycle.
+
+Both caches store one file per scanned root in
+~/.cache/codecity/{files,git-history}/<repo-key>.json. repo_key() is a
+short SHA-256 of the absolute root path.
+
+Invariants:
+  - All loads return safe empty/None values on any error (corrupt JSON,
+    version mismatch, missing file). Cache failures never block scans.
+  - All writes are atomic (tempfile + rename) so an interrupted scan
+    cannot corrupt the cache.
+  - File-stat cache is union-merged on save by callers (entries the
+    scan didn't visit are passed through unchanged). This module just
+    persists whatever dict it's handed.
+  - Git-history cache is overwritten on save (one HEAD per repo).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import TypedDict
+
+# Module-level CACHE_ROOT — tests monkeypatch this to a tempdir. Derived
+# subdirs are computed at call time (not at import) so the override
+# cascades through.
+CACHE_ROOT = Path.home() / ".cache" / "codecity"
+
+_FILE_CACHE_VERSION = 1
+_GIT_HISTORY_CACHE_VERSION = 1
+
+
+class FileEntry(TypedDict):
+    size: int
+    mtime: float
+    lines: int
+    binary: bool
+    ext: str
+
+
+def _coerce_file_entry(value: object) -> FileEntry | None:
+    """Validate a parsed JSON value is a well-formed FileEntry. Returns
+    the entry on success, None if any field is missing or wrong-typed.
+
+    Drops the entry rather than raising — a partially-corrupt cache
+    file should yield only valid entries, not block the whole load."""
+    if not isinstance(value, dict):
+        return None
+    try:
+        size = value["size"]
+        mtime = value["mtime"]
+        lines = value["lines"]
+        binary = value["binary"]
+        ext = value["ext"]
+    except KeyError:
+        return None
+    if not isinstance(size, int):
+        return None
+    if not isinstance(mtime, (int, float)):
+        return None
+    if not isinstance(lines, int):
+        return None
+    if not isinstance(binary, bool):
+        return None
+    if not isinstance(ext, str):
+        return None
+    return {
+        "size": size,
+        "mtime": float(mtime),
+        "lines": lines,
+        "binary": binary,
+        "ext": ext,
+    }
+
+
+def repo_key(abs_root: Path) -> str:
+    """Stable short identifier for a repository's cache file. SHA-256 of
+    the absolute path, first 16 hex chars."""
+    return hashlib.sha256(str(abs_root).encode("utf-8")).hexdigest()[:16]
+
+
+def _atomic_write(path: Path, data: str) -> None:
+    """Write `data` to `path` via tempfile + rename so a crashed write
+    doesn't corrupt the existing file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def _file_cache_path(abs_root: Path) -> Path:
+    return CACHE_ROOT / "files" / f"{repo_key(abs_root)}.json"
+
+
+def cache_load_files(abs_root: Path) -> dict[str, FileEntry]:
+    """Load the file-stat cache for this root. Returns {} on any error.
+
+    Per-entry validation: malformed entries (missing fields, wrong
+    types) are dropped silently. The cache is rebuildable from disk,
+    so a partial load is preferable to a hard failure."""
+    path = _file_cache_path(abs_root)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    if raw.get("version") != _FILE_CACHE_VERSION:
+        return {}
+    entries = raw.get("entries")
+    if not isinstance(entries, dict):
+        return {}
+    result: dict[str, FileEntry] = {}
+    for key, value in entries.items():
+        if not isinstance(key, str):
+            continue
+        coerced = _coerce_file_entry(value)
+        if coerced is not None:
+            result[key] = coerced
+    return result
+
+
+def cache_save_files(abs_root: Path, entries: dict[str, FileEntry]) -> None:
+    """Atomically write the file-stat cache for this root."""
+    payload = {
+        "version": _FILE_CACHE_VERSION,
+        "root": str(abs_root),
+        "entries": entries,
+    }
+    _atomic_write(_file_cache_path(abs_root), json.dumps(payload))
+
+
+def _git_history_cache_path(abs_root: Path) -> Path:
+    return CACHE_ROOT / "git-history" / f"{repo_key(abs_root)}.json"
+
+
+def cache_load_git_history(
+    abs_root: Path, head_sha: str,
+) -> tuple[dict[str, str], dict[str, str]] | None:
+    """Load git-history maps if cached for this root AND HEAD. Returns
+    None on miss, HEAD mismatch, or any error.
+
+    Per-entry validation: only string keys mapped to string values
+    survive; everything else is dropped silently."""
+    path = _git_history_cache_path(abs_root)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    if raw.get("version") != _GIT_HISTORY_CACHE_VERSION:
+        return None
+    if raw.get("head_sha") != head_sha:
+        return None
+    created_raw = raw.get("created")
+    modified_raw = raw.get("modified")
+    if not isinstance(created_raw, dict) or not isinstance(modified_raw, dict):
+        return None
+    created = {
+        k: v for k, v in created_raw.items()
+        if isinstance(k, str) and isinstance(v, str)
+    }
+    modified = {
+        k: v for k, v in modified_raw.items()
+        if isinstance(k, str) and isinstance(v, str)
+    }
+    return created, modified
+
+
+def cache_save_git_history(
+    abs_root: Path,
+    head_sha: str,
+    created: dict[str, str],
+    modified: dict[str, str],
+) -> None:
+    """Atomically write the git-history cache for this root + HEAD."""
+    payload = {
+        "version": _GIT_HISTORY_CACHE_VERSION,
+        "root": str(abs_root),
+        "head_sha": head_sha,
+        "created": created,
+        "modified": modified,
+    }
+    _atomic_write(_git_history_cache_path(abs_root), json.dumps(payload))

--- a/codecity/cli.py
+++ b/codecity/cli.py
@@ -75,22 +75,12 @@ def _add_perf_args(p: argparse.ArgumentParser) -> None:
             "suspect cache staleness."
         ),
     )
-    p.add_argument(
-        "--no-skip-list",
-        action="store_true",
-        help=(
-            "When --include-all (Show all files) is on, walk into "
-            "node_modules/, dist/, .venv/, etc. that would normally be "
-            "skipped. .git/ is still always excluded."
-        ),
-    )
 
 
 def _scan_from_args(args: argparse.Namespace) -> Manifest:
     return scan_tree(
         args.path,
         use_cache=not getattr(args, "no_cache", False),
-        respect_skip_list=not getattr(args, "no_skip_list", False),
     )
 
 
@@ -113,9 +103,9 @@ def _initial_query(args: argparse.Namespace) -> str:
     initial browser URL. Resolves clones eagerly so the user gets a clear
     error in the terminal instead of a silent 502 in the browser.
 
-    Forwards --no-cache and --no-skip-list as query params so the
-    frontend's URL builder picks them up alongside the path / clone
-    args, and the live-update poll inherits them."""
+    Forwards --no-cache as a query param so the frontend's URL builder
+    picks it up alongside the path / clone args, and the live-update
+    poll inherits it."""
     if args.clone:
         try:
             local = ensure_clone(args.clone, args.branch)
@@ -132,8 +122,6 @@ def _initial_query(args: argparse.Namespace) -> str:
 
     if getattr(args, "no_cache", False):
         params["no_cache"] = "true"
-    if getattr(args, "no_skip_list", False):
-        params["no_skip_list"] = "true"
     return "?" + urllib.parse.urlencode(params)
 
 

--- a/codecity/cli.py
+++ b/codecity/cli.py
@@ -64,8 +64,34 @@ def _add_scan_args(p: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_perf_args(p: argparse.ArgumentParser) -> None:
+    """Performance / debugging flags shared by `scan` and `serve`."""
+    p.add_argument(
+        "--no-cache",
+        action="store_true",
+        help=(
+            "Bypass the file-stat and git-history caches under "
+            "~/.cache/codecity/. Diagnostic flag — useful when you "
+            "suspect cache staleness."
+        ),
+    )
+    p.add_argument(
+        "--no-skip-list",
+        action="store_true",
+        help=(
+            "When --include-all (Show all files) is on, walk into "
+            "node_modules/, dist/, .venv/, etc. that would normally be "
+            "skipped. .git/ is still always excluded."
+        ),
+    )
+
+
 def _scan_from_args(args: argparse.Namespace) -> Manifest:
-    return scan_tree(args.path)
+    return scan_tree(
+        args.path,
+        use_cache=not getattr(args, "no_cache", False),
+        respect_skip_list=not getattr(args, "no_skip_list", False),
+    )
 
 
 # ── Commands ─────────────────────────────────────────────────────────────────
@@ -85,7 +111,11 @@ def cmd_scan(args: argparse.Namespace) -> int:
 def _initial_query(args: argparse.Namespace) -> str:
     """Build the `?path=…` or `?clone=…&branch=…` query string for the
     initial browser URL. Resolves clones eagerly so the user gets a clear
-    error in the terminal instead of a silent 502 in the browser."""
+    error in the terminal instead of a silent 502 in the browser.
+
+    Forwards --no-cache and --no-skip-list as query params so the
+    frontend's URL builder picks them up alongside the path / clone
+    args, and the live-update poll inherits them."""
     if args.clone:
         try:
             local = ensure_clone(args.clone, args.branch)
@@ -93,12 +123,18 @@ def _initial_query(args: argparse.Namespace) -> str:
             print(f"error: {e}", file=sys.stderr)
             raise SystemExit(2)
         print(f"[codecity] clone ready at {local}", file=sys.stderr)
-        params = {"clone": args.clone}
+        params: dict[str, str] = {"clone": args.clone}
         if args.branch:
             params["branch"] = args.branch
-        return "?" + urllib.parse.urlencode(params)
-    abs_path = str(Path(args.path).resolve())
-    return "?" + urllib.parse.urlencode({"path": abs_path})
+    else:
+        abs_path = str(Path(args.path).resolve())
+        params = {"path": abs_path}
+
+    if getattr(args, "no_cache", False):
+        params["no_cache"] = "true"
+    if getattr(args, "no_skip_list", False):
+        params["no_skip_list"] = "true"
+    return "?" + urllib.parse.urlencode(params)
 
 
 def cmd_serve(args: argparse.Namespace) -> int:
@@ -292,6 +328,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_serve = sub.add_parser("serve", help="Start the server, open the browser (default action).")
     _add_scan_args(p_serve)
+    _add_perf_args(p_serve)
     p_serve.add_argument(
         "--clone",
         default=None,
@@ -317,6 +354,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_scan = sub.add_parser("scan", help="Emit the scanned manifest as JSON.")
     _add_scan_args(p_scan)
+    _add_perf_args(p_scan)
     p_scan.add_argument(
         "--output",
         default="-",

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from .cache import (
+    FileEntry,
     cache_load_files,
     cache_load_git_history,
     cache_save_files,
@@ -414,21 +415,75 @@ def _read_file_metadata(path_obj: Path) -> tuple[bool, int]:
     return binary, lines
 
 
-def _populate_file_metadata(tree: DirNode) -> None:
+def _node_mtime(node: FileNode) -> float:
+    """Recover the float mtime for a FileNode by stat-ing fullPath.
+    The node's `modified` field is an ISO string (lossy for cache
+    comparison); the raw mtime feeds the cache directly."""
+    try:
+        return Path(node["fullPath"]).stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _populate_file_metadata(
+    tree: DirNode, abs_root: Path, *, use_cache: bool,
+) -> None:
     """Walk the skeleton tree and fill in `lines` + `binary` for every
-    FileNode. Reads run concurrently in a thread pool (GIL releases on
-    file I/O, so this is a real wall-clock win)."""
+    FileNode.
+
+    With ``use_cache=True``, looks up each file in the persistent
+    file-stat cache by (rel-path, size, mtime); cache hits skip the
+    read entirely. Misses run concurrently in a thread pool (GIL
+    releases on file I/O). The cache is union-merged at end-of-scan
+    so files we didn't visit (e.g. excluded by include_all=False)
+    keep their existing entries."""
     nodes: list[FileNode] = list(_iter_file_nodes(tree))
     if not nodes:
         return
 
-    paths = [Path(n["fullPath"]) for n in nodes]
-    with ThreadPoolExecutor(max_workers=_FILE_IO_POOL_SIZE) as pool:
-        results = list(pool.map(_read_file_metadata, paths))
+    cache_entries: dict[str, FileEntry] = (
+        cache_load_files(abs_root) if use_cache else {}
+    )
 
-    for node, (binary, lines) in zip(nodes, results):
-        node["binary"] = binary
-        node["lines"] = lines
+    miss_indices: list[int] = []
+    miss_paths: list[Path] = []
+    for i, node in enumerate(nodes):
+        rel = node["path"]
+        cached = cache_entries.get(rel) if use_cache else None
+        if (
+            cached is not None
+            and cached["size"] == node["size"]
+            and cached["mtime"] == _node_mtime(node)
+        ):
+            node["binary"] = cached["binary"]
+            node["lines"] = cached["lines"]
+            continue
+        miss_indices.append(i)
+        miss_paths.append(Path(node["fullPath"]))
+
+    if miss_paths:
+        with ThreadPoolExecutor(max_workers=_FILE_IO_POOL_SIZE) as pool:
+            results = list(pool.map(_read_file_metadata, miss_paths))
+        for idx, (binary, lines) in zip(miss_indices, results):
+            nodes[idx]["binary"] = binary
+            nodes[idx]["lines"] = lines
+
+    if use_cache:
+        # Union-merge: start from the loaded cache (preserves entries
+        # for files not visited this scan, e.g. when include_all flips)
+        # and overwrite with current values for everything we did visit.
+        for node in nodes:
+            cache_entries[node["path"]] = {
+                "size": node["size"],
+                "mtime": _node_mtime(node),
+                "lines": node["lines"],
+                "binary": node["binary"],
+                "ext": node["extension"],
+            }
+        try:
+            cache_save_files(abs_root, cache_entries)
+        except OSError:
+            pass  # cache save failures must never break scanning
 
 
 def _iter_file_nodes(tree: DirNode) -> Iterator[FileNode]:
@@ -592,7 +647,7 @@ def scan_tree(
         respect_skip_list=respect_skip_list, sig=sig,
     )
     _log(f"walked {_files_seen} files; resolving file metadata")
-    _populate_file_metadata(tree)
+    _populate_file_metadata(tree, Path(root_abs), use_cache=use_cache)
     _log("emitting manifest")
 
     # Repo-level metadata — branch, remote, head, dirty — feeds the

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -547,6 +547,7 @@ def _walk_for_signature(
     is_git_repo: bool,
     tracked_files: set[str],
     include_all: bool,
+    respect_skip_list: bool,
     sig: Any,
 ) -> None:
     """Stat-only walk that feeds the live signature without building nodes.
@@ -562,7 +563,7 @@ def _walk_for_signature(
         return
 
     for entry in entries:
-        if entry.name == ".git":
+        if _should_skip(entry.name, respect_skip_list=respect_skip_list):
             continue
         entry_rel = entry.name if rel_dir == "." else f"{rel_dir}/{entry.name}"
         if is_git_repo and not include_all and entry_rel not in tracked_files:
@@ -576,11 +577,17 @@ def _walk_for_signature(
                 is_git_repo=is_git_repo,
                 tracked_files=tracked_files,
                 include_all=include_all,
+                respect_skip_list=respect_skip_list,
                 sig=sig,
             )
 
 
-def signature_tree(root: str, *, include_all: bool = False) -> SignatureResponse:
+def signature_tree(
+    root: str,
+    *,
+    include_all: bool = False,
+    respect_skip_list: bool = True,
+) -> SignatureResponse:
     """Cheap fingerprint of the tree — equivalent to scan_tree(root, include_all=…)['signature']
     but without building the full manifest.
 
@@ -612,6 +619,7 @@ def signature_tree(root: str, *, include_all: bool = False) -> SignatureResponse
         is_git_repo=is_git_repo,
         tracked_files=tracked_files,
         include_all=include_all,
+        respect_skip_list=respect_skip_list,
         sig=sig,
     )
     if repo_info is not None:

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -303,17 +303,22 @@ def _collect_repo_info(root: Path) -> RepoInfo:
 
 # Directory names that get skipped even when include_all=True. Keeps
 # `Show all files` mode usable on a typical project — without this list
-# enabling include_all pulls in node_modules/, dist/, .venv/, etc. and
-# the city becomes useless noise.
+# enabling include_all pulls in node_modules/, .venv/, etc. and the
+# city becomes useless noise.
 #
 # .git/ is excluded separately (always, even with respect_skip_list=False)
 # because we never want to walk into the object database.
+#
+# We deliberately do NOT include generic names like "dist", "build", "out".
+# Those collide with legitimate source directories in real projects (CMake
+# build configs, audio "out" stems, hand-written `dist/` source trees).
+# Framework-specific build dirs (.next, .nuxt, etc.) are unambiguous and
+# stay in the list.
 ALWAYS_SKIP: frozenset[str] = frozenset({
     ".git", ".hg", ".svn",                          # VCS
     "node_modules",                                 # JS
     ".venv", "venv", "env", "__pycache__",          # Python
     "target", ".cargo",                             # Rust
-    "dist", "build", "out",                         # generic build outputs
     ".next", ".nuxt", ".svelte-kit",                # framework caches
     ".pytest_cache", ".mypy_cache", ".ruff_cache",
     ".tox", ".coverage", "htmlcov",                 # test/coverage

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -399,18 +399,36 @@ def _file_node(
     }
 
 
+# Worker pool size for parallel file content reads. Capped at 32 to
+# avoid pool-construction overhead on machines with very high cpu_count;
+# doubling cpu_count gives oversubscription that helps when threads
+# block on read().
+_FILE_IO_POOL_SIZE = min(32, (os.cpu_count() or 1) * 2)
+
+
+def _read_file_metadata(path_obj: Path) -> tuple[bool, int]:
+    """Return (binary, lines) for one file. Worker function for
+    _populate_file_metadata's thread pool."""
+    binary = _is_binary(path_obj)
+    lines = 0 if binary else _line_count(path_obj)
+    return binary, lines
+
+
 def _populate_file_metadata(tree: DirNode) -> None:
     """Walk the skeleton tree and fill in `lines` + `binary` for every
-    FileNode. Operates in-place on the tree's FileNode dicts.
+    FileNode. Reads run concurrently in a thread pool (GIL releases on
+    file I/O, so this is a real wall-clock win)."""
+    nodes: list[FileNode] = list(_iter_file_nodes(tree))
+    if not nodes:
+        return
 
-    Single-threaded for now; Task 8 parallelizes via ThreadPoolExecutor,
-    Task 9 adds the file-stat cache layer.
-    """
-    for node in _iter_file_nodes(tree):
-        path_obj = Path(node["fullPath"])
-        binary = _is_binary(path_obj)
+    paths = [Path(n["fullPath"]) for n in nodes]
+    with ThreadPoolExecutor(max_workers=_FILE_IO_POOL_SIZE) as pool:
+        results = list(pool.map(_read_file_metadata, paths))
+
+    for node, (binary, lines) in zip(nodes, results):
         node["binary"] = binary
-        node["lines"] = 0 if binary else _line_count(path_obj)
+        node["lines"] = lines
 
 
 def _iter_file_nodes(tree: DirNode) -> Iterator[FileNode]:

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -253,6 +253,43 @@ def _collect_repo_info(root: Path) -> RepoInfo:
     return info
 
 
+# ── Skip list ────────────────────────────────────────────────────────────────
+
+# Directory names that get skipped even when include_all=True. Keeps
+# `Show all files` mode usable on a typical project — without this list
+# enabling include_all pulls in node_modules/, dist/, .venv/, etc. and
+# the city becomes useless noise.
+#
+# .git/ is excluded separately (always, even with respect_skip_list=False)
+# because we never want to walk into the object database.
+ALWAYS_SKIP: frozenset[str] = frozenset({
+    ".git", ".hg", ".svn",                          # VCS
+    "node_modules",                                 # JS
+    ".venv", "venv", "env", "__pycache__",          # Python
+    "target", ".cargo",                             # Rust
+    "dist", "build", "out",                         # generic build outputs
+    ".next", ".nuxt", ".svelte-kit",                # framework caches
+    ".pytest_cache", ".mypy_cache", ".ruff_cache",
+    ".tox", ".coverage", "htmlcov",                 # test/coverage
+    ".idea", ".vscode",                             # IDE state
+    ".DS_Store",                                    # macOS junk
+})
+
+
+def _should_skip(name: str, *, respect_skip_list: bool) -> bool:
+    """Whether to skip a directory entry by name during the walk.
+
+    .git/ is always excluded — we never walk into the object database.
+    Other entries in ALWAYS_SKIP are gated on respect_skip_list, which
+    is True by default but can be turned off for diagnostic walks
+    (--no-skip-list CLI flag, ?no_skip_list=true query param)."""
+    if name == ".git":
+        return True
+    if respect_skip_list and name in ALWAYS_SKIP:
+        return True
+    return False
+
+
 # ── Tree walk ────────────────────────────────────────────────────────────────
 
 
@@ -342,6 +379,7 @@ def _build_tree(
     git_modified: dict[str, str],
     tracked_files: set[str],
     include_all: bool,
+    respect_skip_list: bool,
     sig: Any,
 ) -> DirNode:
     name = os.path.basename(abs_dir)
@@ -360,7 +398,7 @@ def _build_tree(
         entries = []
 
     for entry in entries:
-        if entry.name == ".git":
+        if _should_skip(entry.name, respect_skip_list=respect_skip_list):
             continue
 
         entry_rel = entry.name if rel_dir == "." else f"{rel_dir}/{entry.name}"
@@ -386,7 +424,8 @@ def _build_tree(
                 entry.path, entry_rel,
                 is_git_repo=is_git_repo,
                 git_created=git_created, git_modified=git_modified,
-                tracked_files=tracked_files, include_all=include_all, sig=sig,
+                tracked_files=tracked_files, include_all=include_all,
+                respect_skip_list=respect_skip_list, sig=sig,
             )
             dirs.append(subtree)
             descendants_count += 1 + subtree["descendants_count"]
@@ -414,7 +453,12 @@ def _build_tree(
 # ── Public entry ─────────────────────────────────────────────────────────────
 
 
-def scan_tree(root: str, *, include_all: bool = False) -> Manifest:
+def scan_tree(
+    root: str,
+    *,
+    include_all: bool = False,
+    respect_skip_list: bool = True,
+) -> Manifest:
     """Scan a directory and return the full manifest.
 
     With ``include_all=False`` (default), in a git repo the scanner walks
@@ -425,6 +469,12 @@ def scan_tree(root: str, *, include_all: bool = False) -> Manifest:
 
     Outside a git repo, ``include_all`` has no effect — the tracked set
     is empty either way.
+
+    ``respect_skip_list`` (default True) honors the ALWAYS_SKIP set
+    (``node_modules``, ``dist``, ``.venv``, etc.) even when
+    ``include_all=True``. Set to False (--no-skip-list CLI flag) to
+    walk into those dirs anyway. ``.git`` is always excluded
+    regardless.
     """
     root_abs = str(Path(root).resolve())
     _log(f"resolving {root_abs}")
@@ -451,7 +501,8 @@ def scan_tree(root: str, *, include_all: bool = False) -> Manifest:
         root_abs, ".",
         is_git_repo=is_git_repo,
         git_created=git_created, git_modified=git_modified,
-        tracked_files=tracked_files, include_all=include_all, sig=sig,
+        tracked_files=tracked_files, include_all=include_all,
+        respect_skip_list=respect_skip_list, sig=sig,
     )
     _log(f"walked {_files_seen} files; emitting manifest")
 

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -23,6 +23,7 @@ import json
 import os
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -155,46 +156,53 @@ def _is_git_repo(root: Path) -> bool:
     return _run_git(root, "rev-parse", "--git-dir").strip() != ""
 
 
-def _collect_git_metadata(root: Path) -> tuple[dict[str, str], dict[str, str], set[str]]:
+def _collect_git_dates(root: Path, *log_args: str) -> dict[str, str]:
+    """Walk one `git log` invocation, return {path: ISO-date}.
+
+    The two callers in _collect_git_metadata both use the COMMIT:<date>
+    + --name-only protocol; this helper centralizes the parser so they
+    can run concurrently in a thread pool without duplicating logic.
+
+    First occurrence wins — caller controls direction via `--reverse`."""
+    out = _run_git(
+        root, "log",
+        "--format=COMMIT:%aI", "--name-only",
+        *log_args,
+    )
+    result: dict[str, str] = {}
+    current_date = ""
+    for line in out.splitlines():
+        if line.startswith("COMMIT:"):
+            current_date = line[len("COMMIT:"):]
+        elif line and line not in result:
+            result[line] = current_date
+    return result
+
+
+def _collect_git_metadata(
+    root: Path,
+) -> tuple[dict[str, str], dict[str, str], set[str]]:
     """Return (created_map, modified_map, tracked_set).
 
     - created_map[path]  = earliest add-commit ISO date
     - modified_map[path] = most recent commit-that-touched-it ISO date
     - tracked_set        = all tracked paths + their parent dirs (for gitignore filter)
+
+    The two `git log` walks are independent and run in parallel via a
+    ThreadPoolExecutor. The tracked-set query runs serially after — it's
+    cheap (one `git ls-files`) and the caller may need it before the
+    other two complete anyway.
     """
-    created: dict[str, str] = {}
-    modified: dict[str, str] = {}
-    tracked: set[str] = set()
+    _log("  collecting creation + modified dates (parallel git log walks)…")
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        created_future = pool.submit(
+            _collect_git_dates, root, "--reverse", "--diff-filter=A",
+        )
+        modified_future = pool.submit(_collect_git_dates, root)
+        created = created_future.result()
+        modified = modified_future.result()
+    _log(f"    {len(created)} created, {len(modified)} modified")
 
-    # Created: walk in chronological order, first occurrence wins (oldest).
-    _log("  collecting creation dates (one git log walk)…")
-    out = _run_git(
-        root, "log", "--reverse",
-        "--format=COMMIT:%aI", "--name-only", "--diff-filter=A",
-    )
-    current_date = ""
-    for line in out.splitlines():
-        if line.startswith("COMMIT:"):
-            current_date = line[len("COMMIT:"):]
-        elif line and line not in created:
-            created[line] = current_date
-    _log(f"    {len(created)} files")
-
-    # Modified: reverse-chron (git default), first occurrence wins (most recent).
-    _log("  collecting modified dates (one git log walk)…")
-    out = _run_git(
-        root, "log",
-        "--format=COMMIT:%aI", "--name-only",
-    )
-    current_date = ""
-    for line in out.splitlines():
-        if line.startswith("COMMIT:"):
-            current_date = line[len("COMMIT:"):]
-        elif line and line not in modified:
-            modified[line] = current_date
-    _log(f"    {len(modified)} files")
-
-    # Tracked set (for .gitignore filter) — includes parent dirs.
     _log("  listing tracked files…")
     tracked = _collect_tracked_set(root)
     _log(f"    {len(tracked)} tracked entries (files + dirs)")

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -306,14 +306,15 @@ def _collect_repo_info(root: Path) -> RepoInfo:
 # enabling include_all pulls in node_modules/, .venv/, etc. and the
 # city becomes useless noise.
 #
-# .git/ is excluded separately (always, even with respect_skip_list=False)
-# because we never want to walk into the object database.
-#
 # We deliberately do NOT include generic names like "dist", "build", "out".
 # Those collide with legitimate source directories in real projects (CMake
 # build configs, audio "out" stems, hand-written `dist/` source trees).
 # Framework-specific build dirs (.next, .nuxt, etc.) are unambiguous and
 # stay in the list.
+#
+# Per-project additions go in `<scan-root>/.codecityignore` (see
+# _load_codecityignore). The skip list is always applied — there's no
+# runtime escape hatch beyond editing this file or .codecityignore.
 ALWAYS_SKIP: frozenset[str] = frozenset({
     ".git", ".hg", ".svn",                          # VCS
     "node_modules",                                 # JS
@@ -327,16 +328,56 @@ ALWAYS_SKIP: frozenset[str] = frozenset({
 })
 
 
-def _should_skip(name: str, *, respect_skip_list: bool) -> bool:
-    """Whether to skip a directory entry by name during the walk.
+def _load_codecityignore(root: Path) -> tuple[frozenset[str], frozenset[str]]:
+    """Load .codecityignore from the scan root, return (names, paths).
 
-    .git/ is always excluded — we never walk into the object database.
-    Other entries in ALWAYS_SKIP are gated on respect_skip_list, which
-    is True by default but can be turned off for diagnostic walks
-    (--no-skip-list CLI flag, ?no_skip_list=true query param)."""
-    if name == ".git":
+    Lines without a '/' match any directory/file with that name anywhere
+    in the tree (same semantic as ALWAYS_SKIP). Lines containing '/'
+    are relative-path matches anchored to the scan root.
+
+    Comments (#) and blank lines are ignored. Whitespace is stripped.
+    A leading '/' is dropped — paths are always relative to root.
+    Trailing '/' is stripped — directories vs files don't matter for
+    skipping. Missing file or unreadable contents → two empty sets, no
+    error (the file is optional)."""
+    names: set[str] = set()
+    paths: set[str] = set()
+    try:
+        text = (root / ".codecityignore").read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return frozenset(), frozenset()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        line = line.removeprefix("/").removesuffix("/")
+        if not line:
+            continue
+        if "/" in line:
+            paths.add(line)
+        else:
+            names.add(line)
+    return frozenset(names), frozenset(paths)
+
+
+def _should_skip(
+    name: str,
+    rel_path: str,
+    *,
+    ignore_names: frozenset[str],
+    ignore_paths: frozenset[str],
+) -> bool:
+    """Whether to skip a directory entry during the walk.
+
+    Always-skipped: ALWAYS_SKIP set + any name in `ignore_names` (from
+    .codecityignore single-segment lines). Path-anchored skips: any
+    `rel_path` in `ignore_paths` (from .codecityignore lines containing
+    '/'). `.git/` is in ALWAYS_SKIP; no separate special case needed."""
+    if name in ALWAYS_SKIP:
         return True
-    if respect_skip_list and name in ALWAYS_SKIP:
+    if name in ignore_names:
+        return True
+    if rel_path in ignore_paths:
         return True
     return False
 
@@ -525,7 +566,8 @@ def _build_tree(
     git_modified: dict[str, str],
     tracked_files: set[str],
     include_all: bool,
-    respect_skip_list: bool,
+    ignore_names: frozenset[str],
+    ignore_paths: frozenset[str],
     sig: Any,
 ) -> DirNode:
     name = os.path.basename(abs_dir)
@@ -544,10 +586,13 @@ def _build_tree(
         entries = []
 
     for entry in entries:
-        if _should_skip(entry.name, respect_skip_list=respect_skip_list):
-            continue
-
         entry_rel = entry.name if rel_dir == "." else f"{rel_dir}/{entry.name}"
+
+        if _should_skip(
+            entry.name, entry_rel,
+            ignore_names=ignore_names, ignore_paths=ignore_paths,
+        ):
+            continue
 
         # In a git repo, skip anything not tracked (covers .gitignore + uncommitted
         # additions) — unless include_all is on, the user's "show me everything"
@@ -571,7 +616,8 @@ def _build_tree(
                 is_git_repo=is_git_repo,
                 git_created=git_created, git_modified=git_modified,
                 tracked_files=tracked_files, include_all=include_all,
-                respect_skip_list=respect_skip_list, sig=sig,
+                ignore_names=ignore_names, ignore_paths=ignore_paths,
+                sig=sig,
             )
             dirs.append(subtree)
             descendants_count += 1 + subtree["descendants_count"]
@@ -603,7 +649,6 @@ def scan_tree(
     root: str,
     *,
     include_all: bool = False,
-    respect_skip_list: bool = True,
     use_cache: bool = True,
 ) -> Manifest:
     """Scan a directory and return the full manifest.
@@ -611,17 +656,16 @@ def scan_tree(
     With ``include_all=False`` (default), in a git repo the scanner walks
     only paths in ``git ls-files`` — gitignored and untracked files are
     hidden. With ``include_all=True``, the tracked-files filter is
-    skipped entirely; every file under ``root`` (except the ``.git``
-    directory itself) is emitted. ``.git`` is always excluded.
+    skipped entirely; every file under ``root`` is emitted EXCEPT
+    those in ALWAYS_SKIP (``node_modules``, ``.venv``, ``.git``, etc.)
+    or matched by the optional ``<root>/.codecityignore`` file.
 
     Outside a git repo, ``include_all`` has no effect — the tracked set
     is empty either way.
 
-    ``respect_skip_list`` (default True) honors the ALWAYS_SKIP set
-    (``node_modules``, ``dist``, ``.venv``, etc.) even when
-    ``include_all=True``. Set to False (--no-skip-list CLI flag) to
-    walk into those dirs anyway. ``.git`` is always excluded
-    regardless.
+    The skip list is always applied. Per-project additions go in
+    ``<root>/.codecityignore`` (one literal name per line, or relative
+    paths containing ``/``).
     """
     root_abs = str(Path(root).resolve())
     _log(f"resolving {root_abs}")
@@ -641,6 +685,8 @@ def scan_tree(
     else:
         _log("not a git repo — filesystem dates only")
 
+    ignore_names, ignore_paths = _load_codecityignore(Path(root_abs))
+
     _reset_heartbeat()
     _log("walking tree…")
     sig = hashlib.blake2b(digest_size=16)
@@ -649,7 +695,8 @@ def scan_tree(
         is_git_repo=is_git_repo,
         git_created=git_created, git_modified=git_modified,
         tracked_files=tracked_files, include_all=include_all,
-        respect_skip_list=respect_skip_list, sig=sig,
+        ignore_names=ignore_names, ignore_paths=ignore_paths,
+        sig=sig,
     )
     _log(f"walked {_files_seen} files; resolving file metadata")
     _populate_file_metadata(tree, Path(root_abs), use_cache=use_cache)
@@ -696,7 +743,8 @@ def _walk_for_signature(
     is_git_repo: bool,
     tracked_files: set[str],
     include_all: bool,
-    respect_skip_list: bool,
+    ignore_names: frozenset[str],
+    ignore_paths: frozenset[str],
     sig: Any,
 ) -> None:
     """Stat-only walk that feeds the live signature without building nodes.
@@ -712,9 +760,12 @@ def _walk_for_signature(
         return
 
     for entry in entries:
-        if _should_skip(entry.name, respect_skip_list=respect_skip_list):
-            continue
         entry_rel = entry.name if rel_dir == "." else f"{rel_dir}/{entry.name}"
+        if _should_skip(
+            entry.name, entry_rel,
+            ignore_names=ignore_names, ignore_paths=ignore_paths,
+        ):
+            continue
         if is_git_repo and not include_all and entry_rel not in tracked_files:
             continue
         if entry.is_file(follow_symlinks=False):
@@ -726,7 +777,8 @@ def _walk_for_signature(
                 is_git_repo=is_git_repo,
                 tracked_files=tracked_files,
                 include_all=include_all,
-                respect_skip_list=respect_skip_list,
+                ignore_names=ignore_names,
+                ignore_paths=ignore_paths,
                 sig=sig,
             )
 
@@ -735,7 +787,6 @@ def signature_tree(
     root: str,
     *,
     include_all: bool = False,
-    respect_skip_list: bool = True,
     use_cache: bool = True,
 ) -> SignatureResponse:
     """Cheap fingerprint of the tree — equivalent to scan_tree(root, include_all=…)['signature']
@@ -749,6 +800,9 @@ def signature_tree(
 
     With ``include_all=True``, skips the tracked-files lookup as well —
     the filter isn't applied so we don't need to compute it.
+
+    Honors the same skip list and ``<root>/.codecityignore`` file as
+    scan_tree, so signatures stay in lockstep.
 
     ``use_cache`` is accepted for API symmetry with scan_tree (so both
     /api/manifest and /api/manifest/signature take the same query
@@ -769,13 +823,16 @@ def signature_tree(
             tracked_files = _collect_tracked_set(root_path)
         repo_info = _collect_repo_info(root_path)
 
+    ignore_names, ignore_paths = _load_codecityignore(root_path)
+
     sig = hashlib.blake2b(digest_size=16)
     _walk_for_signature(
         root_abs, ".",
         is_git_repo=is_git_repo,
         tracked_files=tracked_files,
         include_all=include_all,
-        respect_skip_list=respect_skip_list,
+        ignore_names=ignore_names,
+        ignore_paths=ignore_paths,
         sig=sig,
     )
     if repo_info is not None:

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -26,7 +26,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from .cache import (
     cache_load_files,
@@ -368,12 +368,12 @@ def _file_node(
     git_modified: dict[str, str],
     sig: Any,
 ) -> FileNode:
+    """Build a FileNode skeleton — `lines` and `binary` are placeholders
+    that get filled in by _populate_file_metadata after the walk
+    completes. Content I/O is deferred so it can be parallelized and
+    cache-resolved in a single batch."""
     abs_path = entry.path
     size, created, modified, mtime = _stat_fields(entry)
-    path_obj = Path(abs_path)
-
-    binary = _is_binary(path_obj)
-    lines = 0 if binary else _line_count(path_obj)
 
     git_block: GitMeta | None = None
     if is_git_repo:
@@ -391,12 +391,35 @@ def _file_node(
         "fullPath": abs_path,
         "extension": _extension(entry.name),
         "size": size,
-        "lines": lines,
-        "binary": binary,
+        "lines": 0,         # filled in by _populate_file_metadata
+        "binary": False,    # filled in by _populate_file_metadata
         "created": created,
         "modified": modified,
         "git": git_block,
     }
+
+
+def _populate_file_metadata(tree: DirNode) -> None:
+    """Walk the skeleton tree and fill in `lines` + `binary` for every
+    FileNode. Operates in-place on the tree's FileNode dicts.
+
+    Single-threaded for now; Task 8 parallelizes via ThreadPoolExecutor,
+    Task 9 adds the file-stat cache layer.
+    """
+    for node in _iter_file_nodes(tree):
+        path_obj = Path(node["fullPath"])
+        binary = _is_binary(path_obj)
+        node["binary"] = binary
+        node["lines"] = 0 if binary else _line_count(path_obj)
+
+
+def _iter_file_nodes(tree: DirNode) -> Iterator[FileNode]:
+    """Yield every FileNode in the tree (depth-first, alphabetical)."""
+    for child in tree["children"]:
+        if child["type"] == NodeKind.FILE:
+            yield child  # type: ignore[misc]
+        else:
+            yield from _iter_file_nodes(child)  # type: ignore[arg-type]
 
 
 # Global tracker for heartbeat logging during recursion.
@@ -550,7 +573,9 @@ def scan_tree(
         tracked_files=tracked_files, include_all=include_all,
         respect_skip_list=respect_skip_list, sig=sig,
     )
-    _log(f"walked {_files_seen} files; emitting manifest")
+    _log(f"walked {_files_seen} files; resolving file metadata")
+    _populate_file_metadata(tree)
+    _log("emitting manifest")
 
     # Repo-level metadata — branch, remote, head, dirty — feeds the
     # signature so the footer's "live" indicator catches a checkout or

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -28,6 +28,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .cache import (
+    cache_load_files,
+    cache_load_git_history,
+    cache_save_files,
+    cache_save_git_history,
+)
 from .types import (
     DirNode,
     FileNode,
@@ -180,7 +186,7 @@ def _collect_git_dates(root: Path, *log_args: str) -> dict[str, str]:
 
 
 def _collect_git_metadata(
-    root: Path,
+    root: Path, *, use_cache: bool = True,
 ) -> tuple[dict[str, str], dict[str, str], set[str]]:
     """Return (created_map, modified_map, tracked_set).
 
@@ -189,10 +195,17 @@ def _collect_git_metadata(
     - tracked_set        = all tracked paths + their parent dirs (for gitignore filter)
 
     The two `git log` walks are independent and run in parallel via a
-    ThreadPoolExecutor. The tracked-set query runs serially after — it's
-    cheap (one `git ls-files`) and the caller may need it before the
-    other two complete anyway.
+    ThreadPoolExecutor. With ``use_cache=True`` (default), the HEAD-keyed
+    git-history cache short-circuits both walks when HEAD hasn't moved.
     """
+    head_sha = _run_git(root, "rev-parse", "HEAD").strip()
+    if use_cache and head_sha:
+        cached = cache_load_git_history(root, head_sha)
+        if cached is not None:
+            created, modified = cached
+            tracked = _collect_tracked_set(root)
+            return created, modified, tracked
+
     _log("  collecting creation + modified dates (parallel git log walks)…")
     with ThreadPoolExecutor(max_workers=2) as pool:
         created_future = pool.submit(
@@ -206,6 +219,14 @@ def _collect_git_metadata(
     _log("  listing tracked files…")
     tracked = _collect_tracked_set(root)
     _log(f"    {len(tracked)} tracked entries (files + dirs)")
+
+    if use_cache and head_sha:
+        try:
+            cache_save_git_history(root, head_sha, created, modified)
+        except OSError:
+            # Cache failures (disk full, permission denied, read-only fs)
+            # must never block a scan. The next run will retry the write.
+            pass
 
     return created, modified, tracked
 
@@ -482,6 +503,7 @@ def scan_tree(
     *,
     include_all: bool = False,
     respect_skip_list: bool = True,
+    use_cache: bool = True,
 ) -> Manifest:
     """Scan a directory and return the full manifest.
 
@@ -512,7 +534,7 @@ def scan_tree(
     if is_git_repo:
         _log("git repo detected — collecting metadata…")
         git_created, git_modified, tracked_files = _collect_git_metadata(
-            Path(root_abs)
+            Path(root_abs), use_cache=use_cache,
         )
         repo_info = _collect_repo_info(Path(root_abs))
     else:
@@ -611,6 +633,7 @@ def signature_tree(
     *,
     include_all: bool = False,
     respect_skip_list: bool = True,
+    use_cache: bool = True,
 ) -> SignatureResponse:
     """Cheap fingerprint of the tree — equivalent to scan_tree(root, include_all=…)['signature']
     but without building the full manifest.
@@ -623,6 +646,12 @@ def signature_tree(
 
     With ``include_all=True``, skips the tracked-files lookup as well —
     the filter isn't applied so we don't need to compute it.
+
+    ``use_cache`` is accepted for API symmetry with scan_tree (so both
+    /api/manifest and /api/manifest/signature take the same query
+    params) but is a no-op here — signature_tree doesn't compute
+    per-file lines/binary or per-file git history, so there's nothing
+    to cache.
     """
     root_abs = str(Path(root).resolve())
     root_path = Path(root_abs)

--- a/codecity/scan.py
+++ b/codecity/scan.py
@@ -104,19 +104,35 @@ def _stat_fields(entry: os.DirEntry[str]) -> tuple[int, str, str, float]:
     return st.st_size, _epoch_to_iso(birth), _epoch_to_iso(st.st_mtime), st.st_mtime
 
 
+# Above this size, sample first 1 MB and extrapolate. Building height
+# is relative, so ±20% on a 6+ MB file is fine and saves megabytes
+# of read I/O per file.
+_LINE_COUNT_FULL_THRESHOLD = 5 * 1024 * 1024   # 5 MB
+_LINE_COUNT_SAMPLE_BYTES = 1 * 1024 * 1024     # 1 MB
+
+
 def _line_count(path: Path) -> int:
-    # Count b'\n' in chunks to avoid loading huge files into memory.
-    total = 0
     try:
+        size = path.stat().st_size
+        if size <= _LINE_COUNT_FULL_THRESHOLD:
+            # Exact path — count every newline in 1 MB chunks.
+            total = 0
+            with path.open("rb") as fh:
+                while True:
+                    chunk = fh.read(1 << 20)
+                    if not chunk:
+                        break
+                    total += chunk.count(b"\n")
+            return total
+        # Sample-extrapolate path.
         with path.open("rb") as fh:
-            while True:
-                chunk = fh.read(1 << 20)  # 1 MB
-                if not chunk:
-                    break
-                total += chunk.count(b"\n")
+            chunk = fh.read(_LINE_COUNT_SAMPLE_BYTES)
+            sampled = chunk.count(b"\n")
+        if sampled == 0:
+            return 0
+        return int(sampled * (size / _LINE_COUNT_SAMPLE_BYTES))
     except OSError:
         return 0
-    return total
 
 
 # ── Git metadata ─────────────────────────────────────────────────────────────

--- a/codecity/server.py
+++ b/codecity/server.py
@@ -101,6 +101,20 @@ def _parse_include_all(query: str) -> bool:
     return raw in ("true", "1")
 
 
+def _parse_no_cache(query: str) -> bool:
+    """Parse ?no_cache=… as a boolean. Same strict semantics as
+    _parse_include_all. Maps to scan_tree(use_cache=not <this>)."""
+    raw = parse_qs(query).get("no_cache", [""])[0].strip().lower()
+    return raw in ("true", "1")
+
+
+def _parse_no_skip_list(query: str) -> bool:
+    """Parse ?no_skip_list=… as a boolean. Same strict semantics as
+    _parse_include_all. Maps to scan_tree(respect_skip_list=not <this>)."""
+    raw = parse_qs(query).get("no_skip_list", [""])[0].strip().lower()
+    return raw in ("true", "1")
+
+
 def _resolve_scan_target(
     handler: BaseHTTPRequestHandler, query: str
 ) -> Path | None:
@@ -156,9 +170,16 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
     if scan_target is None:
         return
     include_all = _parse_include_all(query)
+    use_cache = not _parse_no_cache(query)
+    respect_skip_list = not _parse_no_skip_list(query)
 
     try:
-        manifest = scan_tree(str(scan_target), include_all=include_all)
+        manifest = scan_tree(
+            str(scan_target),
+            include_all=include_all,
+            respect_skip_list=respect_skip_list,
+            use_cache=use_cache,
+        )
     except Exception as e:  # pylint: disable=broad-except
         _send_json(handler, HTTPStatus.INTERNAL_SERVER_ERROR, {"error": f"scan failed: {e}"})
         return
@@ -179,9 +200,16 @@ def _serve_manifest_signature(handler: BaseHTTPRequestHandler, query: str) -> No
     if scan_target is None:
         return
     include_all = _parse_include_all(query)
+    use_cache = not _parse_no_cache(query)
+    respect_skip_list = not _parse_no_skip_list(query)
 
     try:
-        sig = signature_tree(str(scan_target), include_all=include_all)
+        sig = signature_tree(
+            str(scan_target),
+            include_all=include_all,
+            respect_skip_list=respect_skip_list,
+            use_cache=use_cache,
+        )
     except Exception as e:  # pylint: disable=broad-except
         _send_json(
             handler,

--- a/codecity/server.py
+++ b/codecity/server.py
@@ -108,13 +108,6 @@ def _parse_no_cache(query: str) -> bool:
     return raw in ("true", "1")
 
 
-def _parse_no_skip_list(query: str) -> bool:
-    """Parse ?no_skip_list=… as a boolean. Same strict semantics as
-    _parse_include_all. Maps to scan_tree(respect_skip_list=not <this>)."""
-    raw = parse_qs(query).get("no_skip_list", [""])[0].strip().lower()
-    return raw in ("true", "1")
-
-
 def _resolve_scan_target(
     handler: BaseHTTPRequestHandler, query: str
 ) -> Path | None:
@@ -171,13 +164,11 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
         return
     include_all = _parse_include_all(query)
     use_cache = not _parse_no_cache(query)
-    respect_skip_list = not _parse_no_skip_list(query)
 
     try:
         manifest = scan_tree(
             str(scan_target),
             include_all=include_all,
-            respect_skip_list=respect_skip_list,
             use_cache=use_cache,
         )
     except Exception as e:  # pylint: disable=broad-except
@@ -201,13 +192,11 @@ def _serve_manifest_signature(handler: BaseHTTPRequestHandler, query: str) -> No
         return
     include_all = _parse_include_all(query)
     use_cache = not _parse_no_cache(query)
-    respect_skip_list = not _parse_no_skip_list(query)
 
     try:
         sig = signature_tree(
             str(scan_target),
             include_all=include_all,
-            respect_skip_list=respect_skip_list,
             use_cache=use_cache,
         )
     except Exception as e:  # pylint: disable=broad-except

--- a/codecity/tests/fixtures/large-repo-setup.sh
+++ b/codecity/tests/fixtures/large-repo-setup.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# large-repo-setup.sh — Builds a 15k-file synthetic git repo for manual
+# performance benchmarks of scan_tree / signature_tree.
+#
+# WHY A SCRIPT: The fixture is way too large to commit (~50 MB even with
+# tiny files). Generate locally; not in CI.
+#
+# USAGE:
+#   bash codecity/tests/fixtures/large-repo-setup.sh
+#   # Then run THREE measurements to compare the perf paths:
+#   rm -rf ~/.cache/codecity/files ~/.cache/codecity/git-history
+#   time python3 -m codecity.cli scan codecity/tests/fixtures/large-repo --no-cache --output /dev/null  # cold (no-cache baseline)
+#   time python3 -m codecity.cli scan codecity/tests/fixtures/large-repo --output /dev/null             # cold + populate cache
+#   time python3 -m codecity.cli scan codecity/tests/fixtures/large-repo --output /dev/null             # warm (cache hits)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$SCRIPT_DIR/large-repo"
+
+# Wipe any previous run.
+rm -rf "$REPO_DIR"
+mkdir -p "$REPO_DIR"
+
+export GIT_AUTHOR_NAME="Bench Fixture Bot"
+export GIT_AUTHOR_EMAIL="bench-bot@codecity.test"
+export GIT_COMMITTER_NAME="Bench Fixture Bot"
+export GIT_COMMITTER_EMAIL="bench-bot@codecity.test"
+
+git -C "$REPO_DIR" init -q
+git -C "$REPO_DIR" checkout -q -b main
+
+echo "Generating 15,000 files across ~150 directories…"
+
+# 150 directories × 100 files each = 15,000 files.
+# File sizes sample a realistic distribution: most small, a few medium,
+# rare large.
+for d in $(seq 1 150); do
+    dir="$REPO_DIR/pkg-$d/sub-$((d % 10))"
+    mkdir -p "$dir"
+    for f in $(seq 1 100); do
+        path="$dir/file-$f.py"
+        # Most files: 5-20 lines. ~5% medium: 200-500 lines.
+        # ~0.5% large: 2000-5000 lines.
+        roll=$(( (d * f) % 200 ))
+        if [ "$roll" -lt 1 ]; then
+            lines=$(( 2000 + (d * f) % 3000 ))
+        elif [ "$roll" -lt 11 ]; then
+            lines=$(( 200 + (d * f) % 300 ))
+        else
+            lines=$(( 5 + (d * f) % 15 ))
+        fi
+        printf 'def f_%d():\n    pass\n%.0s' "$((d * 100 + f))" $(seq 1 "$lines") > "$path"
+    done
+done
+
+echo "Committing all files in one commit…"
+git -C "$REPO_DIR" add . > /dev/null 2>&1
+git -C "$REPO_DIR" commit -q -m "initial: 15000 files"
+
+# Make 9 more commits each touching ~500 random files so the
+# `git log --name-only` walks have realistic depth (10 commits total).
+for c in $(seq 2 10); do
+    pkg=$(( (c * 17) % 150 + 1 ))
+    sub=$(( pkg % 10 ))
+    dir="$REPO_DIR/pkg-$pkg/sub-$sub"
+    for f in $(seq 1 100); do
+        echo "# touch $c" >> "$dir/file-$f.py"
+    done
+    git -C "$REPO_DIR" add . > /dev/null 2>&1
+    git -C "$REPO_DIR" commit -q -m "edit batch $c"
+done
+
+count=$(find "$REPO_DIR" -type f -not -path '*/.git/*' | wc -l | tr -d ' ')
+echo
+echo "Done: $REPO_DIR ($count files, $(du -sh "$REPO_DIR" | cut -f1))."
+echo
+echo "Benchmark recipe (three runs to compare paths):"
+echo "  rm -rf ~/.cache/codecity/files ~/.cache/codecity/git-history"
+echo "  time python3 -m codecity.cli scan $REPO_DIR --no-cache --output /dev/null  # cold (no-cache baseline)"
+echo "  time python3 -m codecity.cli scan $REPO_DIR --output /dev/null             # cold + populate cache"
+echo "  time python3 -m codecity.cli scan $REPO_DIR --output /dev/null             # warm (cache hits)"

--- a/codecity/tests/test_cache.py
+++ b/codecity/tests/test_cache.py
@@ -1,0 +1,170 @@
+"""Unit tests for codecity/cache.py."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from codecity import cache as cache_mod
+
+
+class CacheTestBase(unittest.TestCase):
+    """Redirect CACHE_ROOT to a tempdir so tests don't touch ~/.cache."""
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._original_root = cache_mod.CACHE_ROOT
+        cache_mod.CACHE_ROOT = Path(self._tmp.name)
+        self.addCleanup(self._restore_root)
+
+    def _restore_root(self) -> None:
+        cache_mod.CACHE_ROOT = self._original_root
+
+
+class RepoKeyTests(CacheTestBase):
+    def test_stable(self) -> None:
+        self.assertEqual(
+            cache_mod.repo_key(Path("/foo/bar")),
+            cache_mod.repo_key(Path("/foo/bar")),
+        )
+
+    def test_distinct(self) -> None:
+        self.assertNotEqual(
+            cache_mod.repo_key(Path("/foo/bar")),
+            cache_mod.repo_key(Path("/foo/baz")),
+        )
+
+    def test_short_hex(self) -> None:
+        # 16 hex chars — long enough to be unique, short enough to be readable.
+        k = cache_mod.repo_key(Path("/foo/bar"))
+        self.assertEqual(len(k), 16)
+        int(k, 16)  # raises if not hex
+
+
+class FileCacheTests(CacheTestBase):
+    def test_roundtrip(self) -> None:
+        root = Path("/some/repo")
+        entries = {
+            "src/foo.py": {
+                "size": 1234, "mtime": 1715000000.0,
+                "lines": 42, "binary": False, "ext": ".py",
+            },
+        }
+        cache_mod.cache_save_files(root, entries)
+        self.assertEqual(cache_mod.cache_load_files(root), entries)
+
+    def test_load_missing_returns_empty(self) -> None:
+        self.assertEqual(cache_mod.cache_load_files(Path("/never/scanned")), {})
+
+    def test_load_corrupted_returns_empty(self) -> None:
+        root = Path("/some/repo")
+        cache_mod.cache_save_files(root, {})  # ensure dir exists
+        path = cache_mod.CACHE_ROOT / "files" / f"{cache_mod.repo_key(root)}.json"
+        path.write_text("{not valid json")
+        self.assertEqual(cache_mod.cache_load_files(root), {})
+
+    def test_load_version_mismatch_returns_empty(self) -> None:
+        root = Path("/some/repo")
+        cache_mod.cache_save_files(root, {})
+        path = cache_mod.CACHE_ROOT / "files" / f"{cache_mod.repo_key(root)}.json"
+        bad = {"version": 999, "root": str(root), "entries": {"a": "b"}}
+        path.write_text(json.dumps(bad))
+        self.assertEqual(cache_mod.cache_load_files(root), {})
+
+    def test_atomic_write_no_temp_left_behind(self) -> None:
+        root = Path("/some/repo")
+        cache_mod.cache_save_files(root, {"a": {"size": 0, "mtime": 0.0,
+                                                "lines": 0, "binary": False, "ext": ""}})
+        files_dir = cache_mod.CACHE_ROOT / "files"
+        leftovers = [p for p in files_dir.iterdir() if p.suffix == ".tmp"]
+        self.assertEqual(leftovers, [])
+
+    def test_load_drops_malformed_entries(self) -> None:
+        # Mix valid and invalid entries; valid ones survive, invalid ones drop.
+        root = Path("/some/repo")
+        cache_mod.cache_save_files(root, {})
+        path = cache_mod.CACHE_ROOT / "files" / f"{cache_mod.repo_key(root)}.json"
+        payload = {
+            "version": 1,
+            "root": str(root),
+            "entries": {
+                "good.py": {"size": 1, "mtime": 1.0, "lines": 1,
+                            "binary": False, "ext": ".py"},
+                "missing-fields.py": {"size": 1},   # incomplete
+                "wrong-type.py": {"size": "not-an-int", "mtime": 1.0,
+                                  "lines": 1, "binary": False, "ext": ".py"},
+                "not-a-dict.py": "garbage",
+            },
+        }
+        path.write_text(json.dumps(payload))
+        loaded = cache_mod.cache_load_files(root)
+        self.assertIn("good.py", loaded)
+        self.assertNotIn("missing-fields.py", loaded)
+        self.assertNotIn("wrong-type.py", loaded)
+        self.assertNotIn("not-a-dict.py", loaded)
+
+
+class GitHistoryCacheTests(CacheTestBase):
+    def test_hit_on_matching_head(self) -> None:
+        root = Path("/some/repo")
+        created = {"src/a.py": "2024-01-01T00:00:00Z"}
+        modified = {"src/a.py": "2024-06-01T00:00:00Z"}
+        cache_mod.cache_save_git_history(root, "abc123", created, modified)
+        result = cache_mod.cache_load_git_history(root, "abc123")
+        self.assertEqual(result, (created, modified))
+
+    def test_miss_on_different_head(self) -> None:
+        root = Path("/some/repo")
+        cache_mod.cache_save_git_history(root, "abc123", {}, {})
+        self.assertIsNone(cache_mod.cache_load_git_history(root, "def456"))
+
+    def test_load_missing_returns_none(self) -> None:
+        self.assertIsNone(
+            cache_mod.cache_load_git_history(Path("/never/scanned"), "abc123")
+        )
+
+    def test_load_corrupted_returns_none(self) -> None:
+        root = Path("/some/repo")
+        cache_mod.cache_save_git_history(root, "abc", {}, {})
+        path = cache_mod.CACHE_ROOT / "git-history" / f"{cache_mod.repo_key(root)}.json"
+        path.write_text("{garbage")
+        self.assertIsNone(cache_mod.cache_load_git_history(root, "abc"))
+
+    def test_load_version_mismatch_returns_none(self) -> None:
+        root = Path("/some/repo")
+        cache_mod.cache_save_git_history(root, "abc", {}, {})
+        path = cache_mod.CACHE_ROOT / "git-history" / f"{cache_mod.repo_key(root)}.json"
+        bad = {"version": 999, "root": str(root), "head_sha": "abc",
+               "created": {}, "modified": {}}
+        path.write_text(json.dumps(bad))
+        self.assertIsNone(cache_mod.cache_load_git_history(root, "abc"))
+
+    def test_load_drops_non_string_entries(self) -> None:
+        # Mixed string + non-string values in created/modified maps;
+        # only string-keyed string-valued entries survive.
+        root = Path("/some/repo")
+        cache_mod.cache_save_git_history(root, "abc", {}, {})
+        path = cache_mod.CACHE_ROOT / "git-history" / f"{cache_mod.repo_key(root)}.json"
+        payload = {
+            "version": 1, "root": str(root), "head_sha": "abc",
+            "created": {
+                "good.py": "2024-01-01T00:00:00Z",
+                "bad.py": 12345,   # not a string
+            },
+            "modified": {
+                "good.py": "2024-06-01T00:00:00Z",
+            },
+        }
+        path.write_text(json.dumps(payload))
+        result = cache_mod.cache_load_git_history(root, "abc")
+        self.assertIsNotNone(result)
+        created, modified = result
+        self.assertEqual(created, {"good.py": "2024-01-01T00:00:00Z"})
+        self.assertEqual(modified, {"good.py": "2024-06-01T00:00:00Z"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codecity/tests/test_scan.py
+++ b/codecity/tests/test_scan.py
@@ -407,10 +407,107 @@ class GitMetadataParallelTests(unittest.TestCase):
             return original_run(args, **kwargs)
 
         with patch("codecity.scan.subprocess.run", side_effect=counting_run):
-            _collect_git_metadata(FIXTURE)
+            _collect_git_metadata(FIXTURE, use_cache=False)
 
         self.assertEqual(len(log_calls), 2,
                          f"expected exactly 2 git log calls, got: {log_calls}")
+
+
+class GitHistoryCacheTests(unittest.TestCase):
+    """When HEAD hasn't moved, _collect_git_metadata should hit the
+    persistent cache and skip the two `git log` walks entirely."""
+
+    @classmethod
+    def setUpClass(cls):
+        _ensure_fixture()
+
+    def setUp(self) -> None:
+        from codecity import cache as cache_mod
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._original_root = cache_mod.CACHE_ROOT
+        cache_mod.CACHE_ROOT = Path(self._tmp.name)
+        self.addCleanup(self._restore_root)
+
+    def _restore_root(self) -> None:
+        from codecity import cache as cache_mod
+        cache_mod.CACHE_ROOT = self._original_root
+
+    def test_warm_run_skips_git_log(self):
+        from unittest.mock import patch
+        from codecity.scan import _collect_git_metadata
+
+        # Cold run: populates cache.
+        _collect_git_metadata(FIXTURE, use_cache=True)
+
+        original_run = subprocess.run
+        log_calls: list[list[str]] = []
+
+        def counting_run(args, **kwargs):
+            if isinstance(args, list) and "log" in args:
+                log_calls.append(list(args))
+            return original_run(args, **kwargs)
+
+        # Warm run: must not invoke `git log` at all.
+        with patch("codecity.scan.subprocess.run", side_effect=counting_run):
+            _collect_git_metadata(FIXTURE, use_cache=True)
+        self.assertEqual(log_calls, [], "expected zero git log calls on warm run")
+
+    def test_use_cache_false_bypasses(self):
+        from unittest.mock import patch
+        from codecity.scan import _collect_git_metadata
+
+        _collect_git_metadata(FIXTURE, use_cache=True)  # populate
+
+        original_run = subprocess.run
+        log_calls: list[list[str]] = []
+
+        def counting_run(args, **kwargs):
+            if isinstance(args, list) and "log" in args:
+                log_calls.append(list(args))
+            return original_run(args, **kwargs)
+
+        with patch("codecity.scan.subprocess.run", side_effect=counting_run):
+            _collect_git_metadata(FIXTURE, use_cache=False)
+        self.assertEqual(len(log_calls), 2, "use_cache=False must run both log walks")
+
+    def test_cache_invalidated_after_new_commit(self):
+        # Make a commit, confirm next call re-walks history.
+        from unittest.mock import patch
+        from codecity.scan import _collect_git_metadata
+
+        _collect_git_metadata(FIXTURE, use_cache=True)
+
+        # Commit something to move HEAD.
+        new_file = FIXTURE / "cache-bust.txt"
+        new_file.write_text("bust")
+        try:
+            subprocess.check_call(
+                ["git", "-C", str(FIXTURE), "add", str(new_file.name)]
+            )
+            subprocess.check_call(
+                ["git", "-C", str(FIXTURE), "commit", "-q", "-m", "cache-bust"]
+            )
+
+            original_run = subprocess.run
+            log_calls: list[list[str]] = []
+
+            def counting_run(args, **kwargs):
+                if isinstance(args, list) and "log" in args:
+                    log_calls.append(list(args))
+                return original_run(args, **kwargs)
+
+            with patch("codecity.scan.subprocess.run", side_effect=counting_run):
+                _collect_git_metadata(FIXTURE, use_cache=True)
+            self.assertEqual(len(log_calls), 2,
+                             "HEAD moved -> must re-walk")
+        finally:
+            # Reset fixture: undo the commit and remove the file.
+            subprocess.run(
+                ["git", "-C", str(FIXTURE), "reset", "--hard", "HEAD~1"],
+                check=False, capture_output=True,
+            )
+            new_file.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/codecity/tests/test_scan.py
+++ b/codecity/tests/test_scan.py
@@ -233,41 +233,92 @@ class ScanTreeIntegrationTests(_CacheRedirectMixin, unittest.TestCase):
         self.assertNotIn(".git", names)
 
     def test_skip_list_excludes_node_modules_under_include_all(self):
-        # node_modules/ should NOT appear with include_all=True (default
-        # respect_skip_list=True). It IS present on disk in the fixture
-        # for this test only.
+        # node_modules/ must NOT appear with include_all=True. ALWAYS_SKIP
+        # is hardcoded; there's no runtime escape hatch.
         nm_dir = FIXTURE / "node_modules" / "fake-pkg"
         nm_dir.mkdir(parents=True, exist_ok=True)
         nm_file = nm_dir / "index.js"
         nm_file.write_text("module.exports = {};")
         try:
-            m_skipped = scan_tree(str(FIXTURE), include_all=True)
-            names = [n["name"] for n in _walk_dirs(m_skipped["tree"])]
+            m = scan_tree(str(FIXTURE), include_all=True)
+            names = [n["name"] for n in _walk_dirs(m["tree"])]
             self.assertNotIn("node_modules", names)
-
-            m_unskipped = scan_tree(
-                str(FIXTURE), include_all=True, respect_skip_list=False,
-            )
-            names_un = [n["name"] for n in _walk_dirs(m_unskipped["tree"])]
-            self.assertIn("node_modules", names_un)
         finally:
             nm_file.unlink(missing_ok=True)
             nm_dir.rmdir()
             (FIXTURE / "node_modules").rmdir()
 
-    def test_skip_list_does_not_affect_default_scan(self):
-        # In a default tracked-only scan, the skip list is moot because
-        # node_modules/ wouldn't be in git ls-files anyway. Confirm
-        # passing respect_skip_list=False doesn't change anything.
-        m_default = scan_tree(str(FIXTURE))
-        m_no_skip = scan_tree(str(FIXTURE), respect_skip_list=False)
-        self.assertEqual(m_default["signature"], m_no_skip["signature"])
+    def test_codecityignore_name_excludes_directory(self):
+        # A bare name in .codecityignore matches any dir/file with that
+        # name anywhere in the tree.
+        target_dir = FIXTURE / "noisy-fixture"
+        target_dir.mkdir(exist_ok=True)
+        (target_dir / "data.txt").write_text("noise")
+        ignore_file = FIXTURE / ".codecityignore"
+        ignore_file.write_text("# project-specific\nnoisy-fixture\n")
+        try:
+            m = scan_tree(str(FIXTURE), include_all=True)
+            names = [n["name"] for n in _walk_dirs(m["tree"])]
+            self.assertNotIn("noisy-fixture", names)
+        finally:
+            ignore_file.unlink(missing_ok=True)
+            (target_dir / "data.txt").unlink(missing_ok=True)
+            target_dir.rmdir()
 
-    def test_git_dir_excluded_even_with_no_skip_list(self):
-        # .git/ is special: always excluded, even when respect_skip_list=False.
-        m = scan_tree(str(FIXTURE), include_all=True, respect_skip_list=False)
-        names = [n["name"] for n in _walk_dirs(m["tree"])]
-        self.assertNotIn(".git", names)
+    def test_codecityignore_path_excludes_specific_path_only(self):
+        # A line containing '/' is anchored to the scan root. A dir at
+        # a different relative path with the same final segment is NOT
+        # excluded.
+        target_a = FIXTURE / "stash" / "legacy"
+        target_b = FIXTURE / "legacy"  # same name, different path
+        target_a.mkdir(parents=True, exist_ok=True)
+        target_b.mkdir(exist_ok=True)
+        (target_a / "x.txt").write_text("a")
+        (target_b / "x.txt").write_text("b")
+        ignore_file = FIXTURE / ".codecityignore"
+        ignore_file.write_text("stash/legacy\n")
+        try:
+            m = scan_tree(str(FIXTURE), include_all=True)
+            paths = [n["path"] for n in _walk_dirs(m["tree"])]
+            self.assertNotIn("stash/legacy", paths)
+            # The other "legacy" at a different path stays visible.
+            self.assertIn("legacy", paths)
+        finally:
+            ignore_file.unlink(missing_ok=True)
+            (target_a / "x.txt").unlink(missing_ok=True)
+            target_a.rmdir()
+            (FIXTURE / "stash").rmdir()
+            (target_b / "x.txt").unlink(missing_ok=True)
+            target_b.rmdir()
+
+    def test_codecityignore_missing_is_ok(self):
+        # No file -> no error, scan proceeds normally.
+        ignore_file = FIXTURE / ".codecityignore"
+        self.assertFalse(ignore_file.exists())  # sanity
+        m = scan_tree(str(FIXTURE), include_all=True)
+        self.assertGreater(m["tree"]["descendants_file_count"], 0)
+
+    def test_codecityignore_comments_and_blanks(self):
+        # Comments and blank lines are silently dropped.
+        target = FIXTURE / "noisy-comment-test"
+        target.mkdir(exist_ok=True)
+        (target / "x.txt").write_text("x")
+        ignore_file = FIXTURE / ".codecityignore"
+        ignore_file.write_text(
+            "# leading comment\n"
+            "\n"
+            "noisy-comment-test\n"
+            "   \n"  # blank-with-whitespace
+            "# trailing comment\n"
+        )
+        try:
+            m = scan_tree(str(FIXTURE), include_all=True)
+            names = [n["name"] for n in _walk_dirs(m["tree"])]
+            self.assertNotIn("noisy-comment-test", names)
+        finally:
+            ignore_file.unlink(missing_ok=True)
+            (target / "x.txt").unlink(missing_ok=True)
+            target.rmdir()
 
 
 class SignatureTreeTests(_CacheRedirectMixin, unittest.TestCase):
@@ -330,29 +381,31 @@ class SignatureTreeTests(_CacheRedirectMixin, unittest.TestCase):
         finally:
             untracked.unlink(missing_ok=True)
 
-    def test_signature_honors_respect_skip_list(self):
-        # Parity contract: signature_tree must agree with scan_tree on
-        # both respect_skip_list values.
-        nm_dir = FIXTURE / "node_modules" / "fake-pkg"
-        nm_dir.mkdir(parents=True, exist_ok=True)
-        nm_file = nm_dir / "index.js"
-        nm_file.write_text("module.exports = {};")
+    def test_signature_honors_codecityignore(self):
+        # Parity contract: editing .codecityignore must shift the
+        # signature returned by signature_tree (so the live-update poll
+        # actually triggers a reload), and that signature must match
+        # scan_tree's output for the same root.
+        target = FIXTURE / "sig-noise-fixture"
+        target.mkdir(exist_ok=True)
+        (target / "x.txt").write_text("x")
+        ignore_file = FIXTURE / ".codecityignore"
         try:
-            m1 = scan_tree(str(FIXTURE), include_all=True, respect_skip_list=True)
-            s1 = signature_tree(str(FIXTURE), include_all=True, respect_skip_list=True)
-            self.assertEqual(s1["signature"], m1["signature"])
+            # Without ignore file, target is visible.
+            before_sig = signature_tree(str(FIXTURE), include_all=True)["signature"]
+            before_full = scan_tree(str(FIXTURE), include_all=True)["signature"]
+            self.assertEqual(before_sig, before_full)
 
-            m2 = scan_tree(str(FIXTURE), include_all=True, respect_skip_list=False)
-            s2 = signature_tree(str(FIXTURE), include_all=True, respect_skip_list=False)
-            self.assertEqual(s2["signature"], m2["signature"])
-
-            # And the two modes must produce different signatures (otherwise
-            # the toggle wouldn't trigger a reload).
-            self.assertNotEqual(s1["signature"], s2["signature"])
+            # Add ignore entry, both signatures must shift in lockstep.
+            ignore_file.write_text("sig-noise-fixture\n")
+            after_sig = signature_tree(str(FIXTURE), include_all=True)["signature"]
+            after_full = scan_tree(str(FIXTURE), include_all=True)["signature"]
+            self.assertEqual(after_sig, after_full)
+            self.assertNotEqual(before_sig, after_sig)
         finally:
-            nm_file.unlink(missing_ok=True)
-            nm_dir.rmdir()
-            (FIXTURE / "node_modules").rmdir()
+            ignore_file.unlink(missing_ok=True)
+            (target / "x.txt").unlink(missing_ok=True)
+            target.rmdir()
 
 
 class LineCountCapTests(unittest.TestCase):

--- a/codecity/tests/test_scan.py
+++ b/codecity/tests/test_scan.py
@@ -29,6 +29,25 @@ def _ensure_fixture() -> None:
         subprocess.check_call(["bash", str(FIXTURES_DIR / "setup.sh")])
 
 
+class _CacheRedirectMixin:
+    """Mixin that redirects codecity.cache.CACHE_ROOT to a per-test
+    tempdir so calls to scan_tree() / signature_tree() / etc. don't
+    pollute the user's actual ~/.cache/codecity/ during tests."""
+
+    def setUp(self) -> None:
+        super().setUp()  # cooperative chaining for subclasses with their own setUp
+        from codecity import cache as cache_mod
+        self._cache_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._cache_tmp.cleanup)
+        self._original_cache_root = cache_mod.CACHE_ROOT
+        cache_mod.CACHE_ROOT = Path(self._cache_tmp.name)
+        self.addCleanup(self._restore_cache_root)
+
+    def _restore_cache_root(self) -> None:
+        from codecity import cache as cache_mod
+        cache_mod.CACHE_ROOT = self._original_cache_root
+
+
 class ExtensionTests(unittest.TestCase):
     def test_plain_file(self):
         self.assertEqual(_extension("index.ts"), ".ts")
@@ -75,7 +94,7 @@ class BinaryDetectionTests(unittest.TestCase):
         self.assertTrue(_is_binary(p))
 
 
-class ScanTreeIntegrationTests(unittest.TestCase):
+class ScanTreeIntegrationTests(_CacheRedirectMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         _ensure_fixture()
@@ -251,7 +270,7 @@ class ScanTreeIntegrationTests(unittest.TestCase):
         self.assertNotIn(".git", names)
 
 
-class SignatureTreeTests(unittest.TestCase):
+class SignatureTreeTests(_CacheRedirectMixin, unittest.TestCase):
     """signature_tree() must produce the same digest as scan_tree() does
     for the same root — that's the contract the live-update poll relies
     on. Drift here means every poll triggers a full reload."""
@@ -380,7 +399,7 @@ def _walk_dirs(node):
         yield from _walk_dirs(c)
 
 
-class GitMetadataParallelTests(unittest.TestCase):
+class GitMetadataParallelTests(_CacheRedirectMixin, unittest.TestCase):
     """The two git log walks (created + modified) are independent and
     should run concurrently."""
 
@@ -413,25 +432,13 @@ class GitMetadataParallelTests(unittest.TestCase):
                          f"expected exactly 2 git log calls, got: {log_calls}")
 
 
-class GitHistoryCacheTests(unittest.TestCase):
+class GitHistoryCacheTests(_CacheRedirectMixin, unittest.TestCase):
     """When HEAD hasn't moved, _collect_git_metadata should hit the
     persistent cache and skip the two `git log` walks entirely."""
 
     @classmethod
     def setUpClass(cls):
         _ensure_fixture()
-
-    def setUp(self) -> None:
-        from codecity import cache as cache_mod
-        self._tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(self._tmp.cleanup)
-        self._original_root = cache_mod.CACHE_ROOT
-        cache_mod.CACHE_ROOT = Path(self._tmp.name)
-        self.addCleanup(self._restore_root)
-
-    def _restore_root(self) -> None:
-        from codecity import cache as cache_mod
-        cache_mod.CACHE_ROOT = self._original_root
 
     def test_warm_run_skips_git_log(self):
         from unittest.mock import patch
@@ -508,6 +515,89 @@ class GitHistoryCacheTests(unittest.TestCase):
                 check=False, capture_output=True,
             )
             new_file.unlink(missing_ok=True)
+
+
+class FileStatCacheTests(_CacheRedirectMixin, unittest.TestCase):
+    """Warm runs of scan_tree should hit the file-stat cache for
+    unchanged files and skip _is_binary + _line_count entirely."""
+
+    @classmethod
+    def setUpClass(cls):
+        _ensure_fixture()
+
+    def test_warm_run_skips_line_count(self):
+        from unittest.mock import patch
+
+        scan_tree(str(FIXTURE))  # cold: populates cache
+
+        with patch("codecity.scan._line_count") as line_mock, \
+             patch("codecity.scan._is_binary") as binary_mock:
+            scan_tree(str(FIXTURE))  # warm: should not call either
+            self.assertEqual(line_mock.call_count, 0,
+                             "warm scan must not call _line_count")
+            self.assertEqual(binary_mock.call_count, 0,
+                             "warm scan must not call _is_binary")
+
+    def test_warm_run_signature_matches_cold_run(self):
+        cold = scan_tree(str(FIXTURE))
+        warm = scan_tree(str(FIXTURE))
+        self.assertEqual(cold["signature"], warm["signature"])
+        # And tree shape — confirm `lines` survives the cache roundtrip.
+        cold_lines = {
+            n["path"]: n["lines"] for n in _walk_files(cold["tree"])
+        }
+        warm_lines = {
+            n["path"]: n["lines"] for n in _walk_files(warm["tree"])
+        }
+        self.assertEqual(cold_lines, warm_lines)
+
+    def test_modified_file_recomputed(self):
+        from unittest.mock import patch
+
+        scan_tree(str(FIXTURE))  # populate
+
+        # Change one file's mtime by writing to it.
+        target = next(
+            n for n in _walk_files(scan_tree(str(FIXTURE))["tree"])
+            if n["name"] == "index.ts"
+        )
+        target_path = Path(target["fullPath"])
+        original_text = target_path.read_text()
+        target_path.write_text(original_text + "\n// changed\n")
+
+        try:
+            line_calls: list[Path] = []
+            original_line_count = _line_count_real()
+
+            def counting_line_count(p):
+                line_calls.append(p)
+                return original_line_count(p)
+
+            with patch("codecity.scan._line_count", side_effect=counting_line_count):
+                scan_tree(str(FIXTURE))
+
+            # Only the modified file should be recomputed.
+            self.assertEqual(len(line_calls), 1)
+            self.assertEqual(line_calls[0], target_path)
+        finally:
+            target_path.write_text(original_text)
+
+    def test_use_cache_false_bypasses_file_cache(self):
+        from unittest.mock import patch
+
+        scan_tree(str(FIXTURE))  # populate cache
+
+        with patch("codecity.scan._line_count", return_value=42) as line_mock:
+            scan_tree(str(FIXTURE), use_cache=False)
+            # use_cache=False -> every file gets re-read
+            self.assertGreater(line_mock.call_count, 0)
+
+
+def _line_count_real():
+    """Get the unwrapped _line_count for tests that want to call the
+    real implementation while also mocking it."""
+    from codecity.scan import _line_count
+    return _line_count
 
 
 if __name__ == "__main__":

--- a/codecity/tests/test_scan.py
+++ b/codecity/tests/test_scan.py
@@ -311,6 +311,30 @@ class SignatureTreeTests(unittest.TestCase):
         finally:
             untracked.unlink(missing_ok=True)
 
+    def test_signature_honors_respect_skip_list(self):
+        # Parity contract: signature_tree must agree with scan_tree on
+        # both respect_skip_list values.
+        nm_dir = FIXTURE / "node_modules" / "fake-pkg"
+        nm_dir.mkdir(parents=True, exist_ok=True)
+        nm_file = nm_dir / "index.js"
+        nm_file.write_text("module.exports = {};")
+        try:
+            m1 = scan_tree(str(FIXTURE), include_all=True, respect_skip_list=True)
+            s1 = signature_tree(str(FIXTURE), include_all=True, respect_skip_list=True)
+            self.assertEqual(s1["signature"], m1["signature"])
+
+            m2 = scan_tree(str(FIXTURE), include_all=True, respect_skip_list=False)
+            s2 = signature_tree(str(FIXTURE), include_all=True, respect_skip_list=False)
+            self.assertEqual(s2["signature"], m2["signature"])
+
+            # And the two modes must produce different signatures (otherwise
+            # the toggle wouldn't trigger a reload).
+            self.assertNotEqual(s1["signature"], s2["signature"])
+        finally:
+            nm_file.unlink(missing_ok=True)
+            nm_dir.rmdir()
+            (FIXTURE / "node_modules").rmdir()
+
 
 def _walk_files(node):
     """Yield every file node in the tree."""

--- a/codecity/tests/test_scan.py
+++ b/codecity/tests/test_scan.py
@@ -213,6 +213,43 @@ class ScanTreeIntegrationTests(unittest.TestCase):
         names = [n["name"] for n in _walk_dirs(m["tree"])]
         self.assertNotIn(".git", names)
 
+    def test_skip_list_excludes_node_modules_under_include_all(self):
+        # node_modules/ should NOT appear with include_all=True (default
+        # respect_skip_list=True). It IS present on disk in the fixture
+        # for this test only.
+        nm_dir = FIXTURE / "node_modules" / "fake-pkg"
+        nm_dir.mkdir(parents=True, exist_ok=True)
+        nm_file = nm_dir / "index.js"
+        nm_file.write_text("module.exports = {};")
+        try:
+            m_skipped = scan_tree(str(FIXTURE), include_all=True)
+            names = [n["name"] for n in _walk_dirs(m_skipped["tree"])]
+            self.assertNotIn("node_modules", names)
+
+            m_unskipped = scan_tree(
+                str(FIXTURE), include_all=True, respect_skip_list=False,
+            )
+            names_un = [n["name"] for n in _walk_dirs(m_unskipped["tree"])]
+            self.assertIn("node_modules", names_un)
+        finally:
+            nm_file.unlink(missing_ok=True)
+            nm_dir.rmdir()
+            (FIXTURE / "node_modules").rmdir()
+
+    def test_skip_list_does_not_affect_default_scan(self):
+        # In a default tracked-only scan, the skip list is moot because
+        # node_modules/ wouldn't be in git ls-files anyway. Confirm
+        # passing respect_skip_list=False doesn't change anything.
+        m_default = scan_tree(str(FIXTURE))
+        m_no_skip = scan_tree(str(FIXTURE), respect_skip_list=False)
+        self.assertEqual(m_default["signature"], m_no_skip["signature"])
+
+    def test_git_dir_excluded_even_with_no_skip_list(self):
+        # .git/ is special: always excluded, even when respect_skip_list=False.
+        m = scan_tree(str(FIXTURE), include_all=True, respect_skip_list=False)
+        names = [n["name"] for n in _walk_dirs(m["tree"])]
+        self.assertNotIn(".git", names)
+
 
 class SignatureTreeTests(unittest.TestCase):
     """signature_tree() must produce the same digest as scan_tree() does

--- a/codecity/tests/test_scan.py
+++ b/codecity/tests/test_scan.py
@@ -380,5 +380,38 @@ def _walk_dirs(node):
         yield from _walk_dirs(c)
 
 
+class GitMetadataParallelTests(unittest.TestCase):
+    """The two git log walks (created + modified) are independent and
+    should run concurrently."""
+
+    @classmethod
+    def setUpClass(cls):
+        _ensure_fixture()
+
+    def test_parallel_invocation_count_matches_serial(self):
+        # The parallelized version must invoke `git log` exactly twice
+        # (one --reverse --diff-filter=A, one without). No extra calls.
+        from unittest.mock import patch
+        from codecity.scan import _collect_git_metadata
+
+        original_run = subprocess.run
+        log_calls: list[list[str]] = []
+
+        def counting_run(args, **kwargs):
+            if (
+                isinstance(args, list)
+                and args[:2] == ["git", "-C"]
+                and "log" in args
+            ):
+                log_calls.append(list(args))
+            return original_run(args, **kwargs)
+
+        with patch("codecity.scan.subprocess.run", side_effect=counting_run):
+            _collect_git_metadata(FIXTURE)
+
+        self.assertEqual(len(log_calls), 2,
+                         f"expected exactly 2 git log calls, got: {log_calls}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/codecity/tests/test_scan.py
+++ b/codecity/tests/test_scan.py
@@ -336,6 +336,34 @@ class SignatureTreeTests(unittest.TestCase):
             (FIXTURE / "node_modules").rmdir()
 
 
+class LineCountCapTests(unittest.TestCase):
+    """Above ~5 MB the line counter samples and extrapolates instead of
+    reading the entire file. Building height is a relative measure, so
+    an order-of-magnitude estimate is fine on huge files."""
+
+    def test_exact_count_below_threshold(self):
+        from codecity.scan import _line_count
+        with tempfile.NamedTemporaryFile("wb", delete=False) as fh:
+            fh.write(b"line\n" * 1000)
+            small = Path(fh.name)
+        self.addCleanup(small.unlink, missing_ok=True)
+        self.assertEqual(_line_count(small), 1000)
+
+    def test_sample_extrapolation_above_threshold(self):
+        from codecity.scan import _line_count
+        # 6 MB file with one newline every 50 bytes -> ~125k lines true.
+        with tempfile.NamedTemporaryFile("wb", delete=False) as fh:
+            line = b"x" * 49 + b"\n"  # 50 bytes, one newline
+            for _ in range(6 * 1024 * 1024 // 50):
+                fh.write(line)
+            big = Path(fh.name)
+        self.addCleanup(big.unlink, missing_ok=True)
+        result = _line_count(big)
+        # Sample-based estimate; allow ±20%.
+        self.assertGreater(result, 100_000)
+        self.assertLess(result, 150_000)
+
+
 def _walk_files(node):
     """Yield every file node in the tree."""
     if node.get("type") == "file":

--- a/codecity/tests/test_server.py
+++ b/codecity/tests/test_server.py
@@ -17,6 +17,25 @@ from codecity import server as server_mod
 from codecity.server import start_server
 
 
+class _CacheRedirectMixin:
+    """Mixin that redirects codecity.cache.CACHE_ROOT to a per-test
+    tempdir so server-side calls into scan_tree() / signature_tree()
+    don't pollute the user's actual ~/.cache/codecity/ during tests."""
+
+    def setUp(self) -> None:
+        super().setUp()  # cooperative chaining
+        from codecity import cache as cache_mod
+        self._cache_tmp = TemporaryDirectory()
+        self.addCleanup(self._cache_tmp.cleanup)
+        self._original_cache_root = cache_mod.CACHE_ROOT
+        cache_mod.CACHE_ROOT = Path(self._cache_tmp.name)
+        self.addCleanup(self._restore_cache_root)
+
+    def _restore_cache_root(self) -> None:
+        from codecity import cache as cache_mod
+        cache_mod.CACHE_ROOT = self._original_cache_root
+
+
 # Silence scan progress logs.
 os.environ["CODECITY_QUIET"] = "1"
 
@@ -30,8 +49,9 @@ def _get(url: str) -> tuple[int, bytes, str]:
     return resp.status, resp.read(), resp.headers.get("Content-Type", "")
 
 
-class ServerTests(unittest.TestCase):
+class ServerTests(_CacheRedirectMixin, unittest.TestCase):
     def setUp(self) -> None:
+        super().setUp()  # runs _CacheRedirectMixin.setUp -> redirects CACHE_ROOT
         self.tmp = TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
         static = Path(self.tmp.name) / "static"
@@ -294,10 +314,11 @@ class ServerTests(unittest.TestCase):
         self.assertFalse(_parse_no_skip_list(""))
 
 
-class FileApiTests(unittest.TestCase):
+class FileApiTests(_CacheRedirectMixin, unittest.TestCase):
     """Coverage for /api/file — the root-bounded file reader."""
 
     def setUp(self) -> None:
+        super().setUp()  # runs _CacheRedirectMixin.setUp -> redirects CACHE_ROOT
         self.tmp = TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
         self.scan_root = Path(self.tmp.name) / "project"

--- a/codecity/tests/test_server.py
+++ b/codecity/tests/test_server.py
@@ -247,11 +247,11 @@ class ServerTests(_CacheRedirectMixin, unittest.TestCase):
         self.assertFalse(_parse_include_all(""))
         self.assertFalse(_parse_include_all("path=/tmp"))
 
-    def test_manifest_route_honors_no_skip_list(self) -> None:
-        # Init a git repo, create node_modules/foo, commit ONLY README.
-        # node_modules is untracked, so it appears only with include_all.
-        # With include_all=true alone, the skip list excludes it. With
-        # include_all=true&no_skip_list=true, it's included.
+    def test_manifest_route_excludes_skip_list_under_include_all(self) -> None:
+        # Init a git repo, create node_modules/, commit ONLY README.
+        # node_modules is untracked, so it would appear with include_all
+        # if not for ALWAYS_SKIP. The skip list is always applied —
+        # there's no runtime escape hatch.
         import subprocess
         subprocess.run(
             ["git", "-C", str(self.project), "init", "-q"], check=True
@@ -275,25 +275,12 @@ class ServerTests(_CacheRedirectMixin, unittest.TestCase):
         nm.mkdir()
         (nm / "x.js").write_text("x")
 
-        q_skipped = urllib.parse.urlencode({
+        q = urllib.parse.urlencode({
             "path": str(self.project), "include_all": "true",
         })
-        _, body_skipped, _ = _get(self.base + f"/api/manifest?{q_skipped}")
-        names_skipped = [
-            c["name"] for c in json.loads(body_skipped)["tree"]["children"]
-        ]
-        self.assertNotIn("node_modules", names_skipped)
-
-        q_full = urllib.parse.urlencode({
-            "path": str(self.project),
-            "include_all": "true",
-            "no_skip_list": "true",
-        })
-        _, body_full, _ = _get(self.base + f"/api/manifest?{q_full}")
-        names_full = [
-            c["name"] for c in json.loads(body_full)["tree"]["children"]
-        ]
-        self.assertIn("node_modules", names_full)
+        _, body, _ = _get(self.base + f"/api/manifest?{q}")
+        names = [c["name"] for c in json.loads(body)["tree"]["children"]]
+        self.assertNotIn("node_modules", names)
 
     def test_no_cache_query_param_truthy_parsing(self) -> None:
         from codecity.server import _parse_no_cache
@@ -304,14 +291,6 @@ class ServerTests(_CacheRedirectMixin, unittest.TestCase):
         self.assertFalse(_parse_no_cache("no_cache=0"))
         self.assertFalse(_parse_no_cache(""))
         self.assertFalse(_parse_no_cache("path=/tmp"))
-
-    def test_no_skip_list_query_param_truthy_parsing(self) -> None:
-        from codecity.server import _parse_no_skip_list
-        self.assertTrue(_parse_no_skip_list("no_skip_list=true"))
-        self.assertTrue(_parse_no_skip_list("no_skip_list=1"))
-        self.assertFalse(_parse_no_skip_list("no_skip_list=false"))
-        self.assertFalse(_parse_no_skip_list("no_skip_list=yes"))
-        self.assertFalse(_parse_no_skip_list(""))
 
 
 class FileApiTests(_CacheRedirectMixin, unittest.TestCase):

--- a/codecity/tests/test_server.py
+++ b/codecity/tests/test_server.py
@@ -227,6 +227,72 @@ class ServerTests(unittest.TestCase):
         self.assertFalse(_parse_include_all(""))
         self.assertFalse(_parse_include_all("path=/tmp"))
 
+    def test_manifest_route_honors_no_skip_list(self) -> None:
+        # Init a git repo, create node_modules/foo, commit ONLY README.
+        # node_modules is untracked, so it appears only with include_all.
+        # With include_all=true alone, the skip list excludes it. With
+        # include_all=true&no_skip_list=true, it's included.
+        import subprocess
+        subprocess.run(
+            ["git", "-C", str(self.project), "init", "-q"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(self.project), "config", "user.email", "t@t"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.project), "config", "user.name", "t"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.project), "add", "README.md"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(self.project), "commit", "-q", "-m", "init"],
+            check=True,
+        )
+        nm = self.project / "node_modules"
+        nm.mkdir()
+        (nm / "x.js").write_text("x")
+
+        q_skipped = urllib.parse.urlencode({
+            "path": str(self.project), "include_all": "true",
+        })
+        _, body_skipped, _ = _get(self.base + f"/api/manifest?{q_skipped}")
+        names_skipped = [
+            c["name"] for c in json.loads(body_skipped)["tree"]["children"]
+        ]
+        self.assertNotIn("node_modules", names_skipped)
+
+        q_full = urllib.parse.urlencode({
+            "path": str(self.project),
+            "include_all": "true",
+            "no_skip_list": "true",
+        })
+        _, body_full, _ = _get(self.base + f"/api/manifest?{q_full}")
+        names_full = [
+            c["name"] for c in json.loads(body_full)["tree"]["children"]
+        ]
+        self.assertIn("node_modules", names_full)
+
+    def test_no_cache_query_param_truthy_parsing(self) -> None:
+        from codecity.server import _parse_no_cache
+        self.assertTrue(_parse_no_cache("no_cache=true"))
+        self.assertTrue(_parse_no_cache("no_cache=TRUE"))
+        self.assertTrue(_parse_no_cache("no_cache=1"))
+        self.assertFalse(_parse_no_cache("no_cache=false"))
+        self.assertFalse(_parse_no_cache("no_cache=0"))
+        self.assertFalse(_parse_no_cache(""))
+        self.assertFalse(_parse_no_cache("path=/tmp"))
+
+    def test_no_skip_list_query_param_truthy_parsing(self) -> None:
+        from codecity.server import _parse_no_skip_list
+        self.assertTrue(_parse_no_skip_list("no_skip_list=true"))
+        self.assertTrue(_parse_no_skip_list("no_skip_list=1"))
+        self.assertFalse(_parse_no_skip_list("no_skip_list=false"))
+        self.assertFalse(_parse_no_skip_list("no_skip_list=yes"))
+        self.assertFalse(_parse_no_skip_list(""))
+
 
 class FileApiTests(unittest.TestCase):
     """Coverage for /api/file — the root-bounded file reader."""


### PR DESCRIPTION
## Summary

Phase 1 of the [performance roadmap](docs/superpowers/plans/2026-05-05-perf-roadmap.md) — backend scan throughput. Three concrete wins:

- **Persistent file-stat cache** (`~/.cache/codecity/files/<repo-key>.json`) keyed on `(rel_path, size, mtime)`. Warm scans skip `_is_binary` + `_line_count` for unchanged files.
- **HEAD-keyed git-history cache** (`~/.cache/codecity/git-history/<repo-key>.json`). Live-reload polls no longer re-walk `git log --name-only` on every cycle.
- **Parallel I/O** in two places: `_is_binary` + `_line_count` via `ThreadPoolExecutor` (workers = `min(32, cpu_count*2)`), and the two `git log` walks via a 2-worker pool.

Plus quality-of-life:
- `_line_count` cap at 5 MB (sample-and-extrapolate above) — prevents gigabyte-per-file reads on lockfiles, dist bundles, fixtures.
- `ALWAYS_SKIP` set with the usual suspects (`node_modules`, `.venv`, `.git`, etc.) applied even when `Show all files` is on.
- `.codecityignore` for per-project additions. Bare names match anywhere; lines containing `/` are relative-path matches.
- New `--no-cache` CLI flag + `?no_cache=true` query param for diagnostic runs.
- Test isolation: new `_CacheRedirectMixin` redirects `CACHE_ROOT` to a tempdir during tests so the suite no longer pollutes `~/.cache/codecity/`.

## Headline numbers (15k-file synthetic repo)

| Run | Description | Wall time |
|-----|-------------|-----------|
| 1 | Cold (no-cache baseline) | 2.53s |
| 2 | Cold + populate cache | 2.78s |
| 3 | Warm (cache hits) | **0.56s** |

**4.5× faster** on the warm path. Live-reload polls hitting the unchanged tree are now ~stat-only.

Manual benchmark recipe in [codecity/tests/fixtures/large-repo-setup.sh](codecity/tests/fixtures/large-repo-setup.sh).

## API surface

```python
def scan_tree(root: str, *, include_all: bool = False, use_cache: bool = True) -> Manifest: ...
def signature_tree(root: str, *, include_all: bool = False, use_cache: bool = True) -> SignatureResponse: ...
```

`use_cache=False` (CLI: `--no-cache`, query: `?no_cache=true`) bypasses both caches. `signature_tree` accepts `use_cache` for HTTP-level symmetry but doesn't use it internally (nothing per-file to cache).

The original plan had a separate `respect_skip_list` knob; mid-implementation we collapsed it (the two were redundant — skip list only mattered when `include_all` was on). `ALWAYS_SKIP` is now always applied; `.codecityignore` is the per-project escape.

## Test plan

- [ ] `python3 -m unittest discover -s codecity/tests` — 94 tests pass, no production cache pollution (verify `~/.cache/codecity/files` and `~/.cache/codecity/git-history` are absent before + after).
- [ ] `codecity .` — default behavior unchanged (tracked-only).
- [ ] Toggle "Show all files" — drafts + gitignored content surface, but `node_modules/`, `.venv/`, `large-repo/`, `sample-repo/` stay hidden (the last two via the new committed `.codecityignore`).
- [ ] Toggle off again — back to tracked-only.
- [ ] Edit a tracked file with live updates on — city refreshes within poll interval.
- [ ] `codecity .` immediately after another `codecity .` (warm cache) — initial paint feels nearly instant.
- [ ] `codecity --no-cache .` — slower cold path (no cache hits), useful for debugging.
- [ ] `bash codecity/tests/fixtures/large-repo-setup.sh && time codecity scan codecity/tests/fixtures/large-repo --output /dev/null` — first run cold, second run warm; warm should be ~5× faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)