### PR TITLE
feat: label dev URLs as <repo>.localhost so worktrees are identifiable

### DIFF
--- a/codecity/cli.py
+++ b/codecity/cli.py
@@ -184,9 +184,10 @@ def _run_dev_server(vite_port: int, api_port: int) -> int:
     signal.signal(signal.SIGTERM, _signal_handler)
 
     try:
-        if not _wait_for_vite(f"http://127.0.0.1:{vite_port}/", vite_proc, vite_port):
+        if not _wait_for_vite(f"http://[::1]:{vite_port}/", vite_proc, vite_port):
             return 3
-        url = f"http://127.0.0.1:{vite_port}/"
+        label = REPO_ROOT.name.lower().replace("_", "-")
+        url = f"http://{label}.localhost:{vite_port}/"
         webbrowser.open(url)
         print(f"[codecity] open {url} — Ctrl-C to stop", file=sys.stderr)
         while True:

--- a/web/tests/visual/setup.ts
+++ b/web/tests/visual/setup.ts
@@ -70,7 +70,7 @@ export async function setupHarness(port = 18765): Promise<VisualHarness> {
     defaultViewport: { width: 1280, height: 800, deviceScaleFactor: 1 },
   });
   const page = await browser.newPage();
-  await page.goto(`http://127.0.0.1:${port}/?src=${encodeURIComponent(FIXTURE_PATH)}`);
+  await page.goto(`http://[::1]:${port}/?src=${encodeURIComponent(FIXTURE_PATH)}`);
 
   // I3 fix: wait for window.__rig (set in main.ts after startRenderLoop, which
   // runs AFTER the manifest fetch + world.applyManifest). Checking

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -28,12 +28,15 @@ export default defineConfig({
     },
   },
   server: {
-    // Bind explicitly to IPv4. Vite's default `localhost` resolves to ::1
-    // first on many Node setups (macOS especially), but the codecity CLI
-    // polls 127.0.0.1 — the resulting v6/v4 mismatch shows up as "Vite did
-    // not become ready" while the browser still works (since the browser
-    // tries both families).
-    host: '127.0.0.1',
+    // Bind to IPv6 loopback. The codecity CLI opens
+    // `http://<label>.localhost:<port>/` so worktrees are identifiable in
+    // the URL bar; macOS resolves *.localhost to [::1, 127.0.0.1] and
+    // Chrome tries ::1 first. If we bound to 127.0.0.1, the initial doc
+    // load would fall back but parallel subresource fetches race the
+    // refused IPv6 attempt and intermittently fail with
+    // ERR_CONNECTION_REFUSED. Binding to ::1 keeps loopback-only and
+    // matches the address browsers actually try first.
+    host: '::1',
     port: 5173,
     // strictPort: don't silently shift to 5174 if 5173 is taken — codecity
     // dev mode polls 5173, so a port shift would look like "Vite never came


### PR DESCRIPTION
## Summary

- `codecity --dev` / `--dev-worktree` now open `http://<repo>.localhost:<port>/` instead of `http://127.0.0.1:<port>/`, so the URL bar tells you at a glance which worktree a tab points at. Label is derived from `REPO_ROOT.name` (lowercased, `_`→`-`). Main checkout opens `http://codecity.localhost:5173/`; a worktree at `.claude/worktrees/foo/` opens `http://foo.localhost:<port>/`.
- Vite is bound to `::1` instead of `127.0.0.1`. macOS resolves `*.localhost` to `[::1, 127.0.0.1]` and Chrome tries IPv6 first; with a v4-only bind the initial document fell back but parallel subresource fetches raced the refused v6 attempt and intermittently failed with `ERR_CONNECTION_REFUSED`. `::1` matches the address browsers actually try first and stays loopback-only (no LAN exposure).
- Codecity's `_wait_for_vite` poll and the visual-test puppeteer URL both updated to `[::1]` to match the new bind.

## Test plan

- [ ] `codecity --dev` opens `http://codecity.localhost:5173/` and the app loads with no console errors
- [ ] `codecity --dev-worktree` in a worktree opens `http://<worktree-name>.localhost:<port>/` and the app loads with no console errors
- [ ] Two `--dev-worktree` instances side-by-side show different hostnames in tab titles / URL bars
- [ ] `npm run test:visual` still passes (puppeteer now hits `[::1]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)