### PR TITLE
camera: reset to default on load; fix footer stuck on "decorating"

### DIFF
--- a/web/src/constants/storage.ts
+++ b/web/src/constants/storage.ts
@@ -14,8 +14,6 @@ export const STORAGE_PREFIX = 'cc.';
 export const STORAGE_PER_SOURCE_PREFIX = `${STORAGE_PREFIX}source.`;
 
 export const STORAGE_KEYS = {
-  /** Camera position + target, debounced-saved on every controls 'change'. */
-  CAMERA_POSE: `${STORAGE_PREFIX}cameraPose`,
   /** Right (file-preview) sidebar drag-handle width in px. */
   FILE_SIDEBAR_WIDTH: `${STORAGE_PREFIX}fileSidebarWidth`,
   /** Left (tree/info/controls) sidebar drag-handle width in px. */

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -68,10 +68,6 @@ if (_canvas) {
     // synchronously on registration — that first fire covers the boot case.
     SYNTAX_THEME.subscribe(applyHljsTheme);
 
-    // One-shot migration: pre-this-change, PICKER_SELECTION_KEY and cameraPose
-    // were both persisted as global keys. If they're still there AND we have a
-    // source loaded (URL has ?src=), copy them under the source's namespace
-    // and drop the legacy slots.
     // Set CURRENT_SOURCE_KEY from URL params BEFORE wiring per-source
     // persistence so hydration sees the right key.
     {

--- a/web/src/scene/system/cameraRig.ts
+++ b/web/src/scene/system/cameraRig.ts
@@ -1,6 +1,6 @@
 // scene/cameraRig.ts — owns the perspective camera, OrbitControls,
-// camera-pose persistence, initial framing, and the focus/reset
-// animations (R key reset, F key focus-on-selection, dblclick focus).
+// initial framing, and the focus/reset animations (R key reset,
+// F key focus-on-selection, dblclick focus).
 //
 // Public contract:
 //
@@ -20,10 +20,8 @@
 // firstFrame flag is true and world.getBbox() returns non-empty,
 // then clears the flag. There's no surface for an accidental re-frame.
 //
-// Camera-pose persistence: every controls 'change' event debounces a
-// localStorage save (cc.source.<key>.cameraPose). Restoration happens after the
-// initial framing snapshot so reset() always animates back to the true
-// default fit, not the user's last navigated pose.
+// Camera pose is never persisted. Every world load always starts at the
+// default gem-framing position.
 
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -38,12 +36,7 @@ import { BuildingOrient, StreetAxis } from '@/types';
 import type { Building, Street } from '@/types';
 import type { createWorld } from '../world.js';
 
-function _cameraPoseKey(): string | null {
-  const k = CURRENT_SOURCE_KEY.get();
-  return k ? `cc.source.${k}.cameraPose` : null;
-}
 
-// _focusBuilding tries head-on, then tilts up if the view is obstructed.
 const SIGHTLINE_STEP_DEG = 20;
 const SIGHTLINE_MAX_ATTEMPTS = 5;
 const SIGHTLINE_FAR_OFFSET = 0.5;
@@ -102,33 +95,7 @@ export function createCameraRig({
   let initialCamPos: THREE.Vector3 | null = null;
   let initialTarget: THREE.Vector3 | null = null;
 
-  let _saveCameraTimer: ReturnType<typeof setTimeout> | 0 = 0;
-  let _changeListenerAttached = false;
   let _rebuildSubscribed = false;
-
-  function _saveCameraPose() {
-    if (typeof localStorage === 'undefined') return;
-    try {
-      const _ck = _cameraPoseKey();
-      if (_ck)
-        localStorage.setItem(
-          _ck,
-          JSON.stringify({
-            pos: { x: camera.position.x, y: camera.position.y, z: camera.position.z },
-            target: { x: controls.target.x, y: controls.target.y, z: controls.target.z },
-          })
-        );
-    } catch (_) {
-      /* private mode / quota — ignore */
-    }
-  }
-  function _scheduleCameraSave() {
-    if (_saveCameraTimer) clearTimeout(_saveCameraTimer);
-    _saveCameraTimer = setTimeout(() => {
-      _saveCameraTimer = 0;
-      _saveCameraPose();
-    }, 500);
-  }
 
   // Animation cancellation token. Each new focus/reset animation bumps
   // this; in-flight rAF steps abort if their token doesn't match.
@@ -261,63 +228,25 @@ export function createCameraRig({
   const _scratchUserPos = new THREE.Vector3();
   const _scratchUserTarget = new THREE.Vector3();
 
-  // Apply a persisted pose object { pos, target } to the camera and controls.
-  // Extracted so both the constructor hydration and the source-switch
-  // subscription share the same logic.
-  function _applyPose(p: { pos: { x: number; y: number; z: number }; target: { x: number; y: number; z: number } } | null | undefined) {
-    if (!p?.pos || !p?.target) return;
-    camera.position.set(p.pos.x, p.pos.y, p.pos.z);
-    controls.target.set(p.target.x, p.target.y, p.target.z);
-  }
-
   function _frameToBbox() {
     if (!_captureFraming() || !initialCamPos || !initialTarget) return false;
 
-    // First-frame only: actually move the camera to the framed pose.
+    // First-frame only: move the camera to the default framed pose.
     camera.position.copy(initialCamPos);
     camera.lookAt(initialTarget);
     controls.target.copy(initialTarget);
 
-    // Restore saved pose if any. Done BEFORE attaching the change
-    // listener so the restore itself doesn't trigger a re-save.
-    {
-      const _ck = _cameraPoseKey();
-      const savedPoseRaw = _ck ? localStorage.getItem(_ck) : null;
-      if (savedPoseRaw) {
-        try {
-          _applyPose(JSON.parse(savedPoseRaw));
-        } catch (_) {
-          /* corrupt JSON / unavailable storage — stay at default */
-        }
-      }
-    }
-
-    if (!_changeListenerAttached) {
-      controls.addEventListener('change', _scheduleCameraSave);
-      _changeListenerAttached = true;
-    }
     // Re-frame on every manifest swap so R always fits the current city.
     if (!_rebuildSubscribed) {
       world.onChange(() => {
         _captureFraming();
       });
-      // Re-hydrate pose when the user switches source mid-session.
-      // Skip the immediate fire (same key as what _frameToBbox already applied).
+      // Reset to bbox framing when the user switches source mid-session.
       let _lastSourceKey = CURRENT_SOURCE_KEY.get();
       CURRENT_SOURCE_KEY.subscribe((newKey) => {
         if (newKey === null || newKey === _lastSourceKey) return;
         _lastSourceKey = newKey;
-        const raw = localStorage.getItem(`cc.source.${newKey}.cameraPose`);
-        if (raw) {
-          try {
-            _applyPose(JSON.parse(raw));
-          } catch {
-            /* bad JSON — let next bbox-frame run */
-          }
-        } else {
-          // No saved pose for the new source — reset to bbox framing.
-          controls.reset();
-        }
+        controls.reset();
       });
       _rebuildSubscribed = true;
     }
@@ -374,18 +303,6 @@ export function createCameraRig({
     // Cancel any in-flight focus/reset animation so it can't keep
     // walking the camera away from the snap target.
     camAnimToken++;
-    if (_saveCameraTimer) {
-      clearTimeout(_saveCameraTimer);
-      _saveCameraTimer = 0;
-    }
-    // Wipe persisted camera pose so a partially-applied reset doesn't
-    // leave a stale pose to be restored on next page load.
-    try {
-      const _ck = _cameraPoseKey();
-      if (_ck) localStorage.removeItem(_ck);
-    } catch (_) {
-      /* private mode / unavailable — ignore */
-    }
     camera.up.set(0, 1, 0);
     // Hard snap. Bypassing controls.reset() in favor of a manual snap
     // because controls.reset() calls update() at the end, which re-applies
@@ -565,14 +482,6 @@ export function createCameraRig({
   }
 
   function dispose() {
-    if (_changeListenerAttached) {
-      controls.removeEventListener('change', _scheduleCameraSave);
-      _changeListenerAttached = false;
-    }
-    if (_saveCameraTimer) {
-      clearTimeout(_saveCameraTimer);
-      _saveCameraTimer = 0;
-    }
     if (typeof controls.dispose === 'function') controls.dispose();
   }
 

--- a/web/src/scene/world.ts
+++ b/web/src/scene/world.ts
@@ -1198,6 +1198,8 @@ export function createWorld(_canvas: HTMLCanvasElement) {
         _bushes = createBushes(bushPlacements);
         scene.add(_bushes.group);
       }
+
+      REBUILD_STATUS.set('idle');
     }
   }
 


### PR DESCRIPTION
## What changed

### Camera always resets to default on load
Removed camera-pose persistence entirely. Previously the camera position/target was debounce-saved to `localStorage` on every `controls 'change'` event and restored on page load or source switch. Now every world load starts at the default gem-framing position.

- Removed `_saveCameraPose`, `_scheduleCameraSave`, `_applyPose`, `_cameraPoseKey` and the `change` event listener from `cameraRig.ts`
- Removed `STORAGE_KEYS.CAMERA_POSE` from `storage.ts`
- Removed the one-shot migration comment/code block from `main.ts`
- On source switch, `controls.reset()` is always called instead of attempting to hydrate a saved pose

### Footer no longer stuck on "decorating…"
`world.ts` set `REBUILD_STATUS → 'decorating'` before the foliage pass but never reset it. Callers in `liveUpdates.ts` and `configHotReload.ts` manage their own `'rebuilding' → 'idle'` transitions, but the initial-load path in `main.ts` has no post-`applyManifest` idle reset — so the footer stayed on "decorating…" after every cold load.

Fix: `world.ts` now sets `REBUILD_STATUS → 'idle'` after the foliage pass completes. Early-return paths (generation superseded) are unaffected — those always have a new `applyManifest` in flight that will handle the transition.

## Test plan
- [ ] Load a repo — footer should show "decorating…" briefly then clear to idle
- [ ] Reload the page — camera should always start at the default framed position, not a previously saved pose
- [ ] Switch source mid-session — camera resets to default for the new source
- [ ] R key reset still animates back to the default fit
