### PR TITLE
Controls save button + footer rebuild indicator + gem polish + async layout worker

### DIFF
--- a/web/config/drafts.ts
+++ b/web/config/drafts.ts
@@ -1,0 +1,194 @@
+// config/drafts.ts — in-memory draft layer between the controls panel
+// and the real nanostores. Widgets read getEffective() and write
+// setDraft(); the Save button calls commit() to flush every draft into
+// its store (which triggers the existing persist + hot-reload
+// subscriptions). Discard clears drafts without touching stores. Page
+// reload drops drafts (in-memory only — the standard "unsaved changes"
+// pattern).
+//
+// Storage shape: Map<storeRef, Map<key | null, value>>. For atom stores
+// (no setKey), key = null and the inner map has at most one entry.
+
+import { forEachRegisteredStore, getDefault } from './persist.js';
+
+interface MapLikeStore {
+  get(): any;
+  set?(value: any): void;
+  setKey?(key: string, value: any): void;
+  subscribe(listener: (state: any) => void): () => void;
+}
+
+type DraftKey = string | null;
+
+const _drafts: Map<MapLikeStore, Map<DraftKey, unknown>> = new Map();
+const _listeners: Array<() => void> = [];
+
+function _emit(): void {
+  for (const cb of _listeners) {
+    try {
+      cb();
+    } catch (_) {
+      /* noop */
+    }
+  }
+}
+
+function _equal(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch (_) {
+    return false;
+  }
+}
+
+function _clone<T>(v: T): T {
+  try {
+    return JSON.parse(JSON.stringify(v));
+  } catch (_) {
+    return v;
+  }
+}
+
+function _committedValue(store: MapLikeStore, key: DraftKey): unknown {
+  const state = store.get();
+  if (key === null) return state;
+  return state ? state[key] : undefined;
+}
+
+export function setDraft(store: MapLikeStore, key: DraftKey, value: unknown): void {
+  const committed = _committedValue(store, key);
+  let perStore = _drafts.get(store);
+  if (_equal(value, committed)) {
+    // Drop the entry — leaving "dirty" only when pending differs from committed.
+    if (perStore && perStore.has(key)) {
+      perStore.delete(key);
+      if (perStore.size === 0) _drafts.delete(store);
+      _emit();
+    }
+    return;
+  }
+  if (!perStore) {
+    perStore = new Map();
+    _drafts.set(store, perStore);
+  }
+  perStore.set(key, _clone(value));
+  _emit();
+}
+
+export function getEffective(store: MapLikeStore, key: DraftKey): unknown {
+  const perStore = _drafts.get(store);
+  if (perStore && perStore.has(key)) return perStore.get(key);
+  return _committedValue(store, key);
+}
+
+export function stageReset(store: MapLikeStore, key: DraftKey): void {
+  // For atom stores: getDefault(store) returns the whole default value.
+  // For map stores: getDefault(store, key) returns the keyed default.
+  const def = key === null ? getDefault(store) : getDefault(store, key);
+  if (def === undefined) return;
+  setDraft(store, key, def);
+}
+
+export function stageResetAll(): void {
+  let touched = false;
+  forEachRegisteredStore((_name, store, defaults) => {
+    if (
+      defaults &&
+      typeof defaults === 'object' &&
+      !Array.isArray(defaults) &&
+      typeof (store as MapLikeStore).setKey === 'function'
+    ) {
+      // Map store: stage each sub-key whose effective value differs from default.
+      for (const k in defaults) {
+        if (!Object.hasOwn(defaults, k)) continue;
+        if (_equal(getEffective(store as MapLikeStore, k), defaults[k])) continue;
+        _stageWithoutEmit(store as MapLikeStore, k, defaults[k]);
+        touched = true;
+      }
+    } else {
+      // Atom store (or array-shaped atom): stage whole default if effective differs.
+      if (!_equal(getEffective(store as MapLikeStore, null), defaults)) {
+        _stageWithoutEmit(store as MapLikeStore, null, defaults);
+        touched = true;
+      }
+    }
+  });
+  if (touched) _emit();
+}
+
+// Same write logic as setDraft but defers the _emit() call. Used by
+// stageResetAll so a single fan-out happens after the whole sweep.
+function _stageWithoutEmit(
+  store: MapLikeStore,
+  key: DraftKey,
+  value: unknown
+): void {
+  const committed = _committedValue(store, key);
+  let perStore = _drafts.get(store);
+  if (_equal(value, committed)) {
+    if (perStore && perStore.has(key)) {
+      perStore.delete(key);
+      if (perStore.size === 0) _drafts.delete(store);
+    }
+    return;
+  }
+  if (!perStore) {
+    perStore = new Map();
+    _drafts.set(store, perStore);
+  }
+  perStore.set(key, _clone(value));
+}
+
+export function commit(): void {
+  if (_drafts.size === 0) {
+    _emit();
+    return;
+  }
+  // Snapshot the entries first; clearing _drafts before the writes makes
+  // any synchronous store.subscribe handler that re-reads getEffective
+  // see the freshly-committed value instead of the lingering draft.
+  const entries: Array<[MapLikeStore, DraftKey, unknown]> = [];
+  for (const [store, perStore] of _drafts) {
+    for (const [key, value] of perStore) {
+      entries.push([store, key, value]);
+    }
+  }
+  _drafts.clear();
+  for (const [store, key, value] of entries) {
+    if (key === null) {
+      if (typeof store.set === 'function') store.set(value);
+    } else {
+      if (typeof store.setKey === 'function') store.setKey(key, value);
+    }
+  }
+  _emit();
+}
+
+export function discard(): void {
+  if (_drafts.size === 0) {
+    _emit();
+    return;
+  }
+  _drafts.clear();
+  _emit();
+}
+
+export function isDirty(): boolean {
+  return _drafts.size > 0;
+}
+
+export function subscribe(cb: () => void): () => void {
+  if (typeof cb !== 'function') return function () {};
+  _listeners.push(cb);
+  return function () {
+    const idx = _listeners.indexOf(cb);
+    if (idx >= 0) _listeners.splice(idx, 1);
+  };
+}
+
+// Test-only hook so each test starts with an empty draft map.
+export function _resetForTests(): void {
+  _drafts.clear();
+  _listeners.length = 0;
+}

--- a/web/config/gem.ts
+++ b/web/config/gem.ts
@@ -75,10 +75,10 @@ export interface GemGlowConfig {
 
 export const GEM_GLOW = map<GemGlowConfig>({
   ENABLED: true,
-  INNER_SCALE: 4, // hot core, hugging the gem
+  INNER_SCALE: 6, // hot core, hugging the gem
   OUTER_SCALE: 12, // atmospheric falloff, large soft disk
   INNER_OPACITY: 0.6,
-  OUTER_OPACITY: 0.35,
+  OUTER_OPACITY: 0.4,
   ANIMATE_COLORS: true, // cycle the halo color through GEM_FACE_PALETTE
   CYCLE_PERIOD_SECONDS: 6, // one full palette cycle every N seconds
 });

--- a/web/config/gem.ts
+++ b/web/config/gem.ts
@@ -58,6 +58,31 @@ export const GEM_APPEARANCE = map<GemAppearanceConfig>({
   BODY_OPACITY: 1.0,
 });
 
+// ─── Glow halo ─────────────────────────────────────────────────────────────
+// Two billboarded sprite layers behind the gem, each painted with a
+// soft radial-gradient alpha and additively blended. Sizes are
+// multiples of the gem radius so the halo scales with the gem itself.
+// All live/hot-reloadable.
+export interface GemGlowConfig {
+  ENABLED: boolean;
+  INNER_SCALE: number;
+  OUTER_SCALE: number;
+  INNER_OPACITY: number;
+  OUTER_OPACITY: number;
+  ANIMATE_COLORS: boolean;
+  CYCLE_PERIOD_SECONDS: number;
+}
+
+export const GEM_GLOW = map<GemGlowConfig>({
+  ENABLED: true,
+  INNER_SCALE: 4, // hot core, hugging the gem
+  OUTER_SCALE: 12, // atmospheric falloff, large soft disk
+  INNER_OPACITY: 0.6,
+  OUTER_OPACITY: 0.35,
+  ANIMATE_COLORS: true, // cycle the halo color through GEM_FACE_PALETTE
+  CYCLE_PERIOD_SECONDS: 6, // one full palette cycle every N seconds
+});
+
 // ─── Animation ─────────────────────────────────────────────────────────────
 // Read fresh each frame in the render loop, so changes apply immediately.
 export interface GemAnimationConfig {

--- a/web/config/gem.ts
+++ b/web/config/gem.ts
@@ -13,14 +13,17 @@ export interface GemSizingConfig {
   RADIUS_AS_STREET_FRAC: number;
   MIN_RADIUS: number;
   HOVER_LIFT_FRAC: number;
-  BUILDING_CLEARANCE: number;
+  CLEARANCE_AS_GEM_WIDTH_FRAC: number;
 }
 
 export const GEM_SIZING = map<GemSizingConfig>({
-  RADIUS_AS_STREET_FRAC: 0.35, // gem radius = root street width × this
+  RADIUS_AS_STREET_FRAC: 0.5, // gem radius = root street width × this
   MIN_RADIUS: 5, // floor for narrow root streets
   HOVER_LIFT_FRAC: 0.3, // gem hovers above road = radius × this
-  BUILDING_CLEARANCE: 20, // dead-space pad past the gem
+  // Dead-space pad past the gem at the root street's origin end,
+  // expressed as a multiple of the gem's diameter so the plaza always
+  // scales with the gem rather than living in absolute world units.
+  CLEARANCE_AS_GEM_WIDTH_FRAC: 2,
 });
 
 // ─── Face palette ──────────────────────────────────────────────────────────
@@ -52,7 +55,7 @@ export interface GemAppearanceConfig {
 
 export const GEM_APPEARANCE = map<GemAppearanceConfig>({
   EDGE_COLOR: '#f0f0ff',
-  BODY_OPACITY: 0.9,
+  BODY_OPACITY: 1.0,
 });
 
 // ─── Animation ─────────────────────────────────────────────────────────────

--- a/web/config/hotReload.ts
+++ b/web/config/hotReload.ts
@@ -29,6 +29,7 @@ import {
   PATH_LINE,
   HOVER_PATH_LINE,
   GEM_APPEARANCE,
+  GEM_GLOW,
   LABEL_TYPOGRAPHY,
 } from './index.js';
 
@@ -133,6 +134,7 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
     PATH_LINE,
     HOVER_PATH_LINE,
     GEM_APPEARANCE,
+    GEM_GLOW,
   ];
 
   const unsubs: Array<() => void> = [];

--- a/web/config/hotReload.ts
+++ b/web/config/hotReload.ts
@@ -66,9 +66,10 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
     if (!armed) return;
     if (rebuildTimer) clearTimeout(rebuildTimer);
     // Flip to 'rebuilding' immediately when the timer is scheduled
-    // (not just before applyManifest fires) so the browser has time
-    // to paint the indicator before the synchronous rebuild blocks
-    // the main thread.
+    // (not just before applyManifest fires) so the indicator paints
+    // before the debounce gap closes. applyManifest is async now —
+    // its layout phase runs off-thread via the layout worker, and only
+    // the mesh-construction tail blocks the main thread.
     REBUILD_STATUS.set('rebuilding');
     rebuildTimer = setTimeout(async () => {
       rebuildTimer = 0;
@@ -78,6 +79,10 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
         // path reachable via store mutation under normal use. The 'idle'
         // transition below is safe even in that no-op branch.
         if (manifest) await cityScene.applyManifest(manifest);
+        // LAST_UPDATED_AT is set by the coordinator's cityScene.onChange
+        // listener after applyManifest's _emit(changeCbs, ...) fires —
+        // not set here. refreshMaterials below uses its own hot-path
+        // timestamp set because applyTheme doesn't fire onChange.
         REBUILD_STATUS.set('idle');
         LAST_REBUILD_ERROR.set(null);
       } catch (err) {

--- a/web/config/hotReload.ts
+++ b/web/config/hotReload.ts
@@ -65,6 +65,9 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
       rebuildTimer = 0;
       try {
         const manifest = cityScene.getManifest();
+        // getManifest() returns null only during scene teardown — not a
+        // path reachable via store mutation under normal use. The 'idle'
+        // transition below is safe even in that no-op branch.
         if (manifest) cityScene.applyManifest(manifest);
         REBUILD_STATUS.set('idle');
         LAST_REBUILD_ERROR.set(null);

--- a/web/config/hotReload.ts
+++ b/web/config/hotReload.ts
@@ -11,7 +11,7 @@
 // Adding a new config row is a one-line entry in the appropriate set
 // below — the reactions below pick it up automatically.
 
-import { REBUILD_STATUS, LAST_REBUILD_ERROR } from '../liveStatus.js';
+import { REBUILD_STATUS, LAST_REBUILD_ERROR, LAST_UPDATED_AT } from '../liveStatus.js';
 
 import {
   // Rebuild-required (affects layout or geometry):
@@ -37,6 +37,12 @@ import {
 // rebuild after the user stops, instead of one rebuild per slider tick.
 const REBUILD_DEBOUNCE_MS = 50;
 
+// Min-dwell for the 'rebuilding' indicator on the hot-reload path.
+// applyTheme() is synchronous and finishes within microseconds, so without
+// a forced floor the user never sees the yellow flash. ~220 ms is long
+// enough to register visually but short enough to feel snappy.
+const HOT_REBUILD_MIN_DWELL_MS = 220;
+
 interface HotReloadOpts {
   cityScene: {
     getManifest(): unknown;
@@ -53,6 +59,8 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
   let armed = false;
 
   let rebuildTimer: ReturnType<typeof setTimeout> | 0 = 0;
+  let hotIdleTimer: ReturnType<typeof setTimeout> | 0 = 0;
+
   function scheduleRebuild() {
     if (!armed) return;
     if (rebuildTimer) clearTimeout(rebuildTimer);
@@ -80,7 +88,27 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
 
   function refreshMaterials() {
     if (!armed) return;
-    applyTheme();
+    if (hotIdleTimer) clearTimeout(hotIdleTimer);
+    REBUILD_STATUS.set('rebuilding');
+    try {
+      applyTheme();
+    } catch (err) {
+      REBUILD_STATUS.set('error');
+      LAST_REBUILD_ERROR.set(err instanceof Error ? err.message : String(err));
+      return;
+    }
+    // applyTheme is synchronous; hold the 'rebuilding' indicator on
+    // screen for a min-dwell so the user can see the yellow flash.
+    // Only transition if no rebuild is also in flight — applyManifest's
+    // own try/catch owns the final state in that case.
+    hotIdleTimer = setTimeout(() => {
+      hotIdleTimer = 0;
+      if (REBUILD_STATUS.get() === 'rebuilding') {
+        REBUILD_STATUS.set('idle');
+        LAST_REBUILD_ERROR.set(null);
+        LAST_UPDATED_AT.set(Date.now());
+      }
+    }, HOT_REBUILD_MIN_DWELL_MS);
   }
 
   const rebuildStores = [
@@ -121,6 +149,10 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
     if (rebuildTimer) {
       clearTimeout(rebuildTimer);
       rebuildTimer = 0;
+    }
+    if (hotIdleTimer) {
+      clearTimeout(hotIdleTimer);
+      hotIdleTimer = 0;
     }
     for (const unsub of unsubs) {
       try {

--- a/web/config/hotReload.ts
+++ b/web/config/hotReload.ts
@@ -11,6 +11,8 @@
 // Adding a new config row is a one-line entry in the appropriate set
 // below — the reactions below pick it up automatically.
 
+import { REBUILD_STATUS, LAST_REBUILD_ERROR } from '../liveStatus.js';
+
 import {
   // Rebuild-required (affects layout or geometry):
   BUILDING_DIMENSIONS,
@@ -54,10 +56,22 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
   function scheduleRebuild() {
     if (!armed) return;
     if (rebuildTimer) clearTimeout(rebuildTimer);
+    // Flip to 'rebuilding' immediately when the timer is scheduled
+    // (not just before applyManifest fires) so the browser has time
+    // to paint the indicator before the synchronous rebuild blocks
+    // the main thread.
+    REBUILD_STATUS.set('rebuilding');
     rebuildTimer = setTimeout(() => {
       rebuildTimer = 0;
-      const manifest = cityScene.getManifest();
-      if (manifest) cityScene.applyManifest(manifest);
+      try {
+        const manifest = cityScene.getManifest();
+        if (manifest) cityScene.applyManifest(manifest);
+        REBUILD_STATUS.set('idle');
+        LAST_REBUILD_ERROR.set(null);
+      } catch (err) {
+        REBUILD_STATUS.set('error');
+        LAST_REBUILD_ERROR.set(err instanceof Error ? err.message : String(err));
+      }
     }, REBUILD_DEBOUNCE_MS);
   }
 

--- a/web/config/hotReload.ts
+++ b/web/config/hotReload.ts
@@ -47,7 +47,7 @@ const HOT_REBUILD_MIN_DWELL_MS = 220;
 interface HotReloadOpts {
   cityScene: {
     getManifest(): unknown;
-    applyManifest(m: unknown): void;
+    applyManifest(m: unknown): Promise<void>;
   };
   applyTheme: () => void;
 }
@@ -70,14 +70,14 @@ export function attachHotReload({ cityScene, applyTheme }: HotReloadOpts): () =>
     // to paint the indicator before the synchronous rebuild blocks
     // the main thread.
     REBUILD_STATUS.set('rebuilding');
-    rebuildTimer = setTimeout(() => {
+    rebuildTimer = setTimeout(async () => {
       rebuildTimer = 0;
       try {
         const manifest = cityScene.getManifest();
         // getManifest() returns null only during scene teardown — not a
         // path reachable via store mutation under normal use. The 'idle'
         // transition below is safe even in that no-op branch.
-        if (manifest) cityScene.applyManifest(manifest);
+        if (manifest) await cityScene.applyManifest(manifest);
         REBUILD_STATUS.set('idle');
         LAST_REBUILD_ERROR.set(null);
       } catch (err) {

--- a/web/config/live.ts
+++ b/web/config/live.ts
@@ -28,7 +28,7 @@ export const LIVE_UPDATES = map<LiveUpdatesConfig>({
 export const POLL_SECONDS_MIN = 1;
 export const POLL_SECONDS_MAX = 60;
 
-// Note: the in-flight "is reloading" atom intentionally lives OUTSIDE
+// Note: the in-flight rebuild-status atom intentionally lives OUTSIDE
 // this barrel — it's transient runtime state, not a user-tunable
 // config, so it must not be picked up by attachPersistence(Config).
 // See web/liveStatus.ts.

--- a/web/config/persist.ts
+++ b/web/config/persist.ts
@@ -250,3 +250,17 @@ export function clearPersistence(): void {
     }
   }
 }
+
+// forEachRegisteredStore(cb) — visit every store registered via
+// persistStore / attachPersistence. `defaults` is the pre-hydration
+// snapshot (what reset restores to). Used by config/drafts.ts.
+export function forEachRegisteredStore(
+  cb: (name: string, store: any, defaults: any) => void
+): void {
+  for (const name in _DEFAULTS_BY_NAME) {
+    if (!Object.hasOwn(_DEFAULTS_BY_NAME, name)) continue;
+    const store = _STORE_BY_NAME[name];
+    if (!store) continue;
+    cb(name, store, _DEFAULTS_BY_NAME[name]);
+  }
+}

--- a/web/coordinator.ts
+++ b/web/coordinator.ts
@@ -100,6 +100,9 @@ export function createCoordinator({
   // first poll lands a fresh manifest.
   if (initialManifest) LAST_UPDATED_AT.set(Date.now());
 
+  // Transitional shape: feeds the old `reloading` boolean field of
+  // FooterLiveStatus. Task 2 splits the footer API into setLiveStatus +
+  // setBuildStatus and removes this translation.
   function _refreshLiveStatus(): void {
     appFooter.setLiveStatus({
       enabled: LIVE_UPDATES.get().ENABLED,

--- a/web/coordinator.ts
+++ b/web/coordinator.ts
@@ -22,7 +22,7 @@ import { showLeftSidebar } from './views/shell/leftSidebar.js';
 import { showRightSidebar, hideRightSidebar } from './views/shell/rightSidebar.js';
 import { buildFilePreviewPane, humanLanguageFor } from './views/panes/filePreviewPane.js';
 import { LIVE_UPDATES } from './config/index.js';
-import { REBUILD_STATUS, LAST_UPDATED_AT } from './liveStatus.js';
+import { REBUILD_STATUS, LAST_REBUILD_ERROR, LAST_UPDATED_AT } from './liveStatus.js';
 import { DateSource, NodeKind } from './types';
 import type { DirNode, FileNode, Manifest, PickTarget, TreeNode } from './types';
 import type { FooterRepoInfo } from './views/shell/appFooter.js';
@@ -100,24 +100,26 @@ export function createCoordinator({
   // first poll lands a fresh manifest.
   if (initialManifest) LAST_UPDATED_AT.set(Date.now());
 
-  // Transitional shape: feeds the old `reloading` boolean field of
-  // FooterLiveStatus. Task 2 splits the footer API into setLiveStatus +
-  // setBuildStatus and removes this translation.
   function _refreshLiveStatus(): void {
-    appFooter.setLiveStatus({
-      enabled: LIVE_UPDATES.get().ENABLED,
-      reloading: REBUILD_STATUS.get() === 'rebuilding',
+    appFooter.setLiveStatus({ enabled: LIVE_UPDATES.get().ENABLED });
+  }
+  function _refreshBuildStatus(): void {
+    appFooter.setBuildStatus({
+      status: REBUILD_STATUS.get(),
       lastUpdatedAt: LAST_UPDATED_AT.get(),
+      errorMessage: LAST_REBUILD_ERROR.get(),
     });
   }
   _refreshLiveStatus();
+  _refreshBuildStatus();
   const _liveCfgUnsub = LIVE_UPDATES.subscribe(_refreshLiveStatus);
-  const _reloadUnsub = REBUILD_STATUS.subscribe(_refreshLiveStatus);
-  const _stampUnsub = LAST_UPDATED_AT.subscribe(_refreshLiveStatus);
+  const _statusUnsub = REBUILD_STATUS.subscribe(_refreshBuildStatus);
+  const _errorUnsub = LAST_REBUILD_ERROR.subscribe(_refreshBuildStatus);
+  const _stampUnsub = LAST_UPDATED_AT.subscribe(_refreshBuildStatus);
   // Re-render every second so the relative timestamp ("5s ago" → "6s
-  // ago") advances smoothly even when polls aren't firing — the
-  // store-based subscriptions only refresh on actual events.
-  const _tickHandle = window.setInterval(_refreshLiveStatus, 1000);
+  // ago") advances smoothly on the Build indicator. The Live indicator
+  // has no time-dependent state.
+  const _tickHandle = window.setInterval(_refreshBuildStatus, 1000);
 
   _renderSidebar(); // initial paint
 
@@ -268,7 +270,8 @@ export function createCoordinator({
     if (typeof _hovUnsub === 'function') _hovUnsub();
     if (typeof _changeUnsub === 'function') _changeUnsub();
     if (typeof _liveCfgUnsub === 'function') _liveCfgUnsub();
-    if (typeof _reloadUnsub === 'function') _reloadUnsub();
+    if (typeof _statusUnsub === 'function') _statusUnsub();
+    if (typeof _errorUnsub === 'function') _errorUnsub();
     if (typeof _stampUnsub === 'function') _stampUnsub();
     window.clearInterval(_tickHandle);
   }

--- a/web/coordinator.ts
+++ b/web/coordinator.ts
@@ -22,7 +22,7 @@ import { showLeftSidebar } from './views/shell/leftSidebar.js';
 import { showRightSidebar, hideRightSidebar } from './views/shell/rightSidebar.js';
 import { buildFilePreviewPane, humanLanguageFor } from './views/panes/filePreviewPane.js';
 import { LIVE_UPDATES } from './config/index.js';
-import { IS_RELOADING, LAST_UPDATED_AT } from './liveStatus.js';
+import { REBUILD_STATUS, LAST_UPDATED_AT } from './liveStatus.js';
 import { DateSource, NodeKind } from './types';
 import type { DirNode, FileNode, Manifest, PickTarget, TreeNode } from './types';
 import type { FooterRepoInfo } from './views/shell/appFooter.js';
@@ -103,13 +103,13 @@ export function createCoordinator({
   function _refreshLiveStatus(): void {
     appFooter.setLiveStatus({
       enabled: LIVE_UPDATES.get().ENABLED,
-      reloading: IS_RELOADING.get(),
+      reloading: REBUILD_STATUS.get() === 'rebuilding',
       lastUpdatedAt: LAST_UPDATED_AT.get(),
     });
   }
   _refreshLiveStatus();
   const _liveCfgUnsub = LIVE_UPDATES.subscribe(_refreshLiveStatus);
-  const _reloadUnsub = IS_RELOADING.subscribe(_refreshLiveStatus);
+  const _reloadUnsub = REBUILD_STATUS.subscribe(_refreshLiveStatus);
   const _stampUnsub = LAST_UPDATED_AT.subscribe(_refreshLiveStatus);
   // Re-render every second so the relative timestamp ("5s ago" → "6s
   // ago") advances smoothly even when polls aren't firing — the

--- a/web/coordinator.ts
+++ b/web/coordinator.ts
@@ -100,29 +100,25 @@ export function createCoordinator({
   // first poll lands a fresh manifest.
   if (initialManifest) LAST_UPDATED_AT.set(Date.now());
 
-  function _refreshLiveStatus(): void {
-    appFooter.setLiveStatus({ enabled: LIVE_UPDATES.get().ENABLED });
-  }
-  function _refreshBuildStatus(): void {
-    appFooter.setBuildStatus({
-      status: REBUILD_STATUS.get(),
+  function _refreshStatus(): void {
+    appFooter.setStatus({
+      liveEnabled: LIVE_UPDATES.get().ENABLED,
+      rebuildStatus: REBUILD_STATUS.get(),
       lastUpdatedAt: LAST_UPDATED_AT.get(),
       errorMessage: LAST_REBUILD_ERROR.get(),
     });
   }
-  _refreshLiveStatus();
-  _refreshBuildStatus();
-  const _liveCfgUnsub = LIVE_UPDATES.subscribe(_refreshLiveStatus);
-  const _statusUnsub = REBUILD_STATUS.subscribe(_refreshBuildStatus);
+  _refreshStatus();
+  const _liveCfgUnsub = LIVE_UPDATES.subscribe(_refreshStatus);
+  const _statusUnsub = REBUILD_STATUS.subscribe(_refreshStatus);
   // _errorUnsub catches updated error messages even when REBUILD_STATUS
   // is already 'error' (e.g. two failing polls in a row with different
   // messages) — the tooltip needs to refresh on every message change.
-  const _errorUnsub = LAST_REBUILD_ERROR.subscribe(_refreshBuildStatus);
-  const _stampUnsub = LAST_UPDATED_AT.subscribe(_refreshBuildStatus);
+  const _errorUnsub = LAST_REBUILD_ERROR.subscribe(_refreshStatus);
+  const _stampUnsub = LAST_UPDATED_AT.subscribe(_refreshStatus);
   // Re-render every second so the relative timestamp ("5s ago" → "6s
-  // ago") advances smoothly on the Build indicator. The Live indicator
-  // has no time-dependent state.
-  const _tickHandle = window.setInterval(_refreshBuildStatus, 1000);
+  // ago") advances smoothly while idle.
+  const _tickHandle = window.setInterval(_refreshStatus, 1000);
 
   _renderSidebar(); // initial paint
 

--- a/web/coordinator.ts
+++ b/web/coordinator.ts
@@ -114,6 +114,9 @@ export function createCoordinator({
   _refreshBuildStatus();
   const _liveCfgUnsub = LIVE_UPDATES.subscribe(_refreshLiveStatus);
   const _statusUnsub = REBUILD_STATUS.subscribe(_refreshBuildStatus);
+  // _errorUnsub catches updated error messages even when REBUILD_STATUS
+  // is already 'error' (e.g. two failing polls in a row with different
+  // messages) — the tooltip needs to refresh on every message change.
   const _errorUnsub = LAST_REBUILD_ERROR.subscribe(_refreshBuildStatus);
   const _stampUnsub = LAST_UPDATED_AT.subscribe(_refreshBuildStatus);
   // Re-render every second so the relative timestamp ("5s ago" → "6s

--- a/web/liveStatus.ts
+++ b/web/liveStatus.ts
@@ -1,18 +1,27 @@
-// liveStatus.ts — transient runtime state for the live-update poll.
+// liveStatus.ts — transient runtime state for the world-rebuild signal.
 // Lives OUTSIDE web/config/ on purpose: these atoms are session-only
-// and must NOT be persisted to localStorage. If IS_RELOADING were
+// and must NOT be persisted to localStorage. If REBUILD_STATUS were
 // re-exported from the config barrel, attachPersistence(Config) would
-// rehydrate `true` from a session that ended mid-fetch — and the
-// poll's `if (IS_RELOADING.get()) return` guard would then strand the
-// footer on "reloading…" forever.
+// rehydrate `'rebuilding'` from a session that ended mid-fetch — and
+// the poll's status-gated logic would then strand the footer on
+// "rebuilding…" forever.
 //
-// setupLiveUpdates() in main.ts is the sole writer for IS_RELOADING.
+// Two writers, both feed the same atoms:
+//   - setupLiveUpdates() in main.ts — live-poll fetch + applyManifest
+//   - scheduleRebuild() in config/hotReload.ts — save-driven applyManifest
+//
 // LAST_UPDATED_AT is written by the coordinator on every applied
 // manifest (initial paint + each successful poll that swapped state).
 
 import { atom } from 'nanostores';
 
-export const IS_RELOADING = atom<boolean>(false);
+/** State of the most recent (or current) world rebuild. */
+export type RebuildStatus = 'idle' | 'rebuilding' | 'error';
+
+export const REBUILD_STATUS = atom<RebuildStatus>('idle');
+
+/** Error message from the most recent failed rebuild; null when idle/success. */
+export const LAST_REBUILD_ERROR = atom<string | null>(null);
 
 /** Epoch millis of the most recent manifest apply (initial or via poll). */
 export const LAST_UPDATED_AT = atom<number>(0);

--- a/web/main.ts
+++ b/web/main.ts
@@ -250,6 +250,7 @@ function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manifest) {
       outlineRenderer.onResize();
       pathLineRenderer.onResize();
     },
+    getRootName: () => cityScene.getRoot()?.name ?? null,
   });
 
   // Sidewalk tints are scene-state that follow selection / hover. Subscribe

--- a/web/main.ts
+++ b/web/main.ts
@@ -46,7 +46,7 @@ import { createCoordinator } from './coordinator.js';
 import { showTooltip, hideTooltip } from './views/shell/tooltip.js';
 import { buildApiUrl } from './url.js';
 
-function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manifest) {
+async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manifest) {
   // Every visual / layout tunable comes from the named exports of
   // src/defaults.js. Render-loop code reads them fresh each frame (or
   // each event), so the Settings UI can mutate the imported objects in
@@ -63,7 +63,7 @@ function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manifest) {
   // every other module reads cityScene directly through accessors.
   const cityScene = createCityScene(canvas);
   const scene = cityScene.scene;
-  cityScene.applyManifest(manifest);
+  await cityScene.applyManifest(manifest);
 
   // -- 3. Renderer -------------------------------------------------------------
   const renderer = new THREE.WebGLRenderer({
@@ -509,7 +509,7 @@ function _clampPollSeconds(s: number | unknown): number {
 }
 
 interface LiveUpdateHandle {
-  cityScene: ReturnType<typeof startRenderLoop>['cityScene'];
+  cityScene: Awaited<ReturnType<typeof startRenderLoop>>['cityScene'];
   applyTheme: () => void;
 }
 
@@ -538,7 +538,7 @@ function setupLiveUpdates(handle: LiveUpdateHandle, initialSignature: string): v
       const m: Manifest | null = await resp.json();
       if (m?.signature) {
         lastSignature = m.signature;
-        handle.cityScene.applyManifest(m);
+        await handle.cityScene.applyManifest(m);
       }
       REBUILD_STATUS.set('idle');
       LAST_REBUILD_ERROR.set(null);
@@ -645,7 +645,7 @@ if (_canvas) {
     const resp = await fetch(manifestUrl());
     if (!resp.ok) throw new Error(`manifest fetch failed: ${resp.status}`);
     const manifest: Manifest = await resp.json();
-    const handle = startRenderLoop(_canvas, manifest);
+    const handle = await startRenderLoop(_canvas, manifest);
     attachHotReload({
       cityScene: handle.cityScene,
       applyTheme: handle.applyTheme,

--- a/web/main.ts
+++ b/web/main.ts
@@ -21,7 +21,7 @@ import {
   POLL_SECONDS_MAX,
   SCAN_FILTERS,
 } from './config/index.js';
-import { IS_RELOADING } from './liveStatus.js';
+import { REBUILD_STATUS, LAST_REBUILD_ERROR } from './liveStatus.js';
 import { attachPersistence, persistStore } from './config/persist.js';
 import { attachHotReload } from './config/hotReload.js';
 import { DOM_IDS } from './constants';
@@ -420,10 +420,9 @@ function signatureUrl(): string {
 // Two-stage poll: each tick first hits /api/manifest/signature (cheap —
 // stat-only walk, no file content reads, no per-file git history) and
 // only fetches the full /api/manifest when the signature has changed.
-// On a large repo the no-op poll cost drops by ~10×. IS_RELOADING is
-// only set during the actual manifest fetch so the footer's "reloading…"
-// indicator doesn't flicker on every cheap signature check; concurrent
-// ticks are gated by the local `inFlight` flag.
+// On a large repo the no-op poll cost drops by ~10×. REBUILD_STATUS is
+// only flipped during the actual manifest fetch so the footer's
+// "rebuilding…" indicator only lights up when there's real work.
 function _clampPollSeconds(s: number | unknown): number {
   if (typeof s !== 'number' || !isFinite(s)) return POLL_SECONDS_MIN;
   return Math.min(POLL_SECONDS_MAX, Math.max(POLL_SECONDS_MIN, s));
@@ -446,21 +445,26 @@ function setupLiveUpdates(handle: LiveUpdateHandle, initialSignature: string): v
   let inFlight = false;
   let needsRefresh = false;
 
-  // Single fetch+apply path. Always sets IS_RELOADING for the duration —
-  // both the poll's "signature changed" branch and the toggle handler
-  // funnel through here so the footer indicator behaves identically.
+  // Single fetch+apply path. Always flips REBUILD_STATUS to 'rebuilding'
+  // for the duration — both the poll's "signature changed" branch and
+  // the toggle handler funnel through here so the footer indicator
+  // behaves identically. A non-2xx response or a JSON parse error
+  // resolves to 'error' with the message captured in LAST_REBUILD_ERROR.
   async function refreshManifest(): Promise<void> {
-    IS_RELOADING.set(true);
+    REBUILD_STATUS.set('rebuilding');
     try {
       const resp = await fetch(manifestUrl());
-      if (!resp.ok) return;
+      if (!resp.ok) throw new Error(`Manifest fetch failed: HTTP ${resp.status}`);
       const m: Manifest | null = await resp.json();
       if (m?.signature) {
         lastSignature = m.signature;
         handle.cityScene.applyManifest(m);
       }
-    } finally {
-      IS_RELOADING.set(false);
+      REBUILD_STATUS.set('idle');
+      LAST_REBUILD_ERROR.set(null);
+    } catch (err) {
+      REBUILD_STATUS.set('error');
+      LAST_REBUILD_ERROR.set(err instanceof Error ? err.message : String(err));
     }
   }
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -15,6 +15,8 @@ import {
   LABEL_TYPOGRAPHY,
   GEM_ANIMATION,
   GEM_APPEARANCE,
+  GEM_FACE_PALETTE,
+  GEM_GLOW,
   GEM_SIZING,
   LIVE_UPDATES,
   POLL_SECONDS_MIN,
@@ -230,6 +232,26 @@ function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manifest) {
       rootGem.userData.baseY = rootGem.userData.radius + rootGem.userData.streetWidth * hoverFrac;
     }
 
+    // Glow halo: scale, opacity, visibility from GEM_GLOW config. Color
+    // is driven per-frame by the render loop (palette cycle), so we
+    // don't touch it here.
+    if (rootGem && rootGem.userData.radius != null) {
+      const glowCfg = GEM_GLOW.get();
+      const r = rootGem.userData.radius as number;
+      const inner = rootGem.userData.innerGlowSprite as THREE.Sprite | null;
+      const outer = rootGem.userData.outerGlowSprite as THREE.Sprite | null;
+      if (inner) {
+        inner.visible = glowCfg.ENABLED;
+        inner.scale.set(r * glowCfg.INNER_SCALE, r * glowCfg.INNER_SCALE, 1);
+        (inner.material as THREE.SpriteMaterial).opacity = glowCfg.INNER_OPACITY;
+      }
+      if (outer) {
+        outer.visible = glowCfg.ENABLED;
+        outer.scale.set(r * glowCfg.OUTER_SCALE, r * glowCfg.OUTER_SCALE, 1);
+        (outer.material as THREE.SpriteMaterial).opacity = glowCfg.OUTER_OPACITY;
+      }
+    }
+
     const labelCfg = LABEL_TYPOGRAPHY.get();
     const streetLabels = cityScene.getStreetLabels();
     for (const lg of streetLabels) {
@@ -310,6 +332,26 @@ function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manifest) {
       const curS = rootGem.scale.x;
       const nextS = curS + (gemTargetScale - curS) * gemAnim.SCALE_LERP_SPEED;
       rootGem.scale.set(nextS, nextS, nextS);
+
+      // Glow color: animate through GEM_FACE_PALETTE when ANIMATE_COLORS
+      // is on; otherwise fall back to the gem's EDGE_COLOR. Two halos
+      // cycle on different phases so the gem reads with two colors at
+      // any moment, blending as they cross.
+      const glowCfg = GEM_GLOW.get();
+      const inner = rootGem.userData.innerGlowSprite as THREE.Sprite | null;
+      const outer = rootGem.userData.outerGlowSprite as THREE.Sprite | null;
+      if (inner || outer) {
+        if (glowCfg.ANIMATE_COLORS) {
+          const palette = GEM_FACE_PALETTE.get();
+          const period = Math.max(0.001, glowCfg.CYCLE_PERIOD_SECONDS);
+          if (inner) _setPaletteColor((inner.material as THREE.SpriteMaterial).color, palette, t, period, 0);
+          if (outer) _setPaletteColor((outer.material as THREE.SpriteMaterial).color, palette, t, period, 0.5);
+        } else {
+          const edge = GEM_APPEARANCE.get().EDGE_COLOR;
+          if (inner) (inner.material as THREE.SpriteMaterial).color.set(edge);
+          if (outer) (outer.material as THREE.SpriteMaterial).color.set(edge);
+        }
+      }
     }
     lodController.update(canvas); // swap detail↔placeholder by screen-space area
     renderer.render(scene, camera);
@@ -321,6 +363,34 @@ function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manifest) {
   // can swap in fresh manifests, and attachHotReload can dispatch
   // material refreshes without restarting the renderer.
   return { cityScene, applyTheme };
+}
+
+// Cycle a THREE.Color in place through a palette of [r,g,b] triples,
+// smoothly interpolating between adjacent palette entries. One full
+// loop through every color takes `period` seconds; `offset` (0..1)
+// shifts the starting phase so multiple sprites can run different
+// "ahead-of-each-other" cadences without allocating new Colors.
+function _setPaletteColor(
+  out: THREE.Color,
+  palette: ReadonlyArray<readonly [number, number, number]>,
+  t: number,
+  period: number,
+  offset: number
+): void {
+  const n = palette.length;
+  if (n === 0) return;
+  const phase = (((t / period) + offset) % 1 + 1) % 1; // wrap negatives
+  const idxf = phase * n;
+  const a = Math.floor(idxf) % n;
+  const b = (a + 1) % n;
+  const f = idxf - Math.floor(idxf);
+  const A = palette[a];
+  const B = palette[b];
+  out.setRGB(
+    A[0] + (B[0] - A[0]) * f,
+    A[1] + (B[1] - A[1]) * f,
+    A[2] + (B[2] - A[2]) * f
+  );
 }
 
 // Keep flat street labels readable at any orbit. Flip decision comes from the

--- a/web/main.ts
+++ b/web/main.ts
@@ -214,7 +214,16 @@ function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manifest) {
       rootGemEdges.material.color.set(gemAppearance.EDGE_COLOR);
     }
     if (rootGemBody?.material) {
-      rootGemBody.material.opacity = gemAppearance.BODY_OPACITY;
+      const op = gemAppearance.BODY_OPACITY;
+      rootGemBody.material.opacity = op;
+      // Toggle `transparent` to match the opacity. Without this, dropping
+      // opacity below 1 has no visual effect after the gem was created
+      // with opacity = 1.
+      const wantTransparent = op < 1;
+      if (rootGemBody.material.transparent !== wantTransparent) {
+        rootGemBody.material.transparent = wantTransparent;
+        rootGemBody.material.needsUpdate = true;
+      }
     }
     if (rootGem && rootGem.userData.streetWidth != null) {
       const hoverFrac = GEM_SIZING.get().HOVER_LIFT_FRAC;

--- a/web/main.ts
+++ b/web/main.ts
@@ -483,8 +483,12 @@ function setupLiveUpdates(handle: LiveUpdateHandle, initialSignature: string): v
         if (!sig?.signature || sig.signature === lastSignature) break;
         await refreshManifest();
       } while (needsRefresh);
-    } catch {
-      /* keep polling on transient errors */
+    } catch (_) {
+      // Signature-fetch errors (network blip on the cheap probe) are
+      // intentionally not surfaced through REBUILD_STATUS — no rebuild
+      // attempt happened. The next tick retries. Only failures inside
+      // refreshManifest (the full fetch + applyManifest) populate the
+      // error indicator.
     } finally {
       inFlight = false;
     }

--- a/web/scene/cityScene.ts
+++ b/web/scene/cityScene.ts
@@ -761,10 +761,13 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
     if (myGeneration !== _currentGeneration) {
       // A newer applyManifest started while we were building. Dispose the
       // new meshes we just built (they'd leak otherwise) and bail.
+      // disposeLabelMaterials clears the module-level _labelMaterials map
+      // keyed by atlas textures we're about to release.
       for (const block of newBlocks) {
         if (block.detailMesh) _disposeObject(block.detailMesh);
         if (block.labelsMesh) _disposeObject(block.labelsMesh);
       }
+      disposeLabelMaterials();
       for (const tex of newAtlasTextures) tex.dispose();
       built.scene.traverse(_disposeObject);
       return;

--- a/web/scene/cityScene.ts
+++ b/web/scene/cityScene.ts
@@ -42,6 +42,7 @@ import { groupBuildingsByDirectory } from './blocks.js';
 import { createBuildingsInstancedMesh } from './instanced/buildings.js';
 import {
   buildLabelAtlas,
+  truncateLabelToFit,
   createLabelsInstancedMesh,
   disposeLabelMaterials,
 } from './instanced/labels.js';
@@ -699,6 +700,20 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
     const newBlocks = groupBuildingsByDirectory(layout.buildings, layout.streets);
 
     // Task 15: build shared label atlas from all unique street label texts.
+    // Each street.label is first truncated to fit its own road; the atlas
+    // dedups across blocks that resolve to the same truncated form. We
+    // mutate `street.label` in place so the atlas lookup later in the
+    // pipeline finds the same key it was stored under.
+    const labelCfg = LABEL_TYPOGRAPHY.get();
+    const measureCtx = document.createElement('canvas').getContext('2d');
+    if (measureCtx) {
+      measureCtx.font = `${labelCfg.FONT_WEIGHT} ${labelCfg.FONT_SIZE_PX}px ${labelCfg.FONT_FAMILY}`;
+      for (const b of newBlocks) {
+        const street = b.primaryStreet;
+        if (!street || !street.label) continue;
+        street.label = truncateLabelToFit(street.label, street, labelCfg, measureCtx);
+      }
+    }
     const uniqueTexts = Array.from(
       new Set(
         newBlocks
@@ -706,7 +721,7 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
           .filter((t): t is string => Boolean(t)),
       ),
     );
-    const atlas = buildLabelAtlas(uniqueTexts, LABEL_TYPOGRAPHY.get());
+    const atlas = buildLabelAtlas(uniqueTexts, labelCfg);
     _atlasTextures = atlas.pages.map((c) => new THREE.CanvasTexture(c));
 
     // Diagnostic: dump (dir.path → primaryStreet.label) pairs and the atlas

--- a/web/scene/cityScene.ts
+++ b/web/scene/cityScene.ts
@@ -736,12 +736,20 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
       // buildings) and visual confusion (cuboid vs real building). Three's
       // built-in frustum culling per InstancedMesh handles the perf
       // benefit at far zoom that placeholders were supposed to provide.
-      if (block.buildings.length === 0) continue;
-      const detailMesh = createBuildingsInstancedMesh(block);
-      block.detailMesh = detailMesh;
-      scene.add(detailMesh);
+      //
+      // Building mesh is only built when the block has direct files;
+      // container-only directories (e.g. `.superpowers/brainstorm` whose
+      // children are all subdirs) have 0 buildings and skip that path.
+      // The street label is built unconditionally — every street should
+      // be named on the road, including container-only ones.
+      if (block.buildings.length > 0) {
+        const detailMesh = createBuildingsInstancedMesh(block);
+        block.detailMesh = detailMesh;
+        scene.add(detailMesh);
+      }
 
-      // Task 15: per-block label InstancedMesh.
+      // Task 15: per-block label InstancedMesh. Built regardless of
+      // direct-file count.
       const labelsMesh = createLabelsInstancedMesh(block, atlas, _atlasTextures);
       if (labelsMesh) {
         block.labelsMesh = labelsMesh;

--- a/web/scene/cityScene.ts
+++ b/web/scene/cityScene.ts
@@ -659,6 +659,14 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
     // layoutClient signals that via a 'superseded' rejection.
     const newManifestTyped = newManifest as Manifest;
     let newLayout: CityLayout;
+    // Pass the full manifest envelope (not `manifest.tree`) — the worker
+    // forwards it to layoutCityV4, which internally unwraps `.tree` via
+    // `(manifest as { tree?: DirLike }).tree ?? manifest`. Both shapes
+    // produce the same layout, but routing through the envelope keeps
+    // the worker message contract typed against `Manifest` rather than
+    // a structural `DirLike`. A reject with `Error('superseded')` is
+    // expected when a newer applyManifest preempts us — return silently
+    // so the newer run owns the swap.
     try {
       newLayout = await _layoutClient.compute(newManifestTyped);
     } catch (err) {

--- a/web/scene/cityScene.ts
+++ b/web/scene/cityScene.ts
@@ -46,8 +46,9 @@ import {
   createLabelsInstancedMesh,
   disposeLabelMaterials,
 } from './instanced/labels.js';
-import { findLayoutOverlaps, layoutCity } from './layout.js';
+import { findLayoutOverlaps } from './layout.js';
 import type { LayoutOverlap } from './layout.js';
+import { createLayoutClient } from './layoutClient.js';
 import { layoutCityV4WithTrace } from './layoutV4.js';
 import type {
   ChildPlacementTrace,
@@ -234,6 +235,11 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
   // call's captured value by the time a safe-point check runs, that call
   // was superseded and must bail out (cleaning up any meshes it built).
   let _currentGeneration = 0;
+
+  // One layoutClient instance per cityScene. Owns the off-thread worker
+  // (or its sync fallback in test envs). Disposed when the cityScene is
+  // disposed.
+  const _layoutClient = createLayoutClient();
 
   // Manifest-bound state. Reassigned on each applyManifest.
   let manifest: Manifest | null = null;
@@ -648,13 +654,17 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
 
     _emit(beforeChangeCbs, prev);
 
-    // ---- Phase 1: compute the new layout (sync for now — Task 4 swaps in
-    // the off-thread layoutClient). A later applyManifest can preempt us by
-    // bumping _currentGeneration.
+    // ---- Phase 1: compute the new layout off-thread via layoutClient.
+    // A later applyManifest can preempt us by bumping _currentGeneration;
+    // layoutClient signals that via a 'superseded' rejection.
     const newManifestTyped = newManifest as Manifest;
-    const newLayout = layoutCity(
-      newManifestTyped.tree as unknown as Parameters<typeof layoutCity>[0],
-    );
+    let newLayout: CityLayout;
+    try {
+      newLayout = await _layoutClient.compute(newManifestTyped);
+    } catch (err) {
+      if (err instanceof Error && err.message === 'superseded') return;
+      throw err;
+    }
     if (myGeneration !== _currentGeneration) return;
 
     // ---- Phase 2: derive date ranges + color buildings on the NEW layout's
@@ -832,6 +842,7 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
     _disposeAllManifestState();
     beforeChangeCbs.length = 0;
     changeCbs.length = 0;
+    _layoutClient.dispose();
   }
 
   return {

--- a/web/scene/cityScene.ts
+++ b/web/scene/cityScene.ts
@@ -229,6 +229,12 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(SCENE_COLORS.get().GROUND);
 
+  // Generation counter: each applyManifest invocation increments this and
+  // captures its own value. If _currentGeneration has advanced beyond a
+  // call's captured value by the time a safe-point check runs, that call
+  // was superseded and must bail out (cleaning up any meshes it built).
+  let _currentGeneration = 0;
+
   // Manifest-bound state. Reassigned on each applyManifest.
   let manifest: Manifest | null = null;
   let layout: CityLayout | null = null;
@@ -623,7 +629,11 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
   // manifests with string `type` fields rather than the literal
   // 'directory'/'file'. Real callers (the scanner/IPC path) hand us
   // proper Manifest objects.
-  function applyManifest(newManifest: Manifest | { tree: unknown; [k: string]: unknown }): void {
+  async function applyManifest(
+    newManifest: Manifest | { tree: unknown; [k: string]: unknown },
+  ): Promise<void> {
+    const myGeneration = ++_currentGeneration;
+
     const prev: PrevState = {
       buildings: buildingMeshes,
       blocks,
@@ -638,66 +648,42 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
 
     _emit(beforeChangeCbs, prev);
 
-    _disposeAllManifestState();
+    // ---- Phase 1: compute the new layout (sync for now — Task 4 swaps in
+    // the off-thread layoutClient). A later applyManifest can preempt us by
+    // bumping _currentGeneration.
+    const newManifestTyped = newManifest as Manifest;
+    const newLayout = layoutCity(
+      newManifestTyped.tree as unknown as Parameters<typeof layoutCity>[0],
+    );
+    if (myGeneration !== _currentGeneration) return;
 
-    manifest = newManifest as Manifest;
-    // layoutCity / getDateRanges accept the structural-shape variants
-    // (DirLike / TreeNodeLike). DirNode satisfies them at runtime; the
-    // explicit cast keeps the type checker happy across the boundary.
-    layout = layoutCity(manifest.tree as unknown as Parameters<typeof layoutCity>[0]);
-
-    dateRanges = getDateRanges(manifest.tree as unknown as Parameters<typeof getDateRanges>[0]);
-
-    // Color buildings before mesh creation — buildCityScene reads b.color.
+    // ---- Phase 2: derive date ranges + color buildings on the NEW layout's
+    // building list. dateRanges and the color loop don't touch the scene yet.
+    const newDateRanges = getDateRanges(
+      newManifestTyped.tree as unknown as Parameters<typeof getDateRanges>[0],
+    );
     const dirColor = BUILDING_PALETTE.get().DIRECTORY_COLOR;
-    const buildings = layout?.buildings ?? [];
-    for (const b of buildings) {
+    const newBuildings = newLayout?.buildings ?? [];
+    for (const b of newBuildings) {
       b.color =
         b.file?.type === NodeKind.File
           ? getBuildingColor(
               b.file as unknown as Parameters<typeof getBuildingColor>[0],
-              dateRanges
+              newDateRanges,
             )
           : dirColor;
     }
+    if (myGeneration !== _currentGeneration) return;
 
-    // Build streets / labels / paths / gem (not buildings — those are
-    // per-block InstancedMeshes below).
-    const built = buildCityScene(layout);
-    bbox = built.bbox;
-    // buildCityScene still builds per-building meshes internally but we
-    // don't use them. We extract only the non-building parts.
-    streetPickables = built.streetPickables || [];
-    streetLabels = built.streetLabels || [];
-    pathMeshes = built.pathMeshes || [];
-    asphaltMeshes = built.asphaltMeshes || [];
-    rootGem = built.rootGem || null;
-    rootGemBody = built.rootGemBody || null;
-    rootGemEdges = built.rootGemEdges || null;
-
-    // Migrate built scene's non-building children into the persistent scene.
-    // We add them all, then remove the per-building meshes that buildCityScene
-    // still creates (they'll be replaced by InstancedMeshes below).
-    for (const child of [...built.scene.children]) scene.add(child);
-    // buildCityScene also set its own scene.background; mirror onto ours.
-    scene.background = new THREE.Color(SCENE_COLORS.get().GROUND);
-
-    // Remove per-building meshes that buildCityScene created — we replace
-    // them with per-block InstancedMeshes.
-    for (const bm of built.buildingMeshes || []) {
-      if (bm.parent) bm.parent.remove(bm);
-      _disposeObject(bm);
-    }
-
-    // Task 15: Remove old per-Group label meshes from buildCityScene — replaced
-    // by per-block label InstancedMeshes below.
-    for (const lg of built.streetLabels || []) {
-      if (lg.parent) lg.parent.remove(lg);
-      lg.traverse(_disposeObject);
-    }
-
-    // Task 8: group buildings by directory → one InstancedMesh per block.
-    const newBlocks = groupBuildingsByDirectory(layout.buildings, layout.streets);
+    // ---- Phase 3: build all new meshes detached from the live scene.
+    // `built` is a sub-scene from buildCityScene with its own children
+    // (streets, labels, paths, gem). We do NOT add its children to the
+    // live scene yet — that happens in Phase 4's atomic swap.
+    const built = buildCityScene(newLayout);
+    const newBlocks = groupBuildingsByDirectory(
+      newLayout.buildings,
+      newLayout.streets,
+    );
 
     // Task 15: build shared label atlas from all unique street label texts.
     // Each street.label is first truncated to fit its own road; the atlas
@@ -722,7 +708,9 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
       ),
     );
     const atlas = buildLabelAtlas(uniqueTexts, labelCfg);
-    _atlasTextures = atlas.pages.map((c) => new THREE.CanvasTexture(c));
+    const newAtlasTextures = atlas.pages.map(
+      (c) => new THREE.CanvasTexture(c),
+    );
 
     // Diagnostic: dump (dir.path → primaryStreet.label) pairs and the atlas
     // rect each block resolves to. Toggle with window.__labelDebug = true
@@ -745,6 +733,8 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
       (window as unknown as { __labelDebugDump?: unknown }).__labelDebugDump = dump;
     }
 
+    // Per-block detail + label meshes — created here but added to the
+    // scene only in Phase 4 below.
     for (const block of newBlocks) {
       // Placeholders disabled: they caused hover ambiguity (one block's
       // placeholder cuboid intercepting rays meant for another block's
@@ -758,18 +748,68 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
       // The street label is built unconditionally — every street should
       // be named on the road, including container-only ones.
       if (block.buildings.length > 0) {
-        const detailMesh = createBuildingsInstancedMesh(block);
-        block.detailMesh = detailMesh;
-        scene.add(detailMesh);
+        block.detailMesh = createBuildingsInstancedMesh(block);
       }
-
       // Task 15: per-block label InstancedMesh. Built regardless of
       // direct-file count.
-      const labelsMesh = createLabelsInstancedMesh(block, atlas, _atlasTextures);
+      const labelsMesh = createLabelsInstancedMesh(block, atlas, newAtlasTextures);
       if (labelsMesh) {
         block.labelsMesh = labelsMesh;
-        scene.add(labelsMesh);
       }
+    }
+
+    if (myGeneration !== _currentGeneration) {
+      // A newer applyManifest started while we were building. Dispose the
+      // new meshes we just built (they'd leak otherwise) and bail.
+      for (const block of newBlocks) {
+        if (block.detailMesh) _disposeObject(block.detailMesh);
+        if (block.labelsMesh) _disposeObject(block.labelsMesh);
+      }
+      for (const tex of newAtlasTextures) tex.dispose();
+      built.scene.traverse(_disposeObject);
+      return;
+    }
+
+    // ---- Phase 4: atomic swap. Up to this point, the previous scene is
+    // still on screen. Now we dispose the previous state and attach every
+    // new mesh in a single uninterrupted block.
+    _disposeAllManifestState();
+    _atlasTextures = newAtlasTextures;
+
+    manifest = newManifestTyped;
+    layout = newLayout;
+    dateRanges = newDateRanges;
+    bbox = built.bbox;
+
+    streetPickables = built.streetPickables || [];
+    streetLabels = built.streetLabels || [];
+    pathMeshes = built.pathMeshes || [];
+    asphaltMeshes = built.asphaltMeshes || [];
+    rootGem = built.rootGem || null;
+    rootGemBody = built.rootGemBody || null;
+    rootGemEdges = built.rootGemEdges || null;
+
+    // Migrate built scene's non-building children into the persistent scene.
+    for (const child of [...built.scene.children]) scene.add(child);
+    // buildCityScene also set its own scene.background; mirror onto ours.
+    scene.background = new THREE.Color(SCENE_COLORS.get().GROUND);
+
+    // buildCityScene still builds per-building meshes internally; we don't
+    // use them. Remove + dispose to match prior behavior.
+    for (const bm of built.buildingMeshes || []) {
+      if (bm.parent) bm.parent.remove(bm);
+      _disposeObject(bm);
+    }
+    // Task 15: Remove old per-Group label meshes from buildCityScene —
+    // replaced by per-block label InstancedMeshes.
+    for (const lg of built.streetLabels || []) {
+      if (lg.parent) lg.parent.remove(lg);
+      lg.traverse(_disposeObject);
+    }
+
+    for (const block of newBlocks) {
+      if (block.detailMesh) scene.add(block.detailMesh);
+      if (block.labelsMesh) scene.add(block.labelsMesh);
     }
     blocks = newBlocks;
     blocksByDirPath = {};
@@ -777,19 +817,12 @@ export function createCityScene(_canvas: HTMLCanvasElement) {
       if (block.dir?.path != null) blocksByDirPath[block.dir.path] = block;
     }
 
-    // Stamp the gem body so it can participate in raycast picking.
-    if (rootGem) {
-      const gemBody = rootGem.children?.[0];
-      if (gemBody) gemBody.userData.type = NodeKind.Gem;
-    }
-
     // TODO(Task 11/12): _buildOutlinesAndGhosts() removed — per-block
     // instanced outlines/ghosts will be built in Tasks 11-12.
     _buildLookups();
     _computeRootStreetAndGem();
 
-    const diff = _computeDiff(prev);
-    _emit(changeCbs, diff);
+    _emit(changeCbs, _computeDiff(prev));
   }
 
   function dispose() {

--- a/web/scene/engine.ts
+++ b/web/scene/engine.ts
@@ -357,6 +357,9 @@ function createRootGem(street: Street): THREE.Group {
       1
     );
     innerGlowSprite.visible = glowCfg.ENABLED;
+    // Glow is purely visual — never absorbs hover / click. Sprites are
+    // raycast-pickable by default, so override with a no-op.
+    innerGlowSprite.raycast = () => {};
 
     outerGlowSprite = new THREE.Sprite(
       new THREE.SpriteMaterial({
@@ -374,6 +377,7 @@ function createRootGem(street: Street): THREE.Group {
       1
     );
     outerGlowSprite.visible = glowCfg.ENABLED;
+    outerGlowSprite.raycast = () => {};
 
     // Draw outer halo first (largest, softest), then inner, then the
     // opaque body, then the edges. The additive layers blend cumulatively

--- a/web/scene/engine.ts
+++ b/web/scene/engine.ts
@@ -265,9 +265,13 @@ function createRootGem(street: Street): THREE.Group {
     geo,
     new THREE.MeshBasicMaterial({
       vertexColors: true,
-      transparent: true,
+      transparent: appearance.BODY_OPACITY < 1,
       opacity: appearance.BODY_OPACITY,
-      depthWrite: false,
+      // depthWrite must be on so the gem properly occludes road labels
+      // (and anything else) drawn at lower elevation behind it. Prior
+      // versions kept this off for "jewel-like" alpha blending; the
+      // visual side-effect was labels bleeding through the gem.
+      depthWrite: true,
     })
   );
 
@@ -276,7 +280,31 @@ function createRootGem(street: Street): THREE.Group {
     new THREE.LineBasicMaterial({ color: new THREE.Color(edgeColor) })
   );
 
+  // Neon glow halo: a slightly larger octahedron using the same vivid
+  // face palette but rendered with additive blending and low opacity.
+  // The colored faces bleed out around the solid body like a soft aura.
+  // Rendered before the body in the parent group so additive pixels
+  // stack with the body's colors rather than overwriting them; depth
+  // write off so it doesn't occlude anything itself.
+  const GLOW_SCALE = 1.35;
+  const GLOW_OPACITY = 0.45;
+  const glowGeo = new THREE.OctahedronGeometry(radius * GLOW_SCALE, 0);
+  glowGeo.setAttribute('color', new THREE.BufferAttribute(colorAttr.slice(), 3));
+  const glow = new THREE.Mesh(
+    glowGeo,
+    new THREE.MeshBasicMaterial({
+      vertexColors: true,
+      transparent: true,
+      opacity: GLOW_OPACITY,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+      side: THREE.BackSide,
+    })
+  );
+  glow.renderOrder = -1;
+
   const gem = new THREE.Group();
+  gem.add(glow);
   gem.add(body);
   gem.add(edges);
   gem.position.set(gemX, hoverY, gemZ);

--- a/web/scene/engine.ts
+++ b/web/scene/engine.ts
@@ -395,6 +395,11 @@ function createRootGem(street: Street): THREE.Group {
   // recompute baseY = radius + streetWidth × frac.
   gem.userData.streetWidth = street.width;
   gem.userData.radius = radius;
+  // Direct refs to the body and edges meshes so consumers (picker,
+  // applyTheme) don't have to know the child-order convention — which
+  // shifts depending on whether the glow sprites are also children.
+  gem.userData.body = body;
+  gem.userData.edges = edges;
   // Glow sprite refs for hot-reload (applyTheme) and per-frame color
   // cycling. Either may be null when the host can't build a gradient
   // texture (jsdom test env).
@@ -578,12 +583,14 @@ export function buildCityScene(layout: CityLayout) {
       const gemGroup = createRootGem(street);
       scene.add(gemGroup);
       rootGem = (gemGroup.userData.gem as THREE.Group) || null;
-      if (rootGem && rootGem.children) {
+      if (rootGem) {
         rootGemBody =
-          (rootGem.children[0] as THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>) ||
-          null;
+          (rootGem.userData.body as THREE.Mesh<
+            THREE.BufferGeometry,
+            THREE.MeshBasicMaterial
+          >) || null;
         rootGemEdges =
-          (rootGem.children[1] as THREE.LineSegments<
+          (rootGem.userData.edges as THREE.LineSegments<
             THREE.BufferGeometry,
             THREE.LineBasicMaterial
           >) || null;

--- a/web/scene/engine.ts
+++ b/web/scene/engine.ts
@@ -313,6 +313,11 @@ function createRootGem(street: Street): THREE.Group {
       depthWrite: true,
     })
   );
+  // Picker raycasts against the body mesh directly (not the parent
+  // group), so the type flag has to live here for hover/click detection
+  // to fire. Without this, `hit.object.userData.type === NodeKind.Gem`
+  // in inputHandlers / interpretHit silently always evaluates to false.
+  body.userData.type = NodeKind.Gem;
 
   const edges = new THREE.LineSegments(
     new THREE.EdgesGeometry(geo),

--- a/web/scene/engine.ts
+++ b/web/scene/engine.ts
@@ -200,6 +200,40 @@ function createStreetMesh(street: StreetWithJoin, yBase: number): THREE.Group {
   return group;
 }
 
+// Procedural glow texture: a single-channel radial gradient drawn on a
+// canvas, used as the alpha map for the gem's sprite halo. Cached at
+// module scope so a second gem build (live-reload manifest swap) reuses
+// the same GPU texture rather than allocating a fresh one each time.
+//
+// Returns null when the host environment can't build a real gradient
+// (the jsdom canvas mock returns undefined from createRadialGradient).
+// Callers skip the glow sprites in that case.
+let _glowTexture: THREE.CanvasTexture | null = null;
+function _makeGlowTexture(): THREE.CanvasTexture | null {
+  if (_glowTexture) return _glowTexture;
+  const SIZE = 256;
+  const canvas = document.createElement('canvas');
+  canvas.width = SIZE;
+  canvas.height = SIZE;
+  const ctx = canvas.getContext('2d');
+  if (!ctx || typeof ctx.createRadialGradient !== 'function') return null;
+  const cx = SIZE / 2;
+  const cy = SIZE / 2;
+  const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, SIZE / 2);
+  if (!gradient || typeof gradient.addColorStop !== 'function') return null;
+  // Soft falloff: bright hot center, smooth glide to fully transparent
+  // at the edge so the sprite has no visible boundary.
+  gradient.addColorStop(0, 'rgba(255, 255, 255, 1.0)');
+  gradient.addColorStop(0.15, 'rgba(255, 255, 255, 0.65)');
+  gradient.addColorStop(0.4, 'rgba(255, 255, 255, 0.2)');
+  gradient.addColorStop(0.75, 'rgba(255, 255, 255, 0.05)');
+  gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, SIZE, SIZE);
+  _glowTexture = new THREE.CanvasTexture(canvas);
+  return _glowTexture;
+}
+
 // -----------------------------------------------------------------------------
 // createRootGem(street) -> THREE.Group
 //
@@ -280,31 +314,51 @@ function createRootGem(street: Street): THREE.Group {
     new THREE.LineBasicMaterial({ color: new THREE.Color(edgeColor) })
   );
 
-  // Neon glow halo: a slightly larger octahedron using the same vivid
-  // face palette but rendered with additive blending and low opacity.
-  // The colored faces bleed out around the solid body like a soft aura.
-  // Rendered before the body in the parent group so additive pixels
-  // stack with the body's colors rather than overwriting them; depth
-  // write off so it doesn't occlude anything itself.
-  const GLOW_SCALE = 1.35;
-  const GLOW_OPACITY = 0.45;
-  const glowGeo = new THREE.OctahedronGeometry(radius * GLOW_SCALE, 0);
-  glowGeo.setAttribute('color', new THREE.BufferAttribute(colorAttr.slice(), 3));
-  const glow = new THREE.Mesh(
-    glowGeo,
-    new THREE.MeshBasicMaterial({
-      vertexColors: true,
-      transparent: true,
-      opacity: GLOW_OPACITY,
-      blending: THREE.AdditiveBlending,
-      depthWrite: false,
-      side: THREE.BackSide,
-    })
-  );
-  glow.renderOrder = -1;
-
+  // Neon glow: two billboarded sprites stacked behind the gem with a
+  // soft radial-gradient texture. Sprites always face the camera so the
+  // glow reads consistently from any angle. Additive blending makes the
+  // bright center clip toward white where it overlaps the colored gem,
+  // mimicking a real light source. Sized in world units (radius × N) so
+  // the halo scales with the gem.
+  //
+  // Two layers:
+  //   - inner: smaller, brighter — a "hot core" that hugs the gem
+  //   - outer: much larger, dimmer — the atmospheric falloff
+  //
+  // Skipped when _makeGlowTexture returns null (jsdom test env).
   const gem = new THREE.Group();
-  gem.add(glow);
+  const glowTex = _makeGlowTexture();
+  if (glowTex) {
+    const innerGlow = new THREE.Sprite(
+      new THREE.SpriteMaterial({
+        map: glowTex,
+        color: new THREE.Color(edgeColor),
+        transparent: true,
+        opacity: 0.75,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      })
+    );
+    innerGlow.scale.set(radius * 3.2, radius * 3.2, 1);
+
+    const outerGlow = new THREE.Sprite(
+      new THREE.SpriteMaterial({
+        map: glowTex,
+        color: new THREE.Color(edgeColor),
+        transparent: true,
+        opacity: 0.45,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      })
+    );
+    outerGlow.scale.set(radius * 7, radius * 7, 1);
+
+    // Draw outer halo first (largest, softest), then inner, then the
+    // opaque body, then the edges. The additive layers blend cumulatively
+    // beneath the body's colored faces.
+    gem.add(outerGlow);
+    gem.add(innerGlow);
+  }
   gem.add(body);
   gem.add(edges);
   gem.position.set(gemX, hoverY, gemZ);

--- a/web/scene/engine.ts
+++ b/web/scene/engine.ts
@@ -18,6 +18,7 @@ import {
   GEM_SIZING,
   GEM_FACE_PALETTE,
   GEM_APPEARANCE,
+  GEM_GLOW,
   GEM_ANIMATION,
 } from '@/config/index.js';
 import { RENDER_ORDERS } from '@/constants';
@@ -221,12 +222,16 @@ function _makeGlowTexture(): THREE.CanvasTexture | null {
   const cy = SIZE / 2;
   const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, SIZE / 2);
   if (!gradient || typeof gradient.addColorStop !== 'function') return null;
-  // Soft falloff: bright hot center, smooth glide to fully transparent
-  // at the edge so the sprite has no visible boundary.
-  gradient.addColorStop(0, 'rgba(255, 255, 255, 1.0)');
-  gradient.addColorStop(0.15, 'rgba(255, 255, 255, 0.65)');
-  gradient.addColorStop(0.4, 'rgba(255, 255, 255, 0.2)');
-  gradient.addColorStop(0.75, 'rgba(255, 255, 255, 0.05)');
+  // Softer, more gradual falloff than a typical hard-core radial: even the
+  // center is held a little below max alpha, and most of the area is at
+  // very low opacity so the halo reads as a fuzzy haze rather than a
+  // bright disk. Tuned by eye for a "fuzzy neon glow" feel.
+  gradient.addColorStop(0, 'rgba(255, 255, 255, 0.85)');
+  gradient.addColorStop(0.08, 'rgba(255, 255, 255, 0.55)');
+  gradient.addColorStop(0.2, 'rgba(255, 255, 255, 0.3)');
+  gradient.addColorStop(0.4, 'rgba(255, 255, 255, 0.12)');
+  gradient.addColorStop(0.65, 'rgba(255, 255, 255, 0.04)');
+  gradient.addColorStop(0.85, 'rgba(255, 255, 255, 0.01)');
   gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, SIZE, SIZE);
@@ -315,49 +320,66 @@ function createRootGem(street: Street): THREE.Group {
   );
 
   // Neon glow: two billboarded sprites stacked behind the gem with a
-  // soft radial-gradient texture. Sprites always face the camera so the
-  // glow reads consistently from any angle. Additive blending makes the
-  // bright center clip toward white where it overlaps the colored gem,
-  // mimicking a real light source. Sized in world units (radius × N) so
-  // the halo scales with the gem.
+  // soft radial-gradient alpha texture. Sprites always face the camera
+  // so the glow reads consistently from any angle. Additive blending
+  // makes the bright center clip toward white where it overlaps the
+  // colored gem, mimicking a real light source. Sizes are world units
+  // (radius × INNER/OUTER_SCALE) so the halo scales with the gem.
   //
   // Two layers:
   //   - inner: smaller, brighter — a "hot core" that hugs the gem
   //   - outer: much larger, dimmer — the atmospheric falloff
   //
+  // Material refs are stashed on gem.userData so applyTheme + the render
+  // loop can mutate scale/opacity/color without rebuilding. Glow visibility
+  // is driven by the GEM_GLOW.ENABLED flag.
+  //
   // Skipped when _makeGlowTexture returns null (jsdom test env).
   const gem = new THREE.Group();
+  const glowCfg = GEM_GLOW.get();
   const glowTex = _makeGlowTexture();
+  let innerGlowSprite: THREE.Sprite | null = null;
+  let outerGlowSprite: THREE.Sprite | null = null;
   if (glowTex) {
-    const innerGlow = new THREE.Sprite(
+    innerGlowSprite = new THREE.Sprite(
       new THREE.SpriteMaterial({
         map: glowTex,
         color: new THREE.Color(edgeColor),
         transparent: true,
-        opacity: 0.75,
+        opacity: glowCfg.INNER_OPACITY,
         blending: THREE.AdditiveBlending,
         depthWrite: false,
       })
     );
-    innerGlow.scale.set(radius * 3.2, radius * 3.2, 1);
+    innerGlowSprite.scale.set(
+      radius * glowCfg.INNER_SCALE,
+      radius * glowCfg.INNER_SCALE,
+      1
+    );
+    innerGlowSprite.visible = glowCfg.ENABLED;
 
-    const outerGlow = new THREE.Sprite(
+    outerGlowSprite = new THREE.Sprite(
       new THREE.SpriteMaterial({
         map: glowTex,
         color: new THREE.Color(edgeColor),
         transparent: true,
-        opacity: 0.45,
+        opacity: glowCfg.OUTER_OPACITY,
         blending: THREE.AdditiveBlending,
         depthWrite: false,
       })
     );
-    outerGlow.scale.set(radius * 7, radius * 7, 1);
+    outerGlowSprite.scale.set(
+      radius * glowCfg.OUTER_SCALE,
+      radius * glowCfg.OUTER_SCALE,
+      1
+    );
+    outerGlowSprite.visible = glowCfg.ENABLED;
 
     // Draw outer halo first (largest, softest), then inner, then the
     // opaque body, then the edges. The additive layers blend cumulatively
     // beneath the body's colored faces.
-    gem.add(outerGlow);
-    gem.add(innerGlow);
+    gem.add(outerGlowSprite);
+    gem.add(innerGlowSprite);
   }
   gem.add(body);
   gem.add(edges);
@@ -369,6 +391,11 @@ function createRootGem(street: Street): THREE.Group {
   // recompute baseY = radius + streetWidth × frac.
   gem.userData.streetWidth = street.width;
   gem.userData.radius = radius;
+  // Glow sprite refs for hot-reload (applyTheme) and per-frame color
+  // cycling. Either may be null when the host can't build a gradient
+  // texture (jsdom test env).
+  gem.userData.innerGlowSprite = innerGlowSprite;
+  gem.userData.outerGlowSprite = outerGlowSprite;
 
   group.add(gem);
   group.userData.gem = gem;

--- a/web/scene/inputHandlers.ts
+++ b/web/scene/inputHandlers.ts
@@ -73,9 +73,10 @@ export function createInputHandlers({
   function _tooltipForHover(target: PickTarget | null): string | null {
     if (!target) return null;
     if (target.kind === NodeKind.Gem) {
-      // The gem represents the project root; show the root folder name
-      // (prefixed with '/' to match directory tooltips).
-      return _withRoot('');
+      // The gem represents the project root and also acts as the reset
+      // button — clicking it clears the selection and recenters the
+      // camera. Show both so the affordance is discoverable.
+      return `${_withRoot('')}  ·  click to reset view`;
     }
     if (target.kind === NodeKind.File && target.file) {
       const f = target.file;

--- a/web/scene/inputHandlers.ts
+++ b/web/scene/inputHandlers.ts
@@ -58,23 +58,24 @@ export function createInputHandlers({
   let _hoverPending = null;
   let _hoverCommitId: ReturnType<typeof setTimeout> | 0 = 0;
 
-  // Prepend the root directory name to a manifest-relative path so the
-  // hover tooltip reads as the user thinks of it (e.g. "codecity/web/main.ts"
-  // rather than "web/main.ts"). For the root itself (empty path), returns
-  // just the root name. Safe against a null/empty root name.
+  // Prepend the root directory name (with a leading slash) to a manifest-
+  // relative path so the hover tooltip reads as an absolute-looking path
+  // (e.g. "/codecity/web/main.ts" rather than "web/main.ts"). The manifest
+  // uses '.' as the root directory's own path; that sentinel is treated
+  // the same as empty — we don't render "codecity/.".
   function _withRoot(relPath: string): string {
     const root = getRootName();
     if (!root) return relPath || '';
-    if (!relPath) return root;
-    return `${root}/${relPath}`;
+    if (!relPath || relPath === '.') return `/${root}`;
+    return `/${root}/${relPath}`;
   }
 
   function _tooltipForHover(target: PickTarget | null): string | null {
     if (!target) return null;
     if (target.kind === NodeKind.Gem) {
       // The gem represents the project root; show the root folder name
-      // itself (falls back to a generic literal if unknown).
-      return getRootName() || 'root';
+      // (prefixed with '/' to match directory tooltips).
+      return _withRoot('');
     }
     if (target.kind === NodeKind.File && target.file) {
       const f = target.file;
@@ -84,8 +85,10 @@ export function createInputHandlers({
     if (target.kind === NodeKind.Directory && target.dir) {
       const d = target.dir;
       const dpath = _withRoot(d.path || d.name || '');
-      const fileCount = d.descendants_file_count != null ? d.descendants_file_count : 0;
-      const dirCount = d.descendants_dir_count != null ? d.descendants_dir_count : 0;
+      // Show immediate-child counts (not descendants) — the tooltip is a
+      // quick "what's directly inside here", not a subtree summary.
+      const fileCount = d.children_file_count != null ? d.children_file_count : 0;
+      const dirCount = d.children_dir_count != null ? d.children_dir_count : 0;
       const counts = `${fileCount} file${fileCount === 1 ? '' : 's'}, ${dirCount} dir${
         dirCount === 1 ? '' : 's'
       }`;

--- a/web/scene/inputHandlers.ts
+++ b/web/scene/inputHandlers.ts
@@ -27,6 +27,7 @@ export function createInputHandlers({
   showTooltip,
   hideTooltip,
   onResize,
+  getRootName,
 }: {
   canvas: HTMLCanvasElement;
   picker: ReturnType<typeof createPicker>;
@@ -37,6 +38,9 @@ export function createInputHandlers({
   showTooltip: (text: string, x: number, y: number) => void;
   hideTooltip: () => void;
   onResize: () => void;
+  /** Resolve the current root directory name for hover-tooltip prefixing.
+   * Called lazily on each hover so it stays in sync after manifest reloads. */
+  getRootName: () => string | null;
 }) {
   // Click vs. drag: pointerdown→pointerup with movement + time threshold.
   let downX = 0,
@@ -54,27 +58,38 @@ export function createInputHandlers({
   let _hoverPending = null;
   let _hoverCommitId: ReturnType<typeof setTimeout> | 0 = 0;
 
+  // Prepend the root directory name to a manifest-relative path so the
+  // hover tooltip reads as the user thinks of it (e.g. "codecity/web/main.ts"
+  // rather than "web/main.ts"). For the root itself (empty path), returns
+  // just the root name. Safe against a null/empty root name.
+  function _withRoot(relPath: string): string {
+    const root = getRootName();
+    if (!root) return relPath || '';
+    if (!relPath) return root;
+    return `${root}/${relPath}`;
+  }
+
   function _tooltipForHover(target: PickTarget | null): string | null {
     if (!target) return null;
     if (target.kind === NodeKind.Gem) {
-      // Resolve via picker → cityScene only as needed; we don't keep a
-      // direct cityScene ref here.
-      return 'root';
+      // The gem represents the project root; show the root folder name
+      // itself (falls back to a generic literal if unknown).
+      return getRootName() || 'root';
     }
     if (target.kind === NodeKind.File && target.file) {
       const f = target.file;
-      const fpath = f.path || f.name || 'file';
+      const fpath = _withRoot(f.path || f.name || 'file');
       return fpath + (f.lines != null ? `  ·  ${f.lines} lines` : '');
     }
     if (target.kind === NodeKind.Directory && target.dir) {
       const d = target.dir;
-      const dpath = d.path || d.name || 'directory';
+      const dpath = _withRoot(d.path || d.name || '');
       const fileCount = d.descendants_file_count != null ? d.descendants_file_count : 0;
       const dirCount = d.descendants_dir_count != null ? d.descendants_dir_count : 0;
       const counts = `${fileCount} file${fileCount === 1 ? '' : 's'}, ${dirCount} dir${
         dirCount === 1 ? '' : 's'
       }`;
-      return `${dpath}  ·  ${counts}`;
+      return `${dpath || 'directory'}  ·  ${counts}`;
     }
     return null;
   }

--- a/web/scene/instanced/labels.ts
+++ b/web/scene/instanced/labels.ts
@@ -34,6 +34,50 @@ const ATLAS_HEIGHT_MAX = 8192;
 // need >2000 unique directory names to push past page 1 at default font.
 const MAX_PAGES = 16;
 
+/**
+ * Truncate a label so it fits on its street.
+ *
+ * Labels are rendered at a height of `street.width * HEIGHT_FRAC` world
+ * units; canvas height is `FONT_SIZE_PX + 2 * CANVAS_PADDING_PX` pixels.
+ * That ratio gives world-units-per-canvas-pixel, which we use to compute
+ * the maximum canvas-pixel width that fits in `street.length * 0.9`
+ * world units. If the full label exceeds that, we trim characters off
+ * the end and append an ellipsis until it fits.
+ *
+ * Caller passes a 2D canvas context whose font has already been set to
+ * the label typography spec (one ctx is reused across all blocks per
+ * scene build to amortize the cost).
+ *
+ * Returns the original text if it already fits, the longest "<prefix>…"
+ * that fits otherwise, or just "…" if even that doesn't fit.
+ */
+export function truncateLabelToFit(
+  text: string,
+  street: { length: number; width: number },
+  typography: LabelTypographyConfig,
+  measureCtx: CanvasRenderingContext2D,
+): string {
+  if (!text) return text;
+  const labelHeightPx = typography.FONT_SIZE_PX + 2 * typography.CANVAS_PADDING_PX;
+  const worldPerCanvasPx =
+    (street.width * typography.HEIGHT_FRAC) / labelHeightPx;
+  if (worldPerCanvasPx <= 0) return text;
+  const maxCanvasWidthPx = (street.length * 0.9) / worldPerCanvasPx;
+  if (maxCanvasWidthPx <= 0) return text;
+  const measure = (s: string): number =>
+    measureCtx.measureText(s).width + 2 * typography.CANVAS_PADDING_PX;
+  if (measure(text) <= maxCanvasWidthPx) return text;
+
+  const ellipsis = '…';
+  // Linear search from longest to shortest. Labels are short; binary
+  // search would be premature.
+  for (let len = text.length - 1; len > 0; len--) {
+    const candidate = text.slice(0, len) + ellipsis;
+    if (measure(candidate) <= maxCanvasWidthPx) return candidate;
+  }
+  return ellipsis;
+}
+
 export function buildLabelAtlas(
   uniqueTexts: string[],
   typography: LabelTypographyConfig,

--- a/web/scene/layoutClient.ts
+++ b/web/scene/layoutClient.ts
@@ -100,8 +100,12 @@ export function createLayoutClient(): LayoutClient {
       // After an uncaught exception, the worker's state is undefined
       // per spec — posting further messages to it is unreliable. Null
       // the cached ref so the next compute() reconstructs a fresh
-      // worker on demand.
+      // worker on demand, and terminate the dying instance so the
+      // browser frees its thread + memory promptly (browsers don't
+      // always auto-terminate after onerror).
+      const dying = worker;
       worker = null;
+      dying?.terminate();
     });
     return worker;
   }

--- a/web/scene/layoutClient.ts
+++ b/web/scene/layoutClient.ts
@@ -1,0 +1,116 @@
+// scene/layoutClient.ts — main-thread façade for the layout worker.
+// Owns one lazily-created module Worker; exposes a Promise-based
+// `compute(manifest)` API. Generates monotonic request ids and rejects
+// older pending requests when a newer one starts, so a rapid succession
+// of applyManifests can never produce stale layouts.
+//
+// Falls back to synchronous in-process layout when `Worker` is undefined
+// (jsdom test env). In the sync path the returned promise still
+// participates in the supersede protocol so callers see identical
+// semantics regardless of environment.
+
+import { layoutCityV4 } from './layoutV4.js';
+import {
+  STREET_LAYOUT,
+  BUILDING_DIMENSIONS,
+  GEM_SIZING,
+  STREET_TIERS,
+} from '@/config/index.js';
+import type { Manifest, CityLayout } from '@/types';
+
+interface PendingRequest {
+  resolve: (layout: CityLayout) => void;
+  reject: (err: Error) => void;
+}
+
+interface ConfigSnapshot {
+  streetLayout: ReturnType<typeof STREET_LAYOUT.get>;
+  buildingDimensions: ReturnType<typeof BUILDING_DIMENSIONS.get>;
+  gemSizing: ReturnType<typeof GEM_SIZING.get>;
+  streetTiers: ReturnType<typeof STREET_TIERS.get>;
+}
+
+export interface LayoutClient {
+  /**
+   * Compute the layout off-thread (or sync if Worker is unavailable).
+   * The returned promise resolves with the layout, or rejects with
+   * `Error('superseded')` when a newer compute() supersedes it, or
+   * `Error('disposed')` if the client is torn down before the call
+   * completes, or with the worker's own error message on failure.
+   */
+  compute(manifest: Manifest): Promise<CityLayout>;
+  /** Tear down the worker and reject every pending request. */
+  dispose(): void;
+}
+
+function _snapshot(): ConfigSnapshot {
+  return {
+    streetLayout: STREET_LAYOUT.get(),
+    buildingDimensions: BUILDING_DIMENSIONS.get(),
+    gemSizing: GEM_SIZING.get(),
+    streetTiers: STREET_TIERS.get(),
+  };
+}
+
+export function createLayoutClient(): LayoutClient {
+  const pending = new Map<number, PendingRequest>();
+  let nextId = 1;
+  let disposed = false;
+
+  function _supersedeAll(): void {
+    if (pending.size === 0) return;
+    for (const entry of pending.values()) {
+      entry.reject(new Error('superseded'));
+    }
+    pending.clear();
+  }
+
+  function compute(manifest: Manifest): Promise<CityLayout> {
+    if (disposed) {
+      return Promise.reject(new Error('layoutClient disposed'));
+    }
+    const id = nextId++;
+    // Any in-flight compute is replaced by this newer one.
+    _supersedeAll();
+
+    return new Promise<CityLayout>((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+      // Sync fallback path: jsdom + tests, plus any environment without
+      // Worker support. Run synchronously but in a microtask so the
+      // supersede behavior matches the async-worker path. Apply config
+      // snapshot? Skip — in the fallback we're sharing the same store
+      // instances as the caller, so the values are already correct.
+      const snap = _snapshot();
+      void snap; // silence unused-var lint in fallback path
+      try {
+        const layout = layoutCityV4(
+          manifest as unknown as Parameters<typeof layoutCityV4>[0],
+        );
+        // Resolve on a microtask so the supersede check in the next
+        // compute() call still has a chance to fire before this one
+        // resolves. Without queueMicrotask, two synchronous compute()
+        // calls in the same tick would both observe the same pending
+        // map and the supersede semantics would be racy.
+        queueMicrotask(() => {
+          if (!pending.has(id)) return; // already superseded
+          pending.delete(id);
+          resolve(layout);
+        });
+      } catch (err) {
+        queueMicrotask(() => {
+          if (!pending.has(id)) return;
+          pending.delete(id);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        });
+      }
+    });
+  }
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    _supersedeAll();
+  }
+
+  return { compute, dispose };
+}

--- a/web/scene/layoutClient.ts
+++ b/web/scene/layoutClient.ts
@@ -77,11 +77,10 @@ export function createLayoutClient(): LayoutClient {
       pending.set(id, { resolve, reject });
       // Sync fallback path: jsdom + tests, plus any environment without
       // Worker support. Run synchronously but in a microtask so the
-      // supersede behavior matches the async-worker path. Apply config
-      // snapshot? Skip — in the fallback we're sharing the same store
-      // instances as the caller, so the values are already correct.
-      const snap = _snapshot();
-      void snap; // silence unused-var lint in fallback path
+      // supersede behavior matches the async-worker path. We don't
+      // snapshot config here — the sync path shares the caller's
+      // process-local store instances, so the values are already
+      // correct. The Worker path in Task 2 will use _snapshot().
       try {
         const layout = layoutCityV4(
           manifest as unknown as Parameters<typeof layoutCityV4>[0],
@@ -109,7 +108,12 @@ export function createLayoutClient(): LayoutClient {
   function dispose(): void {
     if (disposed) return;
     disposed = true;
-    _supersedeAll();
+    // Distinct rejection reason from supersede so callers can
+    // distinguish "newer compute() arrived" from "client is torn down".
+    for (const entry of pending.values()) {
+      entry.reject(new Error('disposed'));
+    }
+    pending.clear();
   }
 
   return { compute, dispose };

--- a/web/scene/layoutClient.ts
+++ b/web/scene/layoutClient.ts
@@ -56,6 +56,7 @@ export function createLayoutClient(): LayoutClient {
   const pending = new Map<number, PendingRequest>();
   let nextId = 1;
   let disposed = false;
+  let worker: Worker | null = null;
 
   function _supersedeAll(): void {
     if (pending.size === 0) return;
@@ -65,55 +66,98 @@ export function createLayoutClient(): LayoutClient {
     pending.clear();
   }
 
+  function _ensureWorker(): Worker | null {
+    if (worker) return worker;
+    if (typeof Worker === 'undefined') return null;
+    try {
+      worker = new Worker(new URL('./layoutWorker.ts', import.meta.url), {
+        type: 'module',
+      });
+    } catch (_) {
+      // Older browsers without module-worker support — fall back to sync.
+      worker = null;
+      return null;
+    }
+    worker.addEventListener('message', (event: MessageEvent) => {
+      const data = event.data as
+        | { type: 'layout-result'; id: number; layout: CityLayout }
+        | { type: 'layout-error'; id: number; message: string };
+      const entry = pending.get(data.id);
+      if (!entry) return; // already superseded
+      pending.delete(data.id);
+      if (data.type === 'layout-result') {
+        entry.resolve(data.layout);
+      } else {
+        entry.reject(new Error(data.message));
+      }
+    });
+    worker.addEventListener('error', (event: ErrorEvent) => {
+      // Reject every pending request — we don't know which one died.
+      for (const entry of pending.values()) {
+        entry.reject(new Error(event.message || 'layout worker error'));
+      }
+      pending.clear();
+    });
+    return worker;
+  }
+
+  function _computeSync(
+    id: number,
+    manifest: Manifest,
+    resolve: PendingRequest['resolve'],
+    reject: PendingRequest['reject'],
+  ): void {
+    try {
+      const layout = layoutCityV4(
+        manifest as unknown as Parameters<typeof layoutCityV4>[0],
+      );
+      queueMicrotask(() => {
+        if (!pending.has(id)) return;
+        pending.delete(id);
+        resolve(layout);
+      });
+    } catch (err) {
+      queueMicrotask(() => {
+        if (!pending.has(id)) return;
+        pending.delete(id);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      });
+    }
+  }
+
   function compute(manifest: Manifest): Promise<CityLayout> {
     if (disposed) {
       return Promise.reject(new Error('layoutClient disposed'));
     }
     const id = nextId++;
-    // Any in-flight compute is replaced by this newer one.
     _supersedeAll();
-
     return new Promise<CityLayout>((resolve, reject) => {
       pending.set(id, { resolve, reject });
-      // Sync fallback path: jsdom + tests, plus any environment without
-      // Worker support. Run synchronously but in a microtask so the
-      // supersede behavior matches the async-worker path. We don't
-      // snapshot config here — the sync path shares the caller's
-      // process-local store instances, so the values are already
-      // correct. The Worker path in Task 2 will use _snapshot().
-      try {
-        const layout = layoutCityV4(
-          manifest as unknown as Parameters<typeof layoutCityV4>[0],
-        );
-        // Resolve on a microtask so the supersede check in the next
-        // compute() call still has a chance to fire before this one
-        // resolves. Without queueMicrotask, two synchronous compute()
-        // calls in the same tick would both observe the same pending
-        // map and the supersede semantics would be racy.
-        queueMicrotask(() => {
-          if (!pending.has(id)) return; // already superseded
-          pending.delete(id);
-          resolve(layout);
-        });
-      } catch (err) {
-        queueMicrotask(() => {
-          if (!pending.has(id)) return;
-          pending.delete(id);
-          reject(err instanceof Error ? err : new Error(String(err)));
-        });
+      const w = _ensureWorker();
+      if (!w) {
+        _computeSync(id, manifest, resolve, reject);
+        return;
       }
+      w.postMessage({
+        type: 'layout',
+        id,
+        manifest,
+        configSnapshot: _snapshot(),
+      });
     });
   }
 
   function dispose(): void {
     if (disposed) return;
     disposed = true;
-    // Distinct rejection reason from supersede so callers can
-    // distinguish "newer compute() arrived" from "client is torn down".
     for (const entry of pending.values()) {
       entry.reject(new Error('disposed'));
     }
     pending.clear();
+    if (worker) {
+      worker.terminate();
+      worker = null;
+    }
   }
 
   return { compute, dispose };

--- a/web/scene/layoutClient.ts
+++ b/web/scene/layoutClient.ts
@@ -97,6 +97,11 @@ export function createLayoutClient(): LayoutClient {
         entry.reject(new Error(event.message || 'layout worker error'));
       }
       pending.clear();
+      // After an uncaught exception, the worker's state is undefined
+      // per spec — posting further messages to it is unreliable. Null
+      // the cached ref so the next compute() reconstructs a fresh
+      // worker on demand.
+      worker = null;
     });
     return worker;
   }

--- a/web/scene/layoutV4.ts
+++ b/web/scene/layoutV4.ts
@@ -436,7 +436,16 @@ function _layoutDirV4(
     : Math.max(rootEndPad, openEndPad);
   const gemSizing = GEM_SIZING.get();
   const gemRadiusFrac = gemSizing.RADIUS_AS_STREET_FRAC;
-  const gemClearance = gemSizing.BUILDING_CLEARANCE;
+  // Derive the plaza clearance from the gem's own diameter so the dead
+  // space scales with the gem. Mirror the same MIN_RADIUS floor that
+  // engine.ts uses when sizing the actual gem geometry so the layout
+  // pad never under-reserves for a narrow root street.
+  const gemRadius = Math.max(
+    myStreetWidth * gemRadiusFrac,
+    gemSizing.MIN_RADIUS
+  );
+  const gemDiameter = gemRadius * 2;
+  const gemClearance = gemDiameter * gemSizing.CLEARANCE_AS_GEM_WIDTH_FRAC;
   const originPad = !parentStreetWidth
     ? Math.max(endPad, myStreetWidth * (0.5 + gemRadiusFrac) + gemClearance)
     : joinEndBaseline;

--- a/web/scene/layoutWorker.ts
+++ b/web/scene/layoutWorker.ts
@@ -1,0 +1,78 @@
+// scene/layoutWorker.ts — Web Worker entry point. Receives a manifest
+// + a snapshot of the four config stores layoutCityV4 reads, populates
+// the worker's local store instances, runs the layout, posts the
+// result back. Pure compute, no DOM or THREE.* references.
+
+import { layoutCityV4 } from './layoutV4.js';
+import {
+  STREET_LAYOUT,
+  BUILDING_DIMENSIONS,
+  GEM_SIZING,
+  STREET_TIERS,
+} from '@/config/index.js';
+import type { Manifest } from '@/types';
+import type { CityLayout } from '@/types';
+
+type StreetLayoutValue = ReturnType<typeof STREET_LAYOUT.get>;
+type BuildingDimensionsValue = ReturnType<typeof BUILDING_DIMENSIONS.get>;
+type GemSizingValue = ReturnType<typeof GEM_SIZING.get>;
+type StreetTiersValue = ReturnType<typeof STREET_TIERS.get>;
+
+interface LayoutRequest {
+  type: 'layout';
+  id: number;
+  manifest: Manifest;
+  configSnapshot: {
+    streetLayout: StreetLayoutValue;
+    buildingDimensions: BuildingDimensionsValue;
+    gemSizing: GemSizingValue;
+    streetTiers: StreetTiersValue;
+  };
+}
+
+type LayoutResponse =
+  | { type: 'layout-result'; id: number; layout: CityLayout }
+  | { type: 'layout-error'; id: number; message: string };
+
+function _applySnapshot(snap: LayoutRequest['configSnapshot']): void {
+  // map-shaped stores get setKey for each key; atom-shaped stores get
+  // a single set. STREET_TIERS is an atom (whole-array value).
+  for (const k of Object.keys(snap.streetLayout) as Array<
+    keyof StreetLayoutValue
+  >) {
+    STREET_LAYOUT.setKey(k, snap.streetLayout[k]);
+  }
+  for (const k of Object.keys(snap.buildingDimensions) as Array<
+    keyof BuildingDimensionsValue
+  >) {
+    BUILDING_DIMENSIONS.setKey(k, snap.buildingDimensions[k]);
+  }
+  for (const k of Object.keys(snap.gemSizing) as Array<keyof GemSizingValue>) {
+    GEM_SIZING.setKey(k, snap.gemSizing[k]);
+  }
+  STREET_TIERS.set(snap.streetTiers);
+}
+
+self.addEventListener('message', (event: MessageEvent<LayoutRequest>) => {
+  const data = event.data;
+  if (!data || data.type !== 'layout') return;
+  try {
+    _applySnapshot(data.configSnapshot);
+    const layout = layoutCityV4(
+      data.manifest as unknown as Parameters<typeof layoutCityV4>[0],
+    );
+    const reply: LayoutResponse = {
+      type: 'layout-result',
+      id: data.id,
+      layout,
+    };
+    (self as unknown as Worker).postMessage(reply);
+  } catch (err) {
+    const reply: LayoutResponse = {
+      type: 'layout-error',
+      id: data.id,
+      message: err instanceof Error ? err.message : String(err),
+    };
+    (self as unknown as Worker).postMessage(reply);
+  }
+});

--- a/web/scene/picker.ts
+++ b/web/scene/picker.ts
@@ -69,7 +69,9 @@ export function createPicker({
     }
     const gem = cityScene.getRootGem();
     if (gem) {
-      const gemBody = gem.children && gem.children[0];
+      // Body lives at gem.userData.body — don't index children, since
+      // the glow sprites are also children and the order shifts.
+      const gemBody = gem.userData.body as THREE.Object3D | undefined;
       if (gemBody) pickables.push(gemBody);
     }
   }

--- a/web/styles.css
+++ b/web/styles.css
@@ -853,23 +853,30 @@ canvas {
 }
 
 /* Sticky bottom action bar — sibling of .controls-body, NOT inside it,
- * so it stays visible while the form scrolls. Buttons inside stretch to
- * fill the bar's width. */
+ * so it stays visible while the form scrolls. Reset all sits on the
+ * left; Discard + Save are paired on the right. */
 .controls-actions {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
   padding: 10px 16px;
   background: #10111a;
   border-top: 1px solid #1e2030;
 }
+.controls-actions-left,
+.controls-actions-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 .controls-actions .controls-button {
-  flex: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 6px;
+  width: auto;
 }
 .controls-button-icon {
   width: 14px;

--- a/web/styles.css
+++ b/web/styles.css
@@ -356,7 +356,12 @@ canvas {
   color: #44485e;
 }
 .app-footer-status-live {
+  display: inline-flex;
+  align-items: center;
   color: #6b7090;
+  /* Bump up from the footer's 10.5px base so the play/pause glyph stays
+   * recognizable. .lucide-icon sizes at 1em of this. */
+  font-size: 13px;
 }
 .app-footer-status-live.is-paused {
   color: #5d6280;

--- a/web/styles.css
+++ b/web/styles.css
@@ -322,9 +322,12 @@ canvas {
 }
 
 /* ── Combined status indicator (left section) ─────────────────────── */
-/* Layout: [color dot] <status text> · live|paused
- * Dot color encodes rebuild state (green/yellow/red). Trailing token
- * encodes whether live polling is enabled (gray when paused). */
+/* Layout: [dot] <status text>
+ * One dot, two channels:
+ *   color     = rebuild state (green/yellow/red)
+ *   animation = live state (heartbeat when polling, static when paused)
+ * Rebuilding takes precedence: dot pulses fast regardless of live state.
+ * Error: static red (the alert effect comes from the color, not motion). */
 .app-footer-status {
   display: inline-flex;
   align-items: center;
@@ -336,32 +339,35 @@ canvas {
   border-radius: 50%;
   flex: 0 0 auto;
 }
+
+/* Color by rebuild state. */
 .app-footer-status.is-ready .app-footer-status-dot {
   background: #4ade80;
 }
 .app-footer-status.is-rebuilding .app-footer-status-dot {
   background: #fbbf24;
-  animation: app-footer-pulse 0.9s ease-in-out infinite;
 }
 .app-footer-status.is-error .app-footer-status-dot {
   background: #ef4444;
 }
+
+/* Animation by combined state. */
+.app-footer-status.is-rebuilding .app-footer-status-dot {
+  /* Fast pulse during a rebuild — wins over the heartbeat. */
+  animation: app-footer-pulse 0.9s ease-in-out infinite;
+}
+.app-footer-status.is-ready.is-live .app-footer-status-dot {
+  /* Slow gentle heartbeat when polling is on + idle. */
+  animation: app-footer-heartbeat 2.4s ease-in-out infinite;
+}
+/* is-ready.is-paused → no animation (static green dot).
+ * is-error           → no animation (static red dot). */
+
 .app-footer-status-detail {
   color: #6b7090;
 }
 .app-footer-status.is-error .app-footer-status-detail {
   color: #fca5a5;
-}
-.app-footer-status-live {
-  display: inline-flex;
-  align-items: center;
-  /* Bump up from the footer's 10.5px base so the ▶ / ⏸ glyph stays
-   * recognizable. */
-  font-size: 13px;
-  color: #60a5fa; /* blue when live polling is enabled */
-}
-.app-footer-status-live.is-paused {
-  color: #fb923c; /* orange when paused */
 }
 
 @keyframes app-footer-pulse {
@@ -371,6 +377,15 @@ canvas {
   }
   50% {
     opacity: 0.25;
+  }
+}
+@keyframes app-footer-heartbeat {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
   }
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -841,7 +841,7 @@ canvas {
 }
 
 /* Secondary variant: muted background + border, used by "Reset all" so
- * it sits beside the primary "Rebuild" button without competing visually. */
+ * it sits beside the primary "Save" button without competing visually. */
 .controls-button-secondary {
   background: rgba(255, 255, 255, 0.04);
   border-color: rgba(255, 255, 255, 0.1);

--- a/web/styles.css
+++ b/web/styles.css
@@ -352,19 +352,16 @@ canvas {
 .app-footer-status.is-error .app-footer-status-detail {
   color: #fca5a5;
 }
-.app-footer-status-sep {
-  color: #44485e;
-}
 .app-footer-status-live {
   display: inline-flex;
   align-items: center;
-  color: #6b7090;
-  /* Bump up from the footer's 10.5px base so the play/pause glyph stays
-   * recognizable. .lucide-icon sizes at 1em of this. */
+  /* Bump up from the footer's 10.5px base so the ▶ / ⏸ glyph stays
+   * recognizable. */
   font-size: 13px;
+  color: #60a5fa; /* blue when live polling is enabled */
 }
 .app-footer-status-live.is-paused {
-  color: #5d6280;
+  color: #fb923c; /* orange when paused */
 }
 
 @keyframes app-footer-pulse {

--- a/web/styles.css
+++ b/web/styles.css
@@ -321,48 +321,45 @@ canvas {
   font-size: 9.5px;
 }
 
-/* ── Live + Build status indicators (left section) ────────────────── */
-.app-footer-live,
-.app-footer-build {
+/* ── Combined status indicator (left section) ─────────────────────── */
+/* Layout: [color dot] <status text> · live|paused
+ * Dot color encodes rebuild state (green/yellow/red). Trailing token
+ * encodes whether live polling is enabled (gray when paused). */
+.app-footer-status {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
-.app-footer-live-dot,
-.app-footer-build-dot {
+.app-footer-status-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
   flex: 0 0 auto;
 }
-
-/* Live dot: green when enabled, gray when disabled. */
-.app-footer-live .app-footer-live-dot {
+.app-footer-status.is-ready .app-footer-status-dot {
   background: #4ade80;
 }
-.app-footer-live.is-disabled .app-footer-live-dot {
-  background: #44485e;
-}
-.app-footer-live.is-disabled .app-footer-live-label {
-  color: #5d6280;
-}
-
-/* Build dot: green when idle, yellow + pulse when rebuilding, red on error. */
-.app-footer-build.is-ready .app-footer-build-dot {
-  background: #4ade80;
-}
-.app-footer-build.is-rebuilding .app-footer-build-dot {
+.app-footer-status.is-rebuilding .app-footer-status-dot {
   background: #fbbf24;
   animation: app-footer-pulse 0.9s ease-in-out infinite;
 }
-.app-footer-build.is-error .app-footer-build-dot {
+.app-footer-status.is-error .app-footer-status-dot {
   background: #ef4444;
 }
-.app-footer-build.is-error .app-footer-build-detail {
+.app-footer-status-detail {
+  color: #6b7090;
+}
+.app-footer-status.is-error .app-footer-status-detail {
   color: #fca5a5;
 }
-.app-footer-build-detail {
+.app-footer-status-sep {
+  color: #44485e;
+}
+.app-footer-status-live {
   color: #6b7090;
+}
+.app-footer-status-live.is-paused {
+  color: #5d6280;
 }
 
 @keyframes app-footer-pulse {

--- a/web/styles.css
+++ b/web/styles.css
@@ -328,9 +328,6 @@ canvas {
   align-items: center;
   gap: 6px;
 }
-.app-footer-left {
-  gap: 14px;
-}
 .app-footer-live-dot,
 .app-footer-build-dot {
   width: 6px;

--- a/web/styles.css
+++ b/web/styles.css
@@ -321,36 +321,54 @@ canvas {
   font-size: 9.5px;
 }
 
-/* ── Live-reload status indicator (left section) ──────────────────── */
-.app-footer-live {
+/* ── Live + Build status indicators (left section) ────────────────── */
+.app-footer-live,
+.app-footer-build {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
-.app-footer-live-dot {
+.app-footer-left {
+  gap: 14px;
+}
+.app-footer-live-dot,
+.app-footer-build-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #4ade80;
   flex: 0 0 auto;
+}
+
+/* Live dot: green when enabled, gray when disabled. */
+.app-footer-live .app-footer-live-dot {
+  background: #4ade80;
 }
 .app-footer-live.is-disabled .app-footer-live-dot {
   background: #44485e;
 }
-.app-footer-live.is-reloading .app-footer-live-dot {
-  background: #fbbf24;
-  animation: app-footer-live-pulse 0.9s ease-in-out infinite;
-}
 .app-footer-live.is-disabled .app-footer-live-label {
   color: #5d6280;
 }
-.app-footer-live-sep {
-  color: #44485e;
+
+/* Build dot: green when idle, yellow + pulse when rebuilding, red on error. */
+.app-footer-build.is-ready .app-footer-build-dot {
+  background: #4ade80;
 }
-.app-footer-live-detail {
+.app-footer-build.is-rebuilding .app-footer-build-dot {
+  background: #fbbf24;
+  animation: app-footer-pulse 0.9s ease-in-out infinite;
+}
+.app-footer-build.is-error .app-footer-build-dot {
+  background: #ef4444;
+}
+.app-footer-build.is-error .app-footer-build-detail {
+  color: #fca5a5;
+}
+.app-footer-build-detail {
   color: #6b7090;
 }
-@keyframes app-footer-live-pulse {
+
+@keyframes app-footer-pulse {
   0%,
   100% {
     opacity: 1;

--- a/web/tests/config/drafts.test.ts
+++ b/web/tests/config/drafts.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { map, atom } from 'nanostores';
+import {
+  setDraft,
+  getEffective,
+  stageReset,
+  stageResetAll,
+  commit,
+  discard,
+  isDirty,
+  subscribe,
+  _resetForTests,
+} from '@/config/drafts.js';
+import { persistStore } from '@/config/persist.js';
+
+interface FooConfig {
+  COLOR: string;
+  COUNT: number;
+}
+
+describe('drafts', () => {
+  let FOO: ReturnType<typeof map<FooConfig>>;
+  let BAR: ReturnType<typeof atom<number>>;
+
+  beforeEach(() => {
+    // Each test gets fresh stores + fresh draft state. Re-registering
+    // the same name overwrites the prior registration (snapshot is
+    // taken at persistStore time, before any setKey).
+    localStorage.clear();
+    _resetForTests();
+    FOO = map<FooConfig>({ COLOR: '#000000', COUNT: 1 });
+    BAR = atom<number>(10);
+    persistStore('TEST_FOO', FOO);
+    persistStore('TEST_BAR', BAR);
+  });
+
+  describe('setDraft + getEffective + isDirty', () => {
+    it('returns committed value when no draft set', () => {
+      expect(getEffective(FOO, 'COLOR')).toBe('#000000');
+      expect(getEffective(BAR, null)).toBe(10);
+    });
+
+    it('returns pending value when draft set', () => {
+      setDraft(FOO, 'COLOR', '#ff0000');
+      expect(getEffective(FOO, 'COLOR')).toBe('#ff0000');
+      expect(FOO.get().COLOR).toBe('#000000'); // store untouched
+    });
+
+    it('setDraft equal to committed value removes the draft', () => {
+      setDraft(FOO, 'COLOR', '#ff0000');
+      expect(isDirty()).toBe(true);
+      setDraft(FOO, 'COLOR', '#000000');
+      expect(isDirty()).toBe(false);
+    });
+
+    it('isDirty is false initially and after discard', () => {
+      expect(isDirty()).toBe(false);
+      setDraft(FOO, 'COUNT', 5);
+      expect(isDirty()).toBe(true);
+      discard();
+      expect(isDirty()).toBe(false);
+    });
+
+    it('supports atom stores with key = null', () => {
+      setDraft(BAR, null, 42);
+      expect(getEffective(BAR, null)).toBe(42);
+      expect(BAR.get()).toBe(10);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('fires on setDraft, stageReset, stageResetAll, commit, discard', () => {
+      let count = 0;
+      const unsub = subscribe(() => { count++; });
+
+      setDraft(FOO, 'COUNT', 5);
+      expect(count).toBe(1);
+
+      stageReset(FOO, 'COUNT');
+      expect(count).toBe(2);
+
+      setDraft(FOO, 'COUNT', 7);
+      expect(count).toBe(3);
+
+      commit();
+      expect(count).toBe(4);
+
+      setDraft(FOO, 'COUNT', 9);
+      expect(count).toBe(5);
+
+      discard();
+      expect(count).toBe(6);
+
+      unsub();
+      setDraft(FOO, 'COUNT', 11);
+      expect(count).toBe(6); // unsubscribed
+    });
+  });
+
+  describe('stageReset', () => {
+    it('stages the registered default into the draft', () => {
+      FOO.setKey('COLOR', '#ff0000'); // committed override
+      stageReset(FOO, 'COLOR');
+      expect(getEffective(FOO, 'COLOR')).toBe('#000000');
+      expect(FOO.get().COLOR).toBe('#ff0000'); // store untouched
+      expect(isDirty()).toBe(true);
+    });
+
+    it('clears the draft entry when default equals committed', () => {
+      // COLOR is currently at its default. setDraft to '#ff0000', then
+      // stageReset puts the default back — and since default === committed,
+      // the draft entry is dropped (not dirty).
+      setDraft(FOO, 'COLOR', '#ff0000');
+      stageReset(FOO, 'COLOR');
+      expect(isDirty()).toBe(false);
+    });
+
+    it('works on atom stores', () => {
+      BAR.set(99);
+      stageReset(BAR, null);
+      expect(getEffective(BAR, null)).toBe(10);
+      expect(BAR.get()).toBe(99);
+    });
+  });
+
+  describe('stageResetAll', () => {
+    it('stages defaults for every registered (store, key) with non-default effective value', () => {
+      FOO.setKey('COLOR', '#ff0000');
+      FOO.setKey('COUNT', 99);
+      BAR.set(42);
+      stageResetAll();
+      expect(getEffective(FOO, 'COLOR')).toBe('#000000');
+      expect(getEffective(FOO, 'COUNT')).toBe(1);
+      expect(getEffective(BAR, null)).toBe(10);
+    });
+
+    it('is a no-op on the second call (idempotent)', () => {
+      FOO.setKey('COLOR', '#ff0000');
+      stageResetAll();
+      let count = 0;
+      const unsub = subscribe(() => { count++; });
+      stageResetAll();
+      // No new draft entries to stage → no subscribers fired beyond
+      // the always-fire end-of-call notification (allow ≤ 1).
+      expect(count).toBeLessThanOrEqual(1);
+      unsub();
+    });
+
+    it('skips entries where effective value already equals default', () => {
+      // FOO is all default; only BAR is overridden.
+      BAR.set(42);
+      stageResetAll();
+      // Only BAR should have been staged.
+      // We can't directly read the draft map, but we know isDirty must
+      // be true and getEffective(BAR) returns default.
+      expect(isDirty()).toBe(true);
+      expect(getEffective(BAR, null)).toBe(10);
+      // Discard everything; nothing changes in committed stores.
+      discard();
+      expect(BAR.get()).toBe(42);
+    });
+  });
+
+  describe('commit', () => {
+    it('applies map-store drafts via setKey', () => {
+      setDraft(FOO, 'COLOR', '#ff0000');
+      setDraft(FOO, 'COUNT', 7);
+      commit();
+      expect(FOO.get()).toEqual({ COLOR: '#ff0000', COUNT: 7 });
+      expect(isDirty()).toBe(false);
+    });
+
+    it('applies atom-store drafts via set', () => {
+      setDraft(BAR, null, 42);
+      commit();
+      expect(BAR.get()).toBe(42);
+      expect(isDirty()).toBe(false);
+    });
+
+    it('clears drafts after commit', () => {
+      setDraft(FOO, 'COUNT', 5);
+      commit();
+      expect(getEffective(FOO, 'COUNT')).toBe(5); // now committed
+      expect(isDirty()).toBe(false);
+    });
+  });
+
+  describe('discard', () => {
+    it('drops all pending drafts without touching stores', () => {
+      setDraft(FOO, 'COLOR', '#ff0000');
+      setDraft(BAR, null, 99);
+      discard();
+      expect(getEffective(FOO, 'COLOR')).toBe('#000000');
+      expect(getEffective(BAR, null)).toBe(10);
+      expect(FOO.get().COLOR).toBe('#000000');
+      expect(BAR.get()).toBe(10);
+      expect(isDirty()).toBe(false);
+    });
+  });
+});

--- a/web/tests/config/drafts.test.ts
+++ b/web/tests/config/drafts.test.ts
@@ -66,6 +66,13 @@ describe('drafts', () => {
       expect(getEffective(BAR, null)).toBe(42);
       expect(BAR.get()).toBe(10);
     });
+
+    it('treats falsy draft values as real drafts (uses Map.has, not falsy check)', () => {
+      // Default COUNT is 1; drafting 0 must not be mistaken for "no draft".
+      setDraft(FOO, 'COUNT', 0);
+      expect(getEffective(FOO, 'COUNT')).toBe(0);
+      expect(isDirty()).toBe(true);
+    });
   });
 
   describe('subscribe', () => {
@@ -182,6 +189,24 @@ describe('drafts', () => {
       commit();
       expect(getEffective(FOO, 'COUNT')).toBe(5); // now committed
       expect(isDirty()).toBe(false);
+    });
+
+    it('clears drafts before firing store subscribers (synchronous subscribers see committed value, not lingering draft)', () => {
+      let observedInsideSubscribe: unknown = null;
+      setDraft(FOO, 'COLOR', '#ff0000');
+      // Install subscriber AFTER setting the draft but BEFORE commit, so it
+      // only fires on the commit-driven setKey call. nanostores fires .subscribe
+      // synchronously with the current value at subscribe time too — so capture
+      // only the LAST value observed.
+      FOO.subscribe(() => {
+        observedInsideSubscribe = getEffective(FOO, 'COLOR');
+      });
+      commit();
+      // Inside the subscriber, getEffective must reflect the committed value
+      // — the draft must already be cleared at that point.
+      expect(observedInsideSubscribe).toBe('#ff0000');
+      // And of course committed reads return it too.
+      expect(FOO.get().COLOR).toBe('#ff0000');
     });
   });
 

--- a/web/tests/scene/cityScene.test.ts
+++ b/web/tests/scene/cityScene.test.ts
@@ -165,13 +165,13 @@ describe('createCityScene', () => {
     cs.dispose();
   });
 
-  it('applyManifest builds meshes and exposes them through accessors', () => {
+  it('applyManifest builds meshes and exposes them through accessors', async () => {
     const cs = createCityScene(canvas);
     const m = makeManifest('one', [
       { path: 'a.js', size: 100, lines: 5 },
       { path: 'b.js', size: 200, lines: 10 },
     ]);
-    cs.applyManifest(m);
+    await cs.applyManifest(m);
 
     expect(cs.getManifest()).toBe(m);
     expect(cs.getRoot().name).toBe('one');
@@ -190,13 +190,13 @@ describe('createCityScene', () => {
     cs.dispose();
   });
 
-  it('a second applyManifest fires onChange with entering/exiting/staying (InstancedMesh diff)', () => {
+  it('a second applyManifest fires onChange with entering/exiting/staying (InstancedMesh diff)', async () => {
     const cs = createCityScene(canvas);
     const m1 = makeManifest('two', [
       { path: 'a.js', size: 100, lines: 5 },
       { path: 'b.js', size: 200, lines: 10 },
     ]);
-    cs.applyManifest(m1);
+    await cs.applyManifest(m1);
 
     let capturedDiff: Parameters<Parameters<typeof cs.onChange>[0]>[0] | null = null;
     cs.onChange((diff) => {
@@ -207,7 +207,7 @@ describe('createCityScene', () => {
       { path: 'a.js', size: 100, lines: 5 }, // staying (same path)
       { path: 'c.js', size: 300, lines: 15 }, // entering (new path)
     ]);
-    cs.applyManifest(m2);
+    await cs.applyManifest(m2);
 
     expect(capturedDiff).not.toBeNull();
     const diff = capturedDiff!;
@@ -268,9 +268,9 @@ describe('createCityScene', () => {
   //   cs.dispose();
   // });
 
-  it('onBeforeChange fires before the new build', () => {
+  it('onBeforeChange fires before the new build', async () => {
     const cs = createCityScene(canvas);
-    cs.applyManifest(makeManifest('a', [{ path: 'x.js', size: 50, lines: 3 }]));
+    await cs.applyManifest(makeManifest('a', [{ path: 'x.js', size: 50, lines: 3 }]));
 
     let beforeRootName = null;
     cs.onBeforeChange((prev) => {
@@ -278,7 +278,7 @@ describe('createCityScene', () => {
       beforeRootName = prev.manifest && prev.manifest.tree.name;
     });
 
-    cs.applyManifest(makeManifest('b', [{ path: 'y.js', size: 50, lines: 3 }]));
+    await cs.applyManifest(makeManifest('b', [{ path: 'y.js', size: 50, lines: 3 }]));
     expect(beforeRootName).toBe('a');
     cs.dispose();
   });

--- a/web/tests/scene/layoutClient.test.ts
+++ b/web/tests/scene/layoutClient.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createLayoutClient } from '@/scene/layoutClient.js';
+import { NodeKind } from '@/types';
+import type { Manifest } from '@/types';
+
+function makeMinimalManifest(): Manifest {
+  return {
+    root: '/tmp/x',
+    scanned_at: '2026-05-13T00:00:00Z',
+    signature: 'sig',
+    repo: null,
+    tree: {
+      name: 'x',
+      type: NodeKind.Directory,
+      path: '.',
+      fullPath: '/tmp/x',
+      children: [
+        {
+          name: 'a.js',
+          type: NodeKind.File,
+          path: 'a.js',
+          fullPath: '/tmp/x/a.js',
+          extension: '.js',
+          size: 10,
+          lines: 1,
+          binary: false,
+          created: '2024-01-01T00:00:00Z',
+          modified: '2024-01-01T00:00:00Z',
+          git: null,
+        },
+      ],
+      children_count: 1,
+      children_file_count: 1,
+      children_dir_count: 0,
+      descendants_count: 1,
+      descendants_file_count: 1,
+      descendants_dir_count: 0,
+      descendants_size: 10,
+    },
+  };
+}
+
+describe('layoutClient', () => {
+  let client: ReturnType<typeof createLayoutClient>;
+
+  beforeEach(() => {
+    client = createLayoutClient();
+  });
+
+  it('compute() returns a Promise that resolves with a CityLayout', async () => {
+    const m = makeMinimalManifest();
+    const layout = await client.compute(m);
+    expect(Array.isArray(layout.buildings)).toBe(true);
+    expect(Array.isArray(layout.streets)).toBe(true);
+    expect(layout.buildings.length).toBeGreaterThan(0);
+    expect(layout.streets.length).toBeGreaterThan(0);
+  });
+
+  it('supersede: when a second compute() starts, the first promise rejects', async () => {
+    const m = makeMinimalManifest();
+    const first = client.compute(m);
+    const second = client.compute(m);
+    await expect(first).rejects.toThrow(/superseded/i);
+    await expect(second).resolves.toBeDefined();
+  });
+
+  it('dispose() makes subsequent compute() calls reject', async () => {
+    client.dispose();
+    await expect(client.compute(makeMinimalManifest())).rejects.toThrow();
+  });
+});

--- a/web/tests/scene/layoutClient.test.ts
+++ b/web/tests/scene/layoutClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createLayoutClient } from '@/scene/layoutClient.js';
 import { NodeKind } from '@/types';
 import type { Manifest } from '@/types';
@@ -45,6 +45,10 @@ describe('layoutClient', () => {
 
   beforeEach(() => {
     client = createLayoutClient();
+  });
+
+  afterEach(() => {
+    client.dispose();
   });
 
   it('compute() returns a Promise that resolves with a CityLayout', async () => {

--- a/web/tests/views/panes/controlsPane.test.ts
+++ b/web/tests/views/panes/controlsPane.test.ts
@@ -18,13 +18,27 @@ describe('buildControlsPane', () => {
     expect(pane.querySelector('.shortcuts-list .shortcuts-mouse')).not.toBeNull();
   });
 
-  it('renders a Reset-all button in the sticky action bar (no Rebuild)', () => {
+  it('renders three buttons in the sticky action bar: Reset all, Discard, Save', () => {
     const pane = buildControlsPane({});
     const buttons = pane.querySelectorAll<HTMLButtonElement>('.controls-actions .controls-button');
-    expect(buttons.length).toBe(1);
-    expect(buttons[0].textContent).toBe('Reset all');
-    // No "Rebuild" surface anywhere — every config hot-reloads.
+    expect(buttons.length).toBe(3);
+    const labels = Array.from(buttons).map((b) => b.textContent?.trim());
+    expect(labels).toContain('Reset all');
+    expect(labels).toContain('Discard');
+    expect(labels).toContain('Save');
+    // No "Rebuild" surface anywhere — every config hot-reloads (after Save).
     expect(pane.textContent).not.toContain('Rebuild');
+  });
+
+  it('Save and Discard buttons are disabled when no drafts are pending', () => {
+    const pane = buildControlsPane({});
+    const buttons = Array.from(
+      pane.querySelectorAll<HTMLButtonElement>('.controls-actions .controls-button')
+    );
+    const save = buttons.find((b) => b.textContent?.trim() === 'Save')!;
+    const discard = buttons.find((b) => b.textContent?.trim() === 'Discard')!;
+    expect(save.disabled).toBe(true);
+    expect(discard.disabled).toBe(true);
   });
 
   it('does not render any rebuild badges on rows', () => {

--- a/web/views/panes/controlsPane.ts
+++ b/web/views/panes/controlsPane.ts
@@ -171,7 +171,7 @@ function _buildUpdatesSection(): HTMLElement {
   section.appendChild(
     _subgroup('Filters', [
       _toggle('Show all files', SCAN_FILTERS, 'SHOW_ALL_FILES', {
-        tip: 'When on, untracked and gitignored files (node_modules/, build artifacts, drafts) are included. No effect outside a git repo. Toggling re-fetches the manifest.',
+        tip: 'When on, untracked and gitignored files (node_modules/, build artifacts, drafts) are included. No effect outside a git repo. Saving re-fetches the manifest.',
       }),
     ])
   );

--- a/web/views/panes/controlsPane.ts
+++ b/web/views/panes/controlsPane.ts
@@ -544,8 +544,8 @@ function _buildGemSection(): HTMLElement {
       _slider('Hover lift × street width', GEM_SIZING, 'HOVER_LIFT_FRAC', 0, 2, 0.05, {
         tip: 'Extra vertical lift above the road, on top of the gem radius.',
       }),
-      _number('Plaza clearance', GEM_SIZING, 'BUILDING_CLEARANCE', 0, 100, 1, {
-        tip: "Dead-space pad past the gem at the root street's origin end.",
+      _slider('Plaza × gem width', GEM_SIZING, 'CLEARANCE_AS_GEM_WIDTH_FRAC', 0, 5, 0.1, {
+        tip: "Dead-space pad past the gem at the root street's origin end, expressed as a multiple of the gem's diameter. 2 = plaza is two gem-widths long.",
       }),
     ])
   );

--- a/web/views/panes/controlsPane.ts
+++ b/web/views/panes/controlsPane.ts
@@ -34,6 +34,7 @@ import {
   // Gem
   GEM_SIZING,
   GEM_APPEARANCE,
+  GEM_GLOW,
   GEM_ANIMATION,
   // Effects
   RAINBOW,
@@ -557,6 +558,32 @@ function _buildGemSection(): HTMLElement {
       }),
       _slider('Body opacity', GEM_APPEARANCE, 'BODY_OPACITY', 0.0, 1.0, 0.05, {
         tip: 'Gem transparency. Low = jewel-like; high = plastic.',
+      }),
+    ])
+  );
+
+  section.appendChild(
+    _subgroup('Glow halo', [
+      _toggle('Enabled', GEM_GLOW, 'ENABLED', {
+        tip: 'Two billboarded sprites behind the gem painted with a soft radial-gradient — creates a fuzzy neon halo.',
+      }),
+      _slider('Inner scale × radius', GEM_GLOW, 'INNER_SCALE', 1, 12, 0.1, {
+        tip: 'Size of the inner "hot core" halo, as a multiple of the gem radius. Larger = bigger soft disk.',
+      }),
+      _slider('Inner opacity', GEM_GLOW, 'INNER_OPACITY', 0, 1, 0.05, {
+        tip: 'Brightness of the hot core. Lower for a subtler halo.',
+      }),
+      _slider('Outer scale × radius', GEM_GLOW, 'OUTER_SCALE', 1, 30, 0.5, {
+        tip: 'Size of the outer atmospheric halo. Much larger than the inner one so the falloff reaches far past the gem.',
+      }),
+      _slider('Outer opacity', GEM_GLOW, 'OUTER_OPACITY', 0, 1, 0.05, {
+        tip: 'Brightness of the atmospheric halo.',
+      }),
+      _toggle('Animate colors', GEM_GLOW, 'ANIMATE_COLORS', {
+        tip: 'Cycle the halo color through the gem face palette. Off = halo uses the edge color from Appearance above.',
+      }),
+      _slider('Cycle period (s)', GEM_GLOW, 'CYCLE_PERIOD_SECONDS', 1, 30, 0.5, {
+        tip: 'Seconds for one full pass through every palette color.',
       }),
     ])
   );

--- a/web/views/panes/controlsPane.ts
+++ b/web/views/panes/controlsPane.ts
@@ -40,12 +40,20 @@ import {
   SCAN_FILTERS,
 } from '@/config/index.js';
 import {
-  clearPersistence,
   getDefault,
-  resetKey,
-  hasAnyOverrides,
+  forEachRegisteredStore,
   onAnyChange,
 } from '@/config/persist.js';
+import {
+  setDraft,
+  getEffective,
+  stageReset,
+  stageResetAll,
+  commit as commitDrafts,
+  discard as discardDrafts,
+  isDirty as draftsAreDirty,
+  subscribe as subscribeDrafts,
+} from '@/config/drafts.js';
 import { KEY_BINDINGS } from '@/constants';
 import { FadeDetail } from '@/types';
 import { makeLucideIcon } from '@/views/shell/icon.js';
@@ -63,7 +71,6 @@ interface MapLikeStore {
 
 interface ControlOpts {
   tip?: string;
-  onChange?: () => void;
   previewHue?: boolean;
 }
 
@@ -91,14 +98,12 @@ interface SelectOption {
 // table including R, which the existing keydown handler in main.js wires
 // to resetView. The "Reset camera" button is gone.)
 interface BuildControlsPaneOpts {
-  applyTheme?: () => void;
   onClose?: () => void;
   onRunCollisionCheck?: () => void;
   onRunStemDiagnostic?: () => void;
 }
 
 export function buildControlsPane(opts: BuildControlsPaneOpts = {}): HTMLElement {
-  const applyTheme = opts.applyTheme ?? (() => {});
 
   const pane = document.createElement('div');
   pane.className = 'left-pane controls-pane';
@@ -134,11 +139,11 @@ export function buildControlsPane(opts: BuildControlsPaneOpts = {}): HTMLElement
   // (mouse to orbit, kbd to reset). See View > shortcuts list.
   body.appendChild(_buildViewSection());
   body.appendChild(_buildUpdatesSection());
-  body.appendChild(_buildBackgroundSection(applyTheme));
-  body.appendChild(_buildStreetsSection(applyTheme));
-  body.appendChild(_buildBuildingsSection(applyTheme));
-  body.appendChild(_buildGemSection(applyTheme));
-  body.appendChild(_buildEffectsSection(applyTheme));
+  body.appendChild(_buildBackgroundSection());
+  body.appendChild(_buildStreetsSection());
+  body.appendChild(_buildBuildingsSection());
+  body.appendChild(_buildGemSection());
+  body.appendChild(_buildEffectsSection());
   if (
     typeof opts.onRunCollisionCheck === 'function' ||
     typeof opts.onRunStemDiagnostic === 'function'
@@ -251,19 +256,18 @@ function _buildShortcutsList(items: Array<ShortcutItem | null>): HTMLDListElemen
 }
 
 // ─── Background ────────────────────────────────────────────────────────────
-function _buildBackgroundSection(applyTheme: () => void): HTMLElement {
+function _buildBackgroundSection(): HTMLElement {
   const section = _section('Background', 'The void behind everything.');
   section.appendChild(
     _color('Sky / ground', SCENE_COLORS, 'GROUND', {
       tip: 'Color shown behind buildings + streets. Live.',
-      onChange: applyTheme,
     })
   );
   return section;
 }
 
 // ─── Streets ───────────────────────────────────────────────────────────────
-function _buildStreetsSection(applyTheme: () => void): HTMLElement {
+function _buildStreetsSection(): HTMLElement {
   const section = _section(
     'Streets',
     'Asphalt, sidewalks, street labels, and the neon path that highlights the route from the root gem to the selected file.'
@@ -275,7 +279,6 @@ function _buildStreetsSection(applyTheme: () => void): HTMLElement {
     _subgroup('Asphalt', [
       _color('Color', ASPHALT, 'COLOR', {
         tip: 'Color of the inner road stripe. Live.',
-        onChange: applyTheme,
       }),
     ])
   );
@@ -286,15 +289,12 @@ function _buildStreetsSection(applyTheme: () => void): HTMLElement {
     _subgroup('Sidewalk colors', [
       _color('Default', SIDEWALK_COLORS, 'DEFAULT', {
         tip: 'Resting tint on every sidewalk.',
-        onChange: applyTheme,
       }),
       _color('Hover', SIDEWALK_COLORS, 'HOVER', {
         tip: 'When the cursor is over a street.',
-        onChange: applyTheme,
       }),
       _color('Selected', SIDEWALK_COLORS, 'SELECTED', {
         tip: 'When a street (directory) is selected.',
-        onChange: applyTheme,
       }),
     ])
   );
@@ -304,11 +304,9 @@ function _buildStreetsSection(applyTheme: () => void): HTMLElement {
     _subgroup('Street labels', [
       _color('Fill', LABEL_TYPOGRAPHY, 'FILL', {
         tip: 'Text color of the names painted on each road. Live (label textures regenerate on the fly when this changes).',
-        onChange: applyTheme,
       }),
       _slider('Camera-flip dead zone', LABEL_TYPOGRAPHY, 'FLIP_HYSTERESIS', 0, 0.5, 0.01, {
         tip: 'How far the camera must rotate before labels flip 180° to stay readable. Higher = less flicker, more time spent reading upside-down.',
-        onChange: applyTheme,
       }),
       _number('Font size (px)', LABEL_TYPOGRAPHY, 'FONT_SIZE_PX', 32, 512, 8, {
         tip: 'Source canvas font size. Higher = sharper close-zoom, larger texture memory.',
@@ -321,7 +319,6 @@ function _buildStreetsSection(applyTheme: () => void): HTMLElement {
       }),
       _slider('Height × street width', LABEL_TYPOGRAPHY, 'HEIGHT_FRAC', 0, 2, 0.05, {
         tip: 'Label plane height in world units, as a fraction of the street width. Wider streets get bigger labels.',
-        onChange: applyTheme,
       }),
       _slider('Repeat × label width', LABEL_TYPOGRAPHY, 'SPACING_MULT', 0.5, 10, 0.1, {
         tip: 'Distance between label repeats along a long street, expressed as a multiple of the label width.',
@@ -339,11 +336,9 @@ function _buildStreetsSection(applyTheme: () => void): HTMLElement {
     _subgroup('Selection path line', [
       _number('Linewidth', PATH_LINE, 'LINEWIDTH', 1, 20, 1, {
         tip: 'Pixel thickness of the rainbow line.',
-        onChange: applyTheme,
       }),
       _slider('Opacity', PATH_LINE, 'OPACITY', 0.0, 1.0, 0.05, {
         tip: 'Path-line transparency. 0 = invisible; 1 = solid.',
-        onChange: applyTheme,
       }),
     ])
   );
@@ -356,19 +351,15 @@ function _buildStreetsSection(applyTheme: () => void): HTMLElement {
     _subgroup('Hover preview path line', [
       _toggle('Enabled', HOVER_PATH_LINE, 'ENABLED', {
         tip: 'Show a draft preview line from the gem to whatever the cursor is currently over.',
-        onChange: applyTheme,
       }),
       _color('Color', HOVER_PATH_LINE, 'COLOR', {
         tip: 'Solid color of the preview line. Faded white by default so it reads as a draft, not the committed rainbow line.',
-        onChange: applyTheme,
       }),
       _number('Linewidth', HOVER_PATH_LINE, 'LINEWIDTH', 1, 20, 1, {
         tip: 'Pixel thickness of the preview line.',
-        onChange: applyTheme,
       }),
       _slider('Opacity', HOVER_PATH_LINE, 'OPACITY', 0.0, 1.0, 0.05, {
         tip: 'Preview-line transparency. 0 = invisible; 1 = solid.',
-        onChange: applyTheme,
       }),
     ])
   );
@@ -401,7 +392,7 @@ function _buildStreetsSection(applyTheme: () => void): HTMLElement {
 }
 
 // ─── Buildings ─────────────────────────────────────────────────────────────
-function _buildBuildingsSection(applyTheme: () => void): HTMLElement {
+function _buildBuildingsSection(): HTMLElement {
   const section = _section(
     'Buildings',
     'Per-file boxes — height from line count, width from byte size, color from extension + age.'
@@ -460,7 +451,6 @@ function _buildBuildingsSection(applyTheme: () => void): HTMLElement {
     huePaletteRows.push(
       _nestedSlider(ext, BUILDING_PALETTE, 'HUE_EXT_MAP', ext, 0, 359, 1, {
         tip: 'Hue (0–359°) for files with this extension.',
-
         previewHue: true,
       })
     );
@@ -471,18 +461,13 @@ function _buildBuildingsSection(applyTheme: () => void): HTMLElement {
     _subgroup('Outlines', [
       _number('Linewidth', BUILDING_OUTLINE, 'WIDTH', 1, 10, 1, {
         tip: 'Pixel thickness shared by per-building, hover, and selected outlines.',
-        onChange: applyTheme,
       }),
       _color('Hover color', BUILDING_OUTLINE, 'HOVER_COLOR', {
         tip: 'Outline color when the cursor is over a building.',
-        onChange: applyTheme,
       }),
-      _slider('Hover opacity', BUILDING_OUTLINE, 'HOVER_OPACITY', 0, 1, 0.05, {
-        onChange: applyTheme,
-      }),
+      _slider('Hover opacity', BUILDING_OUTLINE, 'HOVER_OPACITY', 0, 1, 0.05, {}),
       _slider('Selected opacity', BUILDING_OUTLINE, 'SELECTED_OPACITY', 0, 1, 0.05, {
         tip: 'Selected outline uses an animated rainbow color — see Effects > Rainbow.',
-        onChange: applyTheme,
       }),
     ])
   );
@@ -496,7 +481,6 @@ function _buildBuildingsSection(applyTheme: () => void): HTMLElement {
     _subgroup('Selection fade — animation', [
       _slider('Fade speed', BUILDING_FADE, 'LERP_SPEED', 0.01, 1.0, 0.01, {
         tip: 'Per-frame easing toward the target opacity. Higher = snappier transitions.',
-        onChange: applyTheme,
       }),
     ])
   );
@@ -511,46 +495,34 @@ function _buildBuildingsSection(applyTheme: () => void): HTMLElement {
     _subgroup('Default — siblings of selection', [
       _select('Detail', BUILDING_FADE, 'DEFAULT_DETAIL', DETAIL_OPTIONS, {
         tip: 'Full = textured walls + windows + doors. Silhouette = solid-color box. Hidden = body invisible (only outline can show).',
-        onChange: applyTheme,
       }),
       _toggle('Outline', BUILDING_FADE, 'DEFAULT_OUTLINE', {
         tip: 'Show the wireframe edge overlay.',
-        onChange: applyTheme,
       }),
       _slider('Body opacity', BUILDING_FADE, 'DEFAULT_BODY_OPACITY', 0.0, 1.0, 0.05, {
         tip: 'Opacity for the body / silhouette layer.',
-        onChange: applyTheme,
       }),
       _slider('Outline opacity', BUILDING_FADE, 'DEFAULT_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {
         tip: 'Opacity for the wireframe outline layer (only visible if Outline is on).',
-        onChange: applyTheme,
       }),
     ])
   );
 
   section.appendChild(
     _subgroup('Level 1 — one hop from selection', [
-      _select('Detail', BUILDING_FADE, 'NEAR_DETAIL', DETAIL_OPTIONS, { onChange: applyTheme }),
-      _toggle('Outline', BUILDING_FADE, 'NEAR_OUTLINE', { onChange: applyTheme }),
-      _slider('Body opacity', BUILDING_FADE, 'NEAR_BODY_OPACITY', 0.0, 1.0, 0.05, {
-        onChange: applyTheme,
-      }),
-      _slider('Outline opacity', BUILDING_FADE, 'NEAR_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {
-        onChange: applyTheme,
-      }),
+      _select('Detail', BUILDING_FADE, 'NEAR_DETAIL', DETAIL_OPTIONS, {}),
+      _toggle('Outline', BUILDING_FADE, 'NEAR_OUTLINE', {}),
+      _slider('Body opacity', BUILDING_FADE, 'NEAR_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
+      _slider('Outline opacity', BUILDING_FADE, 'NEAR_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
     ])
   );
 
   section.appendChild(
     _subgroup('Level 2+ — cousins, deeper subtrees', [
-      _select('Detail', BUILDING_FADE, 'FAR_DETAIL', DETAIL_OPTIONS, { onChange: applyTheme }),
-      _toggle('Outline', BUILDING_FADE, 'FAR_OUTLINE', { onChange: applyTheme }),
-      _slider('Body opacity', BUILDING_FADE, 'FAR_BODY_OPACITY', 0.0, 1.0, 0.05, {
-        onChange: applyTheme,
-      }),
-      _slider('Outline opacity', BUILDING_FADE, 'FAR_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {
-        onChange: applyTheme,
-      }),
+      _select('Detail', BUILDING_FADE, 'FAR_DETAIL', DETAIL_OPTIONS, {}),
+      _toggle('Outline', BUILDING_FADE, 'FAR_OUTLINE', {}),
+      _slider('Body opacity', BUILDING_FADE, 'FAR_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
+      _slider('Outline opacity', BUILDING_FADE, 'FAR_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
     ])
   );
 
@@ -558,7 +530,7 @@ function _buildBuildingsSection(applyTheme: () => void): HTMLElement {
 }
 
 // ─── Gem ───────────────────────────────────────────────────────────────────
-function _buildGemSection(applyTheme: () => void): HTMLElement {
+function _buildGemSection(): HTMLElement {
   const section = _section('Root gem', 'The floating spinning octahedron above the root street.');
 
   section.appendChild(
@@ -571,7 +543,6 @@ function _buildGemSection(applyTheme: () => void): HTMLElement {
       }),
       _slider('Hover lift × street width', GEM_SIZING, 'HOVER_LIFT_FRAC', 0, 2, 0.05, {
         tip: 'Extra vertical lift above the road, on top of the gem radius.',
-        onChange: applyTheme,
       }),
       _number('Plaza clearance', GEM_SIZING, 'BUILDING_CLEARANCE', 0, 100, 1, {
         tip: "Dead-space pad past the gem at the root street's origin end.",
@@ -583,35 +554,27 @@ function _buildGemSection(applyTheme: () => void): HTMLElement {
     _subgroup('Appearance', [
       _color('Edge color', GEM_APPEARANCE, 'EDGE_COLOR', {
         tip: 'Neutral separator line drawn around each gem face.',
-        onChange: applyTheme,
       }),
       _slider('Body opacity', GEM_APPEARANCE, 'BODY_OPACITY', 0.0, 1.0, 0.05, {
         tip: 'Gem transparency. Low = jewel-like; high = plastic.',
-        onChange: applyTheme,
       }),
     ])
   );
 
   section.appendChild(
     _subgroup('Animation', [
-      _slider('Rotation speed', GEM_ANIMATION, 'ROTATION_SPEED', 0, 3, 0.05, {
-        onChange: applyTheme,
-      }),
+      _slider('Rotation speed', GEM_ANIMATION, 'ROTATION_SPEED', 0, 3, 0.05, {}),
       _slider('Bob frequency', GEM_ANIMATION, 'BOB_FREQUENCY', 0, 5, 0.1, {
         tip: 'How fast the gem oscillates vertically.',
-        onChange: applyTheme,
       }),
       _slider('Bob amplitude', GEM_ANIMATION, 'BOB_AMPLITUDE_FRAC', 0, 2, 0.05, {
         tip: 'Vertical bob distance, as a fraction of the gem radius.',
-        onChange: applyTheme,
       }),
       _slider('Hover scale', GEM_ANIMATION, 'HOVER_SCALE', 1, 3, 0.05, {
         tip: 'Multiplier applied to the gem when the cursor is over it.',
-        onChange: applyTheme,
       }),
       _slider('Hover lerp', GEM_ANIMATION, 'SCALE_LERP_SPEED', 0.01, 1, 0.01, {
         tip: 'Per-frame ease toward the hover scale.',
-        onChange: applyTheme,
       }),
     ])
   );
@@ -620,17 +583,16 @@ function _buildGemSection(applyTheme: () => void): HTMLElement {
 }
 
 // ─── Effects ───────────────────────────────────────────────────────────────
-function _buildEffectsSection(applyTheme: () => void): HTMLElement {
+function _buildEffectsSection(): HTMLElement {
   const section = _section('Effects', 'Shared visual effects.');
 
   section.appendChild(
     _subgroup('Rainbow (selected outline + path line)', [
       _slider('Speed', RAINBOW, 'SPEED', 0, 0.005, 0.0001, {
         tip: 'Hue cycles per millisecond. The shared rainbow chases around the selected building outline AND the gem→selection path line.',
-        onChange: applyTheme,
       }),
-      _slider('Saturation', RAINBOW, 'SATURATION', 0, 1, 0.05, { onChange: applyTheme }),
-      _slider('Lightness', RAINBOW, 'LIGHTNESS', 0, 1, 0.05, { onChange: applyTheme }),
+      _slider('Saturation', RAINBOW, 'SATURATION', 0, 1, 0.05, {}),
+      _slider('Lightness', RAINBOW, 'LIGHTNESS', 0, 1, 0.05, {}),
     ])
   );
 
@@ -694,33 +656,91 @@ function _buildDebugSection(
 }
 
 // ─── Sticky bottom action bar ──────────────────────────────────────────────
-// "Reset all" — the global panic button. Per-row reset icons cover the
-// common case. Wiping the persisted overrides triggers each store's
-// hot-reload subscription, so the city snaps back to defaults without
-// a page reload.
+// Three-button bar: Reset all (left) | Discard · Save (right).
+// Widgets write to the draft layer; Save commits to stores (triggering
+// the existing persist + hot-reload subscriptions). Discard drops pending
+// drafts without touching stores. Reset all stages every overridden value
+// back to its default — user still must Save to apply.
 function _buildActionsSection(): HTMLElement {
   const actions = document.createElement('div');
   actions.className = 'controls-actions';
+
+  const left = document.createElement('div');
+  left.className = 'controls-actions-left';
+
+  const right = document.createElement('div');
+  right.className = 'controls-actions-right';
 
   const resetAll = document.createElement('button');
   resetAll.type = 'button';
   resetAll.className = 'controls-button controls-button-secondary';
   resetAll.appendChild(makeLucideIcon('rotate-ccw', { class: 'controls-button-icon' }));
   resetAll.appendChild(document.createTextNode('Reset all'));
-  resetAll.title = 'Wipe every override. (Per-row reset icons restore single values.)';
+  resetAll.title = 'Stage every overridden value back to its default. Click Save to apply.';
   resetAll.addEventListener('click', () => {
     if (resetAll.disabled) return;
-    if (!confirm('Reset every override?')) return;
-    clearPersistence();
+    stageResetAll();
   });
-  actions.appendChild(resetAll);
+  left.appendChild(resetAll);
 
-  // Live enable/disable as values are tweaked or reset.
-  function refreshResetAll() {
-    resetAll.disabled = !hasAnyOverrides();
+  const discard = document.createElement('button');
+  discard.type = 'button';
+  discard.className = 'controls-button controls-button-secondary';
+  discard.textContent = 'Discard';
+  discard.title = 'Drop all unsaved changes.';
+  discard.addEventListener('click', () => {
+    if (discard.disabled) return;
+    discardDrafts();
+  });
+  right.appendChild(discard);
+
+  const save = document.createElement('button');
+  save.type = 'button';
+  save.className = 'controls-button';
+  save.textContent = 'Save';
+  save.title = 'Apply unsaved changes to the scene.';
+  save.addEventListener('click', () => {
+    if (save.disabled) return;
+    commitDrafts();
+  });
+  right.appendChild(save);
+
+  actions.appendChild(left);
+  actions.appendChild(right);
+
+  function refresh() {
+    const dirty = draftsAreDirty();
+    save.disabled = !dirty;
+    discard.disabled = !dirty;
+
+    // Reset all enabled iff at least one (store, key) has an effective
+    // value that differs from its default — i.e., the click would stage
+    // at least one new draft entry. (Same loop shape as stageResetAll.)
+    let canReset = false;
+    forEachRegisteredStore((_name, store, defaults) => {
+      if (canReset) return;
+      if (
+        defaults &&
+        typeof defaults === 'object' &&
+        !Array.isArray(defaults) &&
+        typeof (store as MapLikeStore).setKey === 'function'
+      ) {
+        for (const k in defaults) {
+          if (!Object.hasOwn(defaults, k)) continue;
+          if (!_isEqual(getEffective(store as MapLikeStore, k), (defaults as Record<string, unknown>)[k])) {
+            canReset = true;
+            return;
+          }
+        }
+      } else {
+        if (!_isEqual(getEffective(store as MapLikeStore, null), defaults)) canReset = true;
+      }
+    });
+    resetAll.disabled = !canReset;
   }
-  refreshResetAll();
-  onAnyChange(refreshResetAll);
+  refresh();
+  subscribeDrafts(refresh);
+  onAnyChange(refresh);
 
   return actions;
 }
@@ -797,15 +817,13 @@ function _row(
 
 // _makeResetButton(store, keys, opts) -> <button>
 // Visible only when at least one of `keys` differs from its registered
-// default. Click resets all listed keys, removes the matching localStorage
-// entries (via persist.js's resetKey), and fires opts.onChange so the
-// scene/UI catches up immediately.
+// default (checking effective/draft value). Click stages a reset for each
+// key; user must Save to commit.
 function _makeResetButton(
   store: MapLikeStore,
   keys: string[],
-  opts: ControlOpts
+  _opts: ControlOpts
 ): HTMLButtonElement {
-  const onChange = typeof opts?.onChange === 'function' ? opts.onChange : () => {};
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'theme-row-reset';
@@ -816,19 +834,17 @@ function _makeResetButton(
     if (btn.disabled) return;
     e.preventDefault();
     e.stopPropagation();
-    for (const k of keys) resetKey(store, k);
-    onChange();
+    for (const k of keys) stageReset(store, k);
   });
 
-  // Disabled when value matches default — keeps the icon in layout
-  // (no UI bouncing) but only clickable when there's actually
-  // something to reset.
   function refresh() {
-    const state = store.get();
-    btn.disabled = keys.every((k) => _isEqual(state[k], getDefault(store, k)));
+    btn.disabled = keys.every((k) =>
+      _isEqual(getEffective(store, k), getDefault(store, k))
+    );
   }
   refresh();
   store.subscribe(refresh);
+  subscribeDrafts(refresh);
   return btn;
 }
 
@@ -869,20 +885,19 @@ function _color(
   key: string,
   opts: ControlOpts
 ): HTMLLabelElement {
-  const onChange = _resolveChange(opts);
   const input = document.createElement('input');
   input.type = 'color';
   input.className = 'theme-color';
-  input.value = _toHexInputValue(store.get()[key]);
+  input.value = _toHexInputValue(getEffective(store, key));
   input.addEventListener('input', () => {
-    store.setKey(key, input.value);
-    onChange();
+    setDraft(store, key, input.value);
   });
-  // Reflect outside changes (e.g. reset-to-default) back into the input.
-  store.subscribe((state) => {
-    const hex = _toHexInputValue(state[key]);
+  const refresh = () => {
+    const hex = _toHexInputValue(getEffective(store, key));
     if (input.value.toLowerCase() !== hex) input.value = hex;
-  });
+  };
+  store.subscribe(refresh);
+  subscribeDrafts(refresh);
   return _row(label, input, store, [key], opts);
 }
 
@@ -895,25 +910,23 @@ function _number(
   step: number,
   opts: ControlOpts
 ): HTMLLabelElement {
-  const onChange = _resolveChange(opts);
   const input = document.createElement('input');
   input.type = 'number';
   input.min = String(min);
   input.max = String(max);
   input.step = String(step);
-  input.value = String(store.get()[key]);
+  input.value = String(getEffective(store, key));
   input.className = 'theme-number';
   input.addEventListener('input', () => {
     const v = parseFloat(input.value);
-    if (Number.isFinite(v)) {
-      store.setKey(key, v);
-      onChange();
-    }
+    if (Number.isFinite(v)) setDraft(store, key, v);
   });
-  store.subscribe((state) => {
-    const s = String(state[key]);
+  const refresh = () => {
+    const s = String(getEffective(store, key));
     if (input.value !== s && document.activeElement !== input) input.value = s;
-  });
+  };
+  store.subscribe(refresh);
+  subscribeDrafts(refresh);
   return _row(label, input, store, [key], opts);
 }
 
@@ -926,27 +939,26 @@ function _slider(
   step: number,
   opts: ControlOpts
 ): HTMLLabelElement {
-  const onChange = _resolveChange(opts);
   const refs = {} as SliderRefs;
   const control = _sliderWidget(
-    store.get()[key],
+    getEffective(store, key) as number,
     min,
     max,
     step,
     (v) => {
-      store.setKey(key, v);
-      onChange();
+      setDraft(store, key, v);
     },
     refs
   );
-  // Reflect outside changes (reset-to-default) back into the slider + readout.
-  store.subscribe((state) => {
-    const v = state[key];
+  const refresh = () => {
+    const v = getEffective(store, key) as number;
     if (parseFloat(refs.range.value) !== v) {
       refs.range.value = String(v);
       refs.readout.textContent = _formatNumberForStep(v, step);
     }
-  });
+  };
+  store.subscribe(refresh);
+  subscribeDrafts(refresh);
   return _row(label, control, store, [key], opts);
 }
 
@@ -967,9 +979,9 @@ function _nestedSlider(
   step: number,
   opts: ControlOpts
 ): HTMLLabelElement {
-  const onChange = _resolveChange(opts);
   const refs = {} as SliderRefs;
-  const initial = (store.get()[parentKey] || {})[subKey];
+  const effectiveMap = () => (getEffective(store, parentKey) as any) || {};
+  const initial = effectiveMap()[subKey];
 
   let swatch: HTMLSpanElement | null = null;
   if (opts && opts.previewHue) {
@@ -984,37 +996,30 @@ function _nestedSlider(
     max,
     step,
     (v) => {
-      const current = store.get()[parentKey] || {};
-      const next = {};
+      const current = effectiveMap();
+      const next = {} as Record<string, unknown>;
       for (const k in current) {
         if (Object.hasOwn(current, k)) next[k] = current[k];
       }
       next[subKey] = v;
-      store.setKey(parentKey, next);
+      setDraft(store, parentKey, next);
       if (swatch) swatch.style.background = `hsl(${v}, 80%, 55%)`;
-      onChange();
     },
     refs
   );
 
-  store.subscribe((state) => {
-    const v = (state[parentKey] || {})[subKey];
+  const refresh = () => {
+    const v = effectiveMap()[subKey];
     if (parseFloat(refs.range.value) !== v) {
       refs.range.value = String(v);
       refs.readout.textContent = _formatNumberForStep(v, step);
       if (swatch) swatch.style.background = `hsl(${v}, 80%, 55%)`;
     }
-  });
+  };
+  store.subscribe(refresh);
+  subscribeDrafts(refresh);
 
-  // Reset icon: visible when this sub-key differs from its registered default.
-  // Click resets only this sub-key.
-  const rowOpts: ControlOpts = {};
-  for (const ok in opts) {
-    if (Object.hasOwn(opts, ok)) {
-      (rowOpts as Record<string, unknown>)[ok] = (opts as Record<string, unknown>)[ok];
-    }
-  }
-
+  const rowOpts: ControlOpts = { ...opts };
   const row = _row(label, control, null, null, rowOpts);
   const ctrlWrap = row.querySelector<HTMLElement>('.theme-row-control')!;
   if (swatch) ctrlWrap.appendChild(swatch);
@@ -1031,7 +1036,8 @@ function _nestedSlider(
 function _tierWidthSlider(index: number, minDescendants: number): HTMLLabelElement {
   const refs = {} as SliderRefs;
   const label = `${minDescendants}+ descendants`;
-  const initial = (STREET_TIERS.get()[index] || {}).width;
+  const effectiveTiers = () => (getEffective(STREET_TIERS, null) as any[]) || [];
+  const initial = (effectiveTiers()[index] || {}).width;
 
   const control = _sliderWidget(
     initial,
@@ -1039,21 +1045,23 @@ function _tierWidthSlider(index: number, minDescendants: number): HTMLLabelEleme
     100,
     1,
     (v) => {
-      const current = STREET_TIERS.get();
+      const current = effectiveTiers();
       const next = current.slice();
       next[index] = { min_descendants: current[index].min_descendants, width: v };
-      STREET_TIERS.set(next);
+      setDraft(STREET_TIERS, null, next);
     },
     refs
   );
 
-  STREET_TIERS.subscribe((state) => {
-    const v = (state[index] || {}).width;
+  const refresh = () => {
+    const v = (effectiveTiers()[index] || {}).width;
     if (parseFloat(refs.range.value) !== v) {
       refs.range.value = String(v);
       refs.readout.textContent = _formatNumberForStep(v, 1);
     }
-  });
+  };
+  STREET_TIERS.subscribe(refresh);
+  subscribeDrafts(refresh);
 
   const rowOpts: ControlOpts = {
     tip: 'World-unit width for streets in this descendant-count tier.',
@@ -1072,7 +1080,7 @@ function _makeTierWidthResetButton(index: number): HTMLButtonElement {
   btn.setAttribute('aria-label', 'Reset to default');
   btn.appendChild(makeLucideIcon('rotate-ccw'));
 
-  const defaultArr = getDefault(STREET_TIERS) || [];
+  const defaultArr = (getDefault(STREET_TIERS) as any[]) || [];
   const defaultVal = (defaultArr[index] || {}).width;
   btn.title = `Default: ${_formatDefaultValue(defaultVal)}`;
 
@@ -1080,18 +1088,20 @@ function _makeTierWidthResetButton(index: number): HTMLButtonElement {
     if (btn.disabled) return;
     e.preventDefault();
     e.stopPropagation();
-    const current = STREET_TIERS.get();
+    const current = (getEffective(STREET_TIERS, null) as any[]) || [];
     const next = current.slice();
     next[index] = { min_descendants: current[index].min_descendants, width: defaultVal };
-    STREET_TIERS.set(next);
+    setDraft(STREET_TIERS, null, next);
   });
 
   function refresh() {
-    const v = (STREET_TIERS.get()[index] || {}).width;
+    const arr = (getEffective(STREET_TIERS, null) as any[]) || [];
+    const v = (arr[index] || {}).width;
     btn.disabled = _isEqual(v, defaultVal);
   }
   refresh();
   STREET_TIERS.subscribe(refresh);
+  subscribeDrafts(refresh);
   return btn;
 }
 
@@ -1099,16 +1109,15 @@ function _makeNestedResetButton(
   store: MapLikeStore,
   parentKey: string,
   subKey: string,
-  opts: ControlOpts
+  _opts: ControlOpts
 ): HTMLButtonElement {
-  const onChange = typeof opts?.onChange === 'function' ? opts.onChange : () => {};
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'theme-row-reset';
   btn.setAttribute('aria-label', 'Reset to default');
   btn.appendChild(makeLucideIcon('rotate-ccw'));
 
-  const defaultMap = getDefault(store, parentKey) || {};
+  const defaultMap = (getDefault(store, parentKey) as Record<string, unknown>) || {};
   const defaultVal = defaultMap[subKey];
   btn.title = `Default: ${_formatDefaultValue(defaultVal)}`;
 
@@ -1116,22 +1125,22 @@ function _makeNestedResetButton(
     if (btn.disabled) return;
     e.preventDefault();
     e.stopPropagation();
-    const current = store.get()[parentKey] || {};
-    const next = {};
+    const current = ((getEffective(store, parentKey) as Record<string, unknown>) || {});
+    const next = {} as Record<string, unknown>;
     for (const k in current) {
       if (Object.hasOwn(current, k)) next[k] = current[k];
     }
     next[subKey] = defaultVal;
-    store.setKey(parentKey, next);
-    onChange();
+    setDraft(store, parentKey, next);
   });
 
   function refresh() {
-    const v = (store.get()[parentKey] || {})[subKey];
+    const v = ((getEffective(store, parentKey) as Record<string, unknown>) || {})[subKey];
     btn.disabled = _isEqual(v, defaultVal);
   }
   refresh();
   store.subscribe(refresh);
+  subscribeDrafts(refresh);
   return btn;
 }
 
@@ -1145,7 +1154,6 @@ function _select(
   options: SelectOption[],
   opts: ControlOpts
 ): HTMLLabelElement {
-  const onChange = _resolveChange(opts);
   const wrap = document.createElement('span');
   wrap.className = 'theme-select';
 
@@ -1157,21 +1165,21 @@ function _select(
     btn.textContent = opt.label;
     btn.addEventListener('click', (e) => {
       e.preventDefault();
-      store.setKey(key, opt.value);
-      onChange();
+      setDraft(store, key, opt.value);
     });
     wrap.appendChild(btn);
     return btn;
   });
 
-  function refresh() {
-    const current = store.get()[key];
+  const refresh = () => {
+    const current = getEffective(store, key);
     for (const btn of buttons) {
       btn.classList.toggle('is-active', btn.dataset.value === current);
     }
-  }
+  };
   refresh();
   store.subscribe(refresh);
+  subscribeDrafts(refresh);
   return _row(label, wrap, store, [key], opts);
 }
 
@@ -1182,19 +1190,19 @@ function _toggle(
   key: string,
   opts: ControlOpts
 ): HTMLLabelElement {
-  const onChange = _resolveChange(opts);
   const input = document.createElement('input');
   input.type = 'checkbox';
   input.className = 'theme-toggle';
-  input.checked = !!store.get()[key];
+  input.checked = !!getEffective(store, key);
   input.addEventListener('change', () => {
-    store.setKey(key, input.checked);
-    onChange();
+    setDraft(store, key, input.checked);
   });
-  store.subscribe((state) => {
-    const v = !!state[key];
+  const refresh = () => {
+    const v = !!getEffective(store, key);
     if (input.checked !== v) input.checked = v;
-  });
+  };
+  store.subscribe(refresh);
+  subscribeDrafts(refresh);
   return _row(label, input, store, [key], opts);
 }
 
@@ -1208,8 +1216,8 @@ function _rangePair(
   step: number,
   opts: ControlOpts
 ): HTMLLabelElement {
-  const onChange = _resolveChange(opts);
-  const current = store.get();
+  const initialMin = getEffective(store, minKey) as number;
+  const initialMax = getEffective(store, maxKey) as number;
 
   const pair = document.createElement('span');
   pair.className = 'theme-range-pair';
@@ -1231,9 +1239,9 @@ function _rangePair(
     r.value = String(value);
     return r;
   }
-  const loRange = makeRange(current[minKey]);
+  const loRange = makeRange(initialMin);
   loRange.classList.add('theme-range-pair-lo');
-  const hiRange = makeRange(current[maxKey]);
+  const hiRange = makeRange(initialMax);
   hiRange.classList.add('theme-range-pair-hi');
   pair.appendChild(loRange);
   pair.appendChild(hiRange);
@@ -1262,29 +1270,31 @@ function _rangePair(
       h = l;
       hiRange.value = String(h);
     }
-    store.setKey(minKey, l);
-    store.setKey(maxKey, h);
+    setDraft(store, minKey, l);
+    setDraft(store, maxKey, h);
     paint();
-    onChange();
   }
 
   loRange.addEventListener('input', commit);
   hiRange.addEventListener('input', commit);
   paint();
 
-  // Reflect outside changes (reset-to-default) back into both thumbs.
-  store.subscribe((state) => {
+  const refresh = () => {
     let changed = false;
-    if (parseFloat(loRange.value) !== state[minKey]) {
-      loRange.value = String(state[minKey]);
+    const eMin = getEffective(store, minKey) as number;
+    const eMax = getEffective(store, maxKey) as number;
+    if (parseFloat(loRange.value) !== eMin) {
+      loRange.value = String(eMin);
       changed = true;
     }
-    if (parseFloat(hiRange.value) !== state[maxKey]) {
-      hiRange.value = String(state[maxKey]);
+    if (parseFloat(hiRange.value) !== eMax) {
+      hiRange.value = String(eMax);
       changed = true;
     }
     if (changed) paint();
-  });
+  };
+  store.subscribe(refresh);
+  subscribeDrafts(refresh);
 
   const wrap = document.createElement('span');
   wrap.className = 'theme-slider-wrap';
@@ -1342,13 +1352,6 @@ function _sliderWidget(
     refs.readout = readout;
   }
   return wrap;
-}
-
-// onChange resolution: hot-reload rows pass `applyTheme` as opts.onChange;
-// rebuild rows just persist (no immediate handler).
-function _resolveChange(opts: ControlOpts | undefined): () => void {
-  if (opts && typeof opts.onChange === 'function') return opts.onChange;
-  return function () {};
 }
 
 // Color <input type="color"> only accepts #RRGGBB. Convert from any CSS

--- a/web/views/panes/controlsPane.ts
+++ b/web/views/panes/controlsPane.ts
@@ -4,14 +4,16 @@
 //   .controls-pane (flex column)
 //     .controls-header   — title
 //     .controls-body     — scrollable column of sections (one per scene element)
-//     .controls-actions  — sticky bottom bar: "Reset all"
+//     .controls-actions  — sticky bottom bar: Reset all (left) · Discard · Save (right)
 //
-// Per-row affordance: a reset icon appears in the row's control area
-// ONLY when the value differs from its default; click resets that
-// key (and removes its localStorage entry). Every row is hot-reloadable —
-// changes flow through config/hotReload.js, which dispatches each
-// store mutation to either applyTheme() (live material refresh) or
-// cityScene.applyManifest() (debounced re-layout + re-render).
+// Per-row affordance: a reset icon appears in the row's control area whenever
+// the effective value (pending draft, else committed) differs from its
+// registered default; click stages the default into the draft (Save still
+// required to apply). Every input mutates a single in-memory draft layer
+// (config/drafts.ts); the Save button flushes drafts to the real stores,
+// which triggers the existing config/hotReload.js subscriptions (applyTheme
+// or cityScene.applyManifest). Discard clears drafts without touching stores;
+// page reload is an implicit discard.
 
 import {
   // Background
@@ -89,8 +91,6 @@ interface SelectOption {
 // buildControlsPane(opts) -> HTMLElement
 //
 // opts:
-//   applyTheme — fn() invoked after any hot-reloadable mutation; flushes
-//                the change through to live materials. Optional.
 //   onClose    — fn() invoked when the user clicks the × in the header.
 //                Optional; if omitted, no close button is rendered.
 //
@@ -963,7 +963,7 @@ function _slider(
 }
 
 // _nestedSlider — like _slider but the value lives at store.get()[parentKey][subKey].
-// Writes go through `store.setKey(parentKey, { ...current, [subKey]: v })` so other
+// Writes go through `setDraft(store, parentKey, { ...current, [subKey]: v })` so other
 // sub-keys are preserved. The row's reset icon resets just `subKey` back to its
 // registered default (not the whole map). Used for HUE_EXT_MAP per-extension rows.
 //

--- a/web/views/shell/appFooter.ts
+++ b/web/views/shell/appFooter.ts
@@ -1,12 +1,14 @@
 // views/shell/appFooter.ts — Sitewide bottom status bar. Three sections:
-//   left   — combined status indicator: [color dot] <status text> · live|paused
-//            dot color = rebuild state (green/yellow/red), trailing token =
-//            whether live polling is enabled
+//   left   — combined status indicator: [color dot] <status text> · ▶|⏸
+//            dot color = rebuild state (green/yellow/red), trailing
+//            play/pause icon = whether live polling is enabled (hover
+//            tooltip says "Live updates: on" / "off")
 //   center — repo information (project name + absolute root path)
 //   right  — current selection metadata (language · lines · size · created
 //            · modified for files; file/dir counts + size for directories)
 
 import { DateSource, NodeKind } from '@/types';
+import { makeLucideIcon } from '@/views/shell/icon.js';
 
 interface FooterFileSelection {
   kind: NodeKind.File;
@@ -130,12 +132,16 @@ export function initAppFooter() {
     sep.textContent = '·';
     statusEl.appendChild(sep);
 
-    // Live / paused label (independent of rebuild state)
-    const label = document.createElement('span');
-    label.className = 'app-footer-status-live';
-    label.classList.toggle('is-paused', !status.liveEnabled);
-    label.textContent = status.liveEnabled ? 'live' : 'paused';
-    statusEl.appendChild(label);
+    // Play / pause icon (independent of rebuild state). Tooltip carries
+    // the readable state since the icon alone is visual.
+    const liveWrap = document.createElement('span');
+    liveWrap.className = 'app-footer-status-live';
+    if (!status.liveEnabled) liveWrap.classList.add('is-paused');
+    const tooltip = `Live updates: ${status.liveEnabled ? 'on' : 'off'}`;
+    liveWrap.title = tooltip;
+    liveWrap.setAttribute('aria-label', tooltip);
+    liveWrap.appendChild(makeLucideIcon(status.liveEnabled ? 'play' : 'pause'));
+    statusEl.appendChild(liveWrap);
   }
 
   function setRepoInfo(info: FooterRepoInfo | null): void {

--- a/web/views/shell/appFooter.ts
+++ b/web/views/shell/appFooter.ts
@@ -1,9 +1,13 @@
 // views/shell/appFooter.ts — Sitewide bottom status bar. Three sections:
-//   left   — combined status indicator: ▶|⏸ [color dot] <status text>
-//            leading play/pause glyph = whether live polling is enabled
-//            (blue when on, orange when off; hover tooltip says
-//            "Live updates: on" / "off"); dot color = rebuild state
-//            (green/yellow/red); trailing text = timestamp or status
+//   left   — combined status indicator: [dot] <status text>
+//            One dot, two channels of state:
+//              color    — rebuild state (green=idle, yellow=rebuilding,
+//                         red=error)
+//              animation — live state (slow heartbeat when polling on,
+//                         static when paused, fast pulse when rebuilding,
+//                         static when error)
+//            Hover tooltip surfaces the live state ("Live updates: on/off")
+//            and the rebuild error message (when applicable).
 //   center — repo information (project name + absolute root path)
 //   right  — current selection metadata (language · lines · size · created
 //            · modified for files; file/dir counts + size for directories)
@@ -88,20 +92,25 @@ export function initAppFooter() {
 
   function setStatus(status: FooterStatus): void {
     statusEl.replaceChildren();
-    statusEl.classList.remove('is-rebuilding', 'is-ready', 'is-error');
+    statusEl.classList.remove(
+      'is-rebuilding',
+      'is-ready',
+      'is-error',
+      'is-live',
+      'is-paused'
+    );
     statusEl.removeAttribute('title');
 
-    let modifier: 'is-rebuilding' | 'is-ready' | 'is-error';
+    let buildModifier: 'is-rebuilding' | 'is-ready' | 'is-error';
     let detailText: string;
     if (status.rebuildStatus === 'rebuilding') {
-      modifier = 'is-rebuilding';
+      buildModifier = 'is-rebuilding';
       detailText = 'rebuilding…';
     } else if (status.rebuildStatus === 'error') {
-      modifier = 'is-error';
+      buildModifier = 'is-error';
       detailText = 'error';
-      if (status.errorMessage) statusEl.title = status.errorMessage;
     } else {
-      modifier = 'is-ready';
+      buildModifier = 'is-ready';
       // 'ready' literal is a guard for unit tests or any code path that
       // calls setStatus before LAST_UPDATED_AT is seeded. Production
       // boot seeds the stamp in coordinator.ts before this setter runs.
@@ -110,20 +119,24 @@ export function initAppFooter() {
           ? _relativeTime(status.lastUpdatedAt, Date.now())
           : 'ready';
     }
-    statusEl.classList.add(modifier);
+    statusEl.classList.add(buildModifier);
+    statusEl.classList.add(status.liveEnabled ? 'is-live' : 'is-paused');
 
-    // Live / paused glyph (Unicode for a solid filled look). Tooltip
-    // carries the readable state since the glyph alone is visual.
-    const liveWrap = document.createElement('span');
-    liveWrap.className = 'app-footer-status-live';
-    if (!status.liveEnabled) liveWrap.classList.add('is-paused');
-    const tooltip = `Live updates: ${status.liveEnabled ? 'on' : 'off'}`;
-    liveWrap.title = tooltip;
-    liveWrap.setAttribute('aria-label', tooltip);
-    liveWrap.textContent = status.liveEnabled ? '▶' : '⏸';
-    statusEl.appendChild(liveWrap);
+    // Compose the hover tooltip. Error message wins when present —
+    // otherwise show the live-state summary so users can discover the
+    // play/pause distinction (the dot's heartbeat already hints at it).
+    const liveLabel = `Live updates: ${status.liveEnabled ? 'on' : 'off'}`;
+    if (status.rebuildStatus === 'error' && status.errorMessage) {
+      statusEl.title = `${liveLabel} · ${status.errorMessage}`;
+    } else if (status.rebuildStatus === 'idle' && status.lastUpdatedAt > 0) {
+      const exact = new Date(status.lastUpdatedAt).toLocaleString();
+      statusEl.title = `${liveLabel} · last rebuild ${exact}`;
+    } else {
+      statusEl.title = liveLabel;
+    }
+    statusEl.setAttribute('aria-label', statusEl.title);
 
-    // Dot (color encodes rebuildStatus)
+    // Dot (color = rebuild state; animation = live state, scoped by CSS).
     const dot = document.createElement('span');
     dot.className = 'app-footer-status-dot';
     statusEl.appendChild(dot);
@@ -132,9 +145,6 @@ export function initAppFooter() {
     const detail = document.createElement('span');
     detail.className = 'app-footer-status-detail';
     detail.textContent = detailText;
-    if (status.rebuildStatus === 'idle' && status.lastUpdatedAt > 0) {
-      detail.title = new Date(status.lastUpdatedAt).toLocaleString();
-    }
     statusEl.appendChild(detail);
   }
 

--- a/web/views/shell/appFooter.ts
+++ b/web/views/shell/appFooter.ts
@@ -1,5 +1,7 @@
 // views/shell/appFooter.ts — Sitewide bottom status bar. Three sections:
-//   left   — Live indicator (poll on/off) + Build indicator (idle / rebuilding… / error)
+//   left   — combined status indicator: [color dot] <status text> · live|paused
+//            dot color = rebuild state (green/yellow/red), trailing token =
+//            whether live polling is enabled
 //   center — repo information (project name + absolute root path)
 //   right  — current selection metadata (language · lines · size · created
 //            · modified for files; file/dir counts + size for directories)
@@ -25,16 +27,14 @@ interface FooterDirectorySelection {
 
 export type FooterSelection = FooterFileSelection | FooterDirectorySelection;
 
-export interface FooterLiveStatus {
-  enabled: boolean;
-}
-
-export interface FooterBuildStatus {
+export interface FooterStatus {
+  /** True when live-poll is active; renders as `live`. False renders as `paused`. */
+  liveEnabled: boolean;
   /** Must remain in sync with `RebuildStatus` in `liveStatus.ts` (intentional decoupling). */
-  status: 'idle' | 'rebuilding' | 'error';
+  rebuildStatus: 'idle' | 'rebuilding' | 'error';
   /** Epoch millis of the most recent successful rebuild; 0 ⇒ unknown. */
   lastUpdatedAt: number;
-  /** Surfaced as the indicator's `title` (hover tooltip) when status === 'error'. */
+  /** Surfaced as the indicator's `title` (hover tooltip) when rebuildStatus === 'error'. */
   errorMessage: string | null;
 }
 
@@ -57,17 +57,16 @@ export interface FooterRepoInfo {
 
 const NOOP_API = {
   setSelection(_sel: FooterSelection | null) {},
-  setLiveStatus(_status: FooterLiveStatus) {},
-  setBuildStatus(_status: FooterBuildStatus) {},
+  setStatus(_status: FooterStatus) {},
   setRepoInfo(_info: FooterRepoInfo | null) {},
 };
 
 /**
  * Initialise the sitewide footer. Returns:
- *   setLiveStatus({ enabled })                          — left section (Live dot)
- *   setBuildStatus({ status, lastUpdatedAt, errorMessage }) — left section (Build dot)
- *   setRepoInfo({ ... })                                — center section
- *   setSelection(sel | null)                            — right section
+ *   setStatus({ liveEnabled, rebuildStatus, lastUpdatedAt, errorMessage })
+ *                                            — left section (combined indicator)
+ *   setRepoInfo({ ... })                     — center section
+ *   setSelection(sel | null)                 — right section
  */
 export function initAppFooter() {
   const footer = document.getElementById('app-footer');
@@ -75,12 +74,9 @@ export function initAppFooter() {
 
   const leftEl = document.createElement('div');
   leftEl.className = 'app-footer-section app-footer-left';
-  const liveEl = document.createElement('span');
-  liveEl.className = 'app-footer-live';
-  const buildEl = document.createElement('span');
-  buildEl.className = 'app-footer-build';
-  leftEl.appendChild(liveEl);
-  leftEl.appendChild(buildEl);
+  const statusEl = document.createElement('span');
+  statusEl.className = 'app-footer-status';
+  leftEl.appendChild(statusEl);
 
   const centerEl = document.createElement('div');
   centerEl.className = 'app-footer-section app-footer-center';
@@ -88,57 +84,58 @@ export function initAppFooter() {
   rightEl.className = 'app-footer-section app-footer-right';
   footer.replaceChildren(leftEl, centerEl, rightEl);
 
-  function setLiveStatus(status: FooterLiveStatus): void {
-    liveEl.replaceChildren();
-    liveEl.classList.toggle('is-disabled', !status.enabled);
-
-    const dot = document.createElement('span');
-    dot.className = 'app-footer-live-dot';
-    liveEl.appendChild(dot);
-
-    const label = document.createElement('span');
-    label.className = 'app-footer-live-label';
-    label.textContent = 'live';
-    liveEl.appendChild(label);
-  }
-
-  function setBuildStatus(status: FooterBuildStatus): void {
-    buildEl.replaceChildren();
-    buildEl.classList.remove('is-rebuilding', 'is-ready', 'is-error');
-    buildEl.removeAttribute('title');
+  function setStatus(status: FooterStatus): void {
+    statusEl.replaceChildren();
+    statusEl.classList.remove('is-rebuilding', 'is-ready', 'is-error');
+    statusEl.removeAttribute('title');
 
     let modifier: 'is-rebuilding' | 'is-ready' | 'is-error';
     let detailText: string;
-    if (status.status === 'rebuilding') {
+    if (status.rebuildStatus === 'rebuilding') {
       modifier = 'is-rebuilding';
       detailText = 'rebuilding…';
-    } else if (status.status === 'error') {
+    } else if (status.rebuildStatus === 'error') {
       modifier = 'is-error';
       detailText = 'error';
-      if (status.errorMessage) buildEl.title = status.errorMessage;
+      if (status.errorMessage) statusEl.title = status.errorMessage;
     } else {
       modifier = 'is-ready';
       // 'ready' literal is a guard for unit tests or any code path that
-      // calls setBuildStatus before LAST_UPDATED_AT is seeded. Production
+      // calls setStatus before LAST_UPDATED_AT is seeded. Production
       // boot seeds the stamp in coordinator.ts before this setter runs.
       detailText =
         status.lastUpdatedAt > 0
           ? _relativeTime(status.lastUpdatedAt, Date.now())
           : 'ready';
     }
-    buildEl.classList.add(modifier);
+    statusEl.classList.add(modifier);
 
+    // Dot (color encodes rebuildStatus)
     const dot = document.createElement('span');
-    dot.className = 'app-footer-build-dot';
-    buildEl.appendChild(dot);
+    dot.className = 'app-footer-status-dot';
+    statusEl.appendChild(dot);
 
+    // Status detail (timestamp / "rebuilding…" / "error")
     const detail = document.createElement('span');
-    detail.className = 'app-footer-build-detail';
+    detail.className = 'app-footer-status-detail';
     detail.textContent = detailText;
-    if (status.status === 'idle' && status.lastUpdatedAt > 0) {
+    if (status.rebuildStatus === 'idle' && status.lastUpdatedAt > 0) {
       detail.title = new Date(status.lastUpdatedAt).toLocaleString();
     }
-    buildEl.appendChild(detail);
+    statusEl.appendChild(detail);
+
+    // Separator
+    const sep = document.createElement('span');
+    sep.className = 'app-footer-status-sep';
+    sep.textContent = '·';
+    statusEl.appendChild(sep);
+
+    // Live / paused label (independent of rebuild state)
+    const label = document.createElement('span');
+    label.className = 'app-footer-status-live';
+    label.classList.toggle('is-paused', !status.liveEnabled);
+    label.textContent = status.liveEnabled ? 'live' : 'paused';
+    statusEl.appendChild(label);
   }
 
   function setRepoInfo(info: FooterRepoInfo | null): void {
@@ -202,7 +199,7 @@ export function initAppFooter() {
     }
   }
 
-  return { setSelection, setLiveStatus, setBuildStatus, setRepoInfo };
+  return { setSelection, setStatus, setRepoInfo };
 }
 
 const SEC_MS = 1000;

--- a/web/views/shell/appFooter.ts
+++ b/web/views/shell/appFooter.ts
@@ -27,9 +27,14 @@ export type FooterSelection = FooterFileSelection | FooterDirectorySelection;
 
 export interface FooterLiveStatus {
   enabled: boolean;
-  reloading: boolean;
-  /** Epoch millis of the most recent manifest apply; 0 ⇒ unknown. */
+}
+
+export interface FooterBuildStatus {
+  status: 'idle' | 'rebuilding' | 'error';
+  /** Epoch millis of the most recent successful rebuild; 0 ⇒ unknown. */
   lastUpdatedAt: number;
+  /** Surfaced as the indicator's `title` (hover tooltip) when status === 'error'. */
+  errorMessage: string | null;
 }
 
 export interface FooterRepoInfo {
@@ -52,14 +57,16 @@ export interface FooterRepoInfo {
 const NOOP_API = {
   setSelection(_sel: FooterSelection | null) {},
   setLiveStatus(_status: FooterLiveStatus) {},
+  setBuildStatus(_status: FooterBuildStatus) {},
   setRepoInfo(_info: FooterRepoInfo | null) {},
 };
 
 /**
  * Initialise the sitewide footer. Returns:
- *   setLiveStatus({ enabled, reloading }) — left section
- *   setRepoInfo({ name, root })           — center section
- *   setSelection(sel | null)              — right section
+ *   setLiveStatus({ enabled })                          — left section (Live dot)
+ *   setBuildStatus({ status, lastUpdatedAt, errorMessage }) — left section (Build dot)
+ *   setRepoInfo({ ... })                                — center section
+ *   setSelection(sel | null)                            — right section
  */
 export function initAppFooter() {
   const footer = document.getElementById('app-footer');
@@ -67,6 +74,13 @@ export function initAppFooter() {
 
   const leftEl = document.createElement('div');
   leftEl.className = 'app-footer-section app-footer-left';
+  const liveEl = document.createElement('span');
+  liveEl.className = 'app-footer-live';
+  const buildEl = document.createElement('span');
+  buildEl.className = 'app-footer-build';
+  leftEl.appendChild(liveEl);
+  leftEl.appendChild(buildEl);
+
   const centerEl = document.createElement('div');
   centerEl.className = 'app-footer-section app-footer-center';
   const rightEl = document.createElement('div');
@@ -74,42 +88,54 @@ export function initAppFooter() {
   footer.replaceChildren(leftEl, centerEl, rightEl);
 
   function setLiveStatus(status: FooterLiveStatus): void {
-    leftEl.replaceChildren();
-    const indicator = document.createElement('span');
-    indicator.className = 'app-footer-live';
-    if (!status.enabled) indicator.classList.add('is-disabled');
-    else if (status.reloading) indicator.classList.add('is-reloading');
-    else indicator.classList.add('is-live');
+    liveEl.replaceChildren();
+    liveEl.classList.remove('is-disabled', 'is-live');
+    liveEl.classList.add(status.enabled ? 'is-live' : 'is-disabled');
 
     const dot = document.createElement('span');
     dot.className = 'app-footer-live-dot';
-    indicator.appendChild(dot);
+    liveEl.appendChild(dot);
 
-    const primary = document.createElement('span');
-    primary.className = 'app-footer-live-label';
-    primary.textContent = status.enabled ? 'live' : 'live updates off';
-    indicator.appendChild(primary);
+    const label = document.createElement('span');
+    label.className = 'app-footer-live-label';
+    label.textContent = 'live';
+    liveEl.appendChild(label);
+  }
 
-    if (status.enabled) {
-      const sep = document.createElement('span');
-      sep.className = 'app-footer-live-sep';
-      sep.textContent = '·';
-      indicator.appendChild(sep);
+  function setBuildStatus(status: FooterBuildStatus): void {
+    buildEl.replaceChildren();
+    buildEl.classList.remove('is-rebuilding', 'is-ready', 'is-error');
+    buildEl.removeAttribute('title');
 
-      const detail = document.createElement('span');
-      detail.className = 'app-footer-live-detail';
-      if (status.reloading) {
-        detail.textContent = 'reloading…';
-      } else if (status.lastUpdatedAt > 0) {
-        detail.textContent = _relativeTime(status.lastUpdatedAt, Date.now());
-        detail.title = new Date(status.lastUpdatedAt).toLocaleString();
-      } else {
-        detail.textContent = '—';
-      }
-      indicator.appendChild(detail);
+    let modifier: 'is-rebuilding' | 'is-ready' | 'is-error';
+    let detailText: string;
+    if (status.status === 'rebuilding') {
+      modifier = 'is-rebuilding';
+      detailText = 'rebuilding…';
+    } else if (status.status === 'error') {
+      modifier = 'is-error';
+      detailText = 'error';
+      if (status.errorMessage) buildEl.title = status.errorMessage;
+    } else {
+      modifier = 'is-ready';
+      detailText =
+        status.lastUpdatedAt > 0
+          ? _relativeTime(status.lastUpdatedAt, Date.now())
+          : 'ready';
     }
+    buildEl.classList.add(modifier);
 
-    leftEl.appendChild(indicator);
+    const dot = document.createElement('span');
+    dot.className = 'app-footer-build-dot';
+    buildEl.appendChild(dot);
+
+    const detail = document.createElement('span');
+    detail.className = 'app-footer-build-detail';
+    detail.textContent = detailText;
+    if (status.status === 'idle' && status.lastUpdatedAt > 0) {
+      detail.title = new Date(status.lastUpdatedAt).toLocaleString();
+    }
+    buildEl.appendChild(detail);
   }
 
   function setRepoInfo(info: FooterRepoInfo | null): void {
@@ -173,7 +199,7 @@ export function initAppFooter() {
     }
   }
 
-  return { setSelection, setLiveStatus, setRepoInfo };
+  return { setSelection, setLiveStatus, setBuildStatus, setRepoInfo };
 }
 
 const SEC_MS = 1000;

--- a/web/views/shell/appFooter.ts
+++ b/web/views/shell/appFooter.ts
@@ -1,14 +1,14 @@
 // views/shell/appFooter.ts — Sitewide bottom status bar. Three sections:
-//   left   — combined status indicator: [color dot] <status text> · ▶|⏸
-//            dot color = rebuild state (green/yellow/red), trailing
-//            play/pause icon = whether live polling is enabled (hover
-//            tooltip says "Live updates: on" / "off")
+//   left   — combined status indicator: ▶|⏸ [color dot] <status text>
+//            leading play/pause glyph = whether live polling is enabled
+//            (blue when on, orange when off; hover tooltip says
+//            "Live updates: on" / "off"); dot color = rebuild state
+//            (green/yellow/red); trailing text = timestamp or status
 //   center — repo information (project name + absolute root path)
 //   right  — current selection metadata (language · lines · size · created
 //            · modified for files; file/dir counts + size for directories)
 
 import { DateSource, NodeKind } from '@/types';
-import { makeLucideIcon } from '@/views/shell/icon.js';
 
 interface FooterFileSelection {
   kind: NodeKind.File;
@@ -112,6 +112,17 @@ export function initAppFooter() {
     }
     statusEl.classList.add(modifier);
 
+    // Live / paused glyph (Unicode for a solid filled look). Tooltip
+    // carries the readable state since the glyph alone is visual.
+    const liveWrap = document.createElement('span');
+    liveWrap.className = 'app-footer-status-live';
+    if (!status.liveEnabled) liveWrap.classList.add('is-paused');
+    const tooltip = `Live updates: ${status.liveEnabled ? 'on' : 'off'}`;
+    liveWrap.title = tooltip;
+    liveWrap.setAttribute('aria-label', tooltip);
+    liveWrap.textContent = status.liveEnabled ? '▶' : '⏸';
+    statusEl.appendChild(liveWrap);
+
     // Dot (color encodes rebuildStatus)
     const dot = document.createElement('span');
     dot.className = 'app-footer-status-dot';
@@ -125,23 +136,6 @@ export function initAppFooter() {
       detail.title = new Date(status.lastUpdatedAt).toLocaleString();
     }
     statusEl.appendChild(detail);
-
-    // Separator
-    const sep = document.createElement('span');
-    sep.className = 'app-footer-status-sep';
-    sep.textContent = '·';
-    statusEl.appendChild(sep);
-
-    // Play / pause icon (independent of rebuild state). Tooltip carries
-    // the readable state since the icon alone is visual.
-    const liveWrap = document.createElement('span');
-    liveWrap.className = 'app-footer-status-live';
-    if (!status.liveEnabled) liveWrap.classList.add('is-paused');
-    const tooltip = `Live updates: ${status.liveEnabled ? 'on' : 'off'}`;
-    liveWrap.title = tooltip;
-    liveWrap.setAttribute('aria-label', tooltip);
-    liveWrap.appendChild(makeLucideIcon(status.liveEnabled ? 'play' : 'pause'));
-    statusEl.appendChild(liveWrap);
   }
 
   function setRepoInfo(info: FooterRepoInfo | null): void {

--- a/web/views/shell/appFooter.ts
+++ b/web/views/shell/appFooter.ts
@@ -1,5 +1,5 @@
 // views/shell/appFooter.ts — Sitewide bottom status bar. Three sections:
-//   left   — live-reload status (live / reloading… / off)
+//   left   — Live indicator (poll on/off) + Build indicator (idle / rebuilding… / error)
 //   center — repo information (project name + absolute root path)
 //   right  — current selection metadata (language · lines · size · created
 //            · modified for files; file/dir counts + size for directories)
@@ -30,6 +30,7 @@ export interface FooterLiveStatus {
 }
 
 export interface FooterBuildStatus {
+  /** Must remain in sync with `RebuildStatus` in `liveStatus.ts` (intentional decoupling). */
   status: 'idle' | 'rebuilding' | 'error';
   /** Epoch millis of the most recent successful rebuild; 0 ⇒ unknown. */
   lastUpdatedAt: number;
@@ -89,8 +90,7 @@ export function initAppFooter() {
 
   function setLiveStatus(status: FooterLiveStatus): void {
     liveEl.replaceChildren();
-    liveEl.classList.remove('is-disabled', 'is-live');
-    liveEl.classList.add(status.enabled ? 'is-live' : 'is-disabled');
+    liveEl.classList.toggle('is-disabled', !status.enabled);
 
     const dot = document.createElement('span');
     dot.className = 'app-footer-live-dot';
@@ -118,6 +118,9 @@ export function initAppFooter() {
       if (status.errorMessage) buildEl.title = status.errorMessage;
     } else {
       modifier = 'is-ready';
+      // 'ready' literal is a guard for unit tests or any code path that
+      // calls setBuildStatus before LAST_UPDATED_AT is seeded. Production
+      // boot seeds the stamp in coordinator.ts before this setter runs.
       detailText =
         status.lastUpdatedAt > 0
           ? _relativeTime(status.lastUpdatedAt, Date.now())

--- a/web/views/shell/leftSidebar.ts
+++ b/web/views/shell/leftSidebar.ts
@@ -17,7 +17,7 @@ const SIDEBAR_MIN_WIDTH = 280;
 const SIDEBAR_MAX_WIDTH = 600;
 
 interface ShowLeftSidebarOpts {
-  /** fn() the Settings UI calls after mutating any imported theme constant — flushes the change through to live materials. */
+  /** fn() the Settings UI used to call after every input edit. Now driven by config/hotReload.js subscriptions when the user clicks Save; this option is accepted for caller compatibility but is no longer forwarded to the controls panel. */
   applyTheme?: () => void;
   /** fn() called when the user clicks the "Run collision check" debug button. */
   onRunCollisionCheck?: () => void;
@@ -40,8 +40,10 @@ interface ShowLeftSidebarOpts {
 // showLeftSidebar(manifest, opts) -> { setSelectedTreePath, setHoveredTreePath }
 //
 // opts:
-//   applyTheme        — fn() the Settings UI calls after mutating any imported
-//                       theme constant — flushes the change through to live materials.
+//   applyTheme        — fn() the Settings UI used to call after every input edit.
+//                       Now driven by config/hotReload.js subscriptions when the
+//                       user clicks Save; accepted for caller compatibility but no
+//                       longer forwarded to the controls panel.
 //   initialTab        — 'tree' | 'controls' (default 'tree')
 //   onTreeSelect      — fn(node) called when the user single-clicks a tree row.
 //                       Host wires to _setSelection so tree → city selection

--- a/web/views/shell/leftSidebar.ts
+++ b/web/views/shell/leftSidebar.ts
@@ -96,7 +96,6 @@ export function showLeftSidebar(
   panes[SidebarTab.Tree] = treeBundle.pane;
   panes[SidebarTab.Info] = infoBundle.pane;
   panes[SidebarTab.Controls] = buildControlsPane({
-    applyTheme: opts.applyTheme,
     onClose: paneOnClose,
     onRunCollisionCheck: opts.onRunCollisionCheck,
     onRunStemDiagnostic: opts.onRunStemDiagnostic,


### PR DESCRIPTION
## Summary

Four related feature increments in one branch:

### 1. Controls panel save button
Replaces live-write behavior with a save-gated workflow. Edits buffer into an in-memory **draft layer** (`web/config/drafts.ts`); scene/persistence only update when **Save** is clicked. New action bar: **Reset all** (stage defaults) · **Discard** (drop drafts) · **Save** (commit). Per-row reset icons stage the default into the draft; nothing applies until Save.

### 2. Footer rebuild-status indicator
Adds a unified status indicator to the footer left section: a single dot whose **color** encodes rebuild state (green idle / yellow rebuilding / red error) and whose **animation** encodes live polling (slow heartbeat when on, static when off / paused). Replaces the boolean `IS_RELOADING` with `REBUILD_STATUS` enum + `LAST_REBUILD_ERROR` atom. Save-driven rebuilds and live-poll fetches both drive the indicator. Errors now surface visually with a hover tooltip.

### 3. Root gem polish
- Default radius bumped to 0.5× street width
- Plaza clearance is now gem-relative (`CLEARANCE_AS_GEM_WIDTH_FRAC = 2`)
- Click-to-reset affordance discoverable via hover tooltip
- Body writes depth so labels behind no longer bleed through
- Neon glow halo: two billboarded sprites with a soft radial gradient, color-animated through the gem face palette
- Configurable glow controls in the panel

### 4. Async layout worker (Phase 1)
Moves the recursive layout packer off the main thread to fix the 5+ second freeze on large repos:
- New `web/scene/layoutWorker.ts` runs `layoutCityV4` in a Web Worker
- New `web/scene/layoutClient.ts` façade with supersede protocol (rapid succession saves drop stale results)
- `applyManifest` is now async with an **atomic swap** — the previous scene stays on screen until new meshes are fully built, then dispose-and-attach happens in one uninterrupted block
- Sync fallback when `Worker` is undefined (jsdom test env)

### Bonus fixes along the way
- Hover tooltips include the root folder name as a leading-slash absolute path (`/codecity/web/main.ts`)
- Road labels render on container-only directories (e.g. `.superpowers/brainstorm`)
- Long road labels truncate with `…` instead of shrinking illegibly
- Directory tooltips show immediate-child counts (not descendant counts)
- Gem hover/click works again (glow sprites no longer intercept raycasts; body has its own `userData.type` stamp)
- Color-only saves (hot-reload path) now flash the rebuilding indicator too

## Test Plan

- [ ] `cd web && npm run typecheck` — clean
- [ ] `cd web && npm test` — 1560 tests passing
- [ ] Open the app, drag a slider in the Controls tab, click Save — confirm the build dot pulses yellow then goes green, timestamp updates
- [ ] With a large repo: trigger a save. Confirm the UI stays interactive during the rebuild (camera orbit/pan/zoom should work while the build dot pulses)
- [ ] Hover over the root gem — tooltip reads `/<root>  ·  click to reset view`
- [ ] Click the gem — selection clears, camera resets
- [ ] Toggle live updates off — footer's heartbeat stops, dot stays green
- [ ] Hover a directory street — tooltip path includes the root name; counts are immediate children only

🤖 Generated with [Claude Code](https://claude.com/claude-code)