### PR TITLE
fix: heartbeat during silent on-demand blob fetch on large clones

### DIFF
--- a/codecity/clone.py
+++ b/codecity/clone.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 
 from codecity.types import (
@@ -114,7 +115,39 @@ def _run_git(*args: str, cwd: Path | None = None) -> str:
     return proc.stdout
 
 
-def _run_git_streaming(*args: str, cwd: Path | None = None) -> str:
+# Heartbeat cadence for the stall watchdog. Tuned for the gap between
+# git's "Resolving deltas: 100% done" and clone return on a large
+# --filter=blob:none clone — that gap is the on-demand promisor fetch
+# materializing the working tree, which emits no progress at all. Short
+# enough that the user notices the heartbeat within a few seconds of
+# git falling silent; long enough that a normal small clone never sees
+# a heartbeat fire at all.
+_STALL_HEARTBEAT_SECS = 5.0
+
+
+def _pack_dir_bytes(pack_dir: Path) -> int:
+    """Sum of file sizes directly under ``pack_dir``. Non-recursive: git
+    writes `pack-<sha>.pack` and `pack-<sha>.idx` flat in this dir, so
+    we don't need to descend. Returns 0 if the dir doesn't exist yet
+    (clone is still setting up .git/)."""
+    total = 0
+    try:
+        for entry in os.scandir(pack_dir):
+            try:
+                if entry.is_file(follow_symlinks=False):
+                    total += entry.stat(follow_symlinks=False).st_size
+            except OSError:
+                continue
+    except OSError:
+        return 0
+    return total
+
+
+def _run_git_streaming(
+    *args: str,
+    cwd: Path | None = None,
+    progress_dir: Path | None = None,
+) -> str:
     """Run git and forward stderr to ``_log`` line-by-line as it arrives.
 
     Use for long-running network ops (clone, fetch) so the user sees
@@ -128,7 +161,16 @@ def _run_git_streaming(*args: str, cwd: Path | None = None) -> str:
     a syscall hot spot on large clones (linux kernel: ~5M stderr bytes
     → ~5M read() calls). 4 KB chunks reduce that to ~1.2K syscalls
     without changing semantics — we still split on the same CR/LF
-    boundaries."""
+    boundaries.
+
+    ``progress_dir`` (typically the clone target's
+    ``.git/objects/pack``) is sampled by the stall watchdog when git
+    falls silent. ``--filter=blob:none`` clones spend minutes in a
+    silent on-demand blob fetch after "Resolving deltas: 100% done";
+    git launches it as an internal sub-process that does NOT inherit
+    ``--progress``, so we'd otherwise show nothing for the entire
+    materialization phase. The watchdog surfaces pack-dir growth so
+    the user can see download progress."""
     try:
         proc = subprocess.Popen(
             ["git", *args],
@@ -144,6 +186,10 @@ def _run_git_streaming(*args: str, cwd: Path | None = None) -> str:
 
     captured_stderr: list[str] = []
     stdout_holder: list[str] = []
+    # Wall-clock of the last stderr line we forwarded. The watchdog
+    # treats anything older than _STALL_HEARTBEAT_SECS as a stall.
+    last_output_at = [time.monotonic()]
+    proc_done = threading.Event()
 
     def _drain_stderr() -> None:
         assert proc.stderr is not None
@@ -163,6 +209,7 @@ def _run_git_streaming(*args: str, cwd: Path | None = None) -> str:
                     if line:
                         captured_stderr.append(line)
                         _log(line)
+                        last_output_at[0] = time.monotonic()
                     start = i + 1
             if start:
                 del buf[:start]
@@ -171,18 +218,55 @@ def _run_git_streaming(*args: str, cwd: Path | None = None) -> str:
             if line:
                 captured_stderr.append(line)
                 _log(line)
+                last_output_at[0] = time.monotonic()
 
     def _drain_stdout() -> None:
         assert proc.stdout is not None
         stdout_holder.append(proc.stdout.read().decode("utf-8", errors="replace"))
 
+    def _heartbeat() -> None:
+        """Emit a 'still working' line when git has been silent past the
+        threshold. Includes pack-dir size + delta when ``progress_dir``
+        is set so the user sees actual download progress during the
+        promisor blob fetch (which is otherwise invisible)."""
+        last_bytes: int | None = None
+        # Poll faster than the threshold so we notice stalls within
+        # roughly one threshold period, not two. Capped at 1s so quick
+        # commands don't pay any noticeable thread-wakeup overhead.
+        poll = min(1.0, _STALL_HEARTBEAT_SECS / 3)
+        while not proc_done.wait(poll):
+            silent_for = time.monotonic() - last_output_at[0]
+            if silent_for < _STALL_HEARTBEAT_SECS:
+                continue
+            size_note = ""
+            if progress_dir is not None:
+                current = _pack_dir_bytes(progress_dir)
+                current_mb = current / (1024 * 1024)
+                if last_bytes is not None:
+                    delta_mb = (current - last_bytes) / (1024 * 1024)
+                    size_note = (
+                        f", {current_mb:.0f} MB on disk "
+                        f"({delta_mb:+.1f} MB since last tick)"
+                    )
+                else:
+                    size_note = f", {current_mb:.0f} MB on disk"
+                last_bytes = current
+            _log(f"still working… ({silent_for:.0f}s silent{size_note})")
+            # Reset so the next heartbeat fires at a regular cadence
+            # instead of every second once silent_for > threshold.
+            last_output_at[0] = time.monotonic()
+
     t_err = threading.Thread(target=_drain_stderr, daemon=True)
     t_out = threading.Thread(target=_drain_stdout, daemon=True)
+    t_heartbeat = threading.Thread(target=_heartbeat, daemon=True)
     t_err.start()
     t_out.start()
+    t_heartbeat.start()
     proc.wait()
+    proc_done.set()
     t_err.join()
     t_out.join()
+    t_heartbeat.join()
 
     stdout = stdout_holder[0] if stdout_holder else ""
     if proc.returncode != 0:
@@ -221,10 +305,14 @@ def ensure_clone(url: str, branch: str | None = None) -> Path:
       - CloneError          — any other git failure (auth, ssl, etc.)
     """
     target = clone_dir_for(url, branch)
+    pack_dir = target / ".git" / "objects" / "pack"
     if target.exists():
         try:
             _log(f"fetching updates for {url}")
-            _run_git_streaming("fetch", "--prune", "--progress", "origin", cwd=target)
+            _run_git_streaming(
+                "fetch", "--prune", "--progress", "origin",
+                cwd=target, progress_dir=pack_dir,
+            )
             ref = f"origin/{branch}" if branch else f"origin/{_resolve_default_branch(target)}"
             _log(f"resetting to {ref}")
             _run_git("reset", "--hard", ref, cwd=target)
@@ -253,7 +341,7 @@ def ensure_clone(url: str, branch: str | None = None) -> Path:
         args += ["--branch", branch]
     args += ["--", url, str(target)]
     try:
-        _run_git_streaming(*args)
+        _run_git_streaming(*args, progress_dir=pack_dir)
         _log("clone complete")
     except CloneError as e:
         # First-clone failure: nuke the partial directory before re-raising,

--- a/codecity/tests/test_clone.py
+++ b/codecity/tests/test_clone.py
@@ -7,8 +7,10 @@ the user's real ``~/.cache/codecity/``.
 
 from __future__ import annotations
 
+import io
 import os
 import subprocess
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -297,6 +299,116 @@ class EnsureCloneErrorRoutingTests(unittest.TestCase):
                 target.exists(),
                 "update-path failure removed the existing clone directory",
             )
+
+
+class _SilentFakeProc:
+    """subprocess.Popen stand-in whose stderr/stdout return EOF
+    immediately but whose wait() blocks for ``runtime`` seconds. Mimics
+    the real-world failure mode the watchdog exists to surface: a git
+    sub-process that's doing work (pack download) but emitting nothing
+    to stderr."""
+
+    returncode = 0
+
+    def __init__(self, runtime: float) -> None:
+        self.stdout = io.BytesIO(b"")
+        self.stderr = io.BytesIO(b"")
+        self._done = threading.Event()
+        threading.Timer(runtime, self._done.set).start()
+
+    def wait(self) -> int:
+        self._done.wait()
+        return 0
+
+
+class StallWatchdogTests(unittest.TestCase):
+    def test_pack_dir_bytes_sums_top_level_files(self) -> None:
+        with TemporaryDirectory() as td:
+            pack = Path(td) / "pack"
+            pack.mkdir()
+            (pack / "pack-aaa.pack").write_bytes(b"x" * 1500)
+            (pack / "pack-aaa.idx").write_bytes(b"y" * 500)
+            self.assertEqual(clone_mod._pack_dir_bytes(pack), 2000)
+
+    def test_pack_dir_bytes_missing_dir_returns_zero(self) -> None:
+        # The .git/objects/pack dir doesn't exist for the first ~second
+        # of a clone; helper must not raise.
+        self.assertEqual(
+            clone_mod._pack_dir_bytes(Path("/nonexistent/path/xyz")), 0
+        )
+
+    def test_heartbeat_fires_when_subprocess_is_silent(self) -> None:
+        """Watchdog emits 'still working' line when stderr is quiet past
+        the threshold. This is the protection against the
+        --filter=blob:none silent-blob-fetch UX bug."""
+        captured: list[str] = []
+        fake = _SilentFakeProc(runtime=0.6)
+        with mock.patch.object(clone_mod, "_STALL_HEARTBEAT_SECS", 0.15):
+            with mock.patch.object(clone_mod, "_log", side_effect=captured.append):
+                with mock.patch.object(subprocess, "Popen", return_value=fake):
+                    clone_mod._run_git_streaming("ignored")
+        heartbeats = [m for m in captured if "still working" in m]
+        self.assertGreaterEqual(
+            len(heartbeats), 1,
+            f"expected at least one heartbeat; got: {captured}",
+        )
+
+    def test_heartbeat_includes_pack_size_when_progress_dir_set(self) -> None:
+        """When progress_dir is provided, heartbeat surfaces pack-dir
+        bytes so the user sees download progress during silent fetch."""
+        captured: list[str] = []
+        with TemporaryDirectory() as td:
+            pack = Path(td) / "pack"
+            pack.mkdir()
+            (pack / "pack-xyz.pack").write_bytes(b"z" * 3 * 1024 * 1024)  # 3 MB
+
+            fake = _SilentFakeProc(runtime=0.5)
+            with mock.patch.object(clone_mod, "_STALL_HEARTBEAT_SECS", 0.15):
+                with mock.patch.object(clone_mod, "_log", side_effect=captured.append):
+                    with mock.patch.object(subprocess, "Popen", return_value=fake):
+                        clone_mod._run_git_streaming("ignored", progress_dir=pack)
+
+        heartbeats = [m for m in captured if "still working" in m]
+        self.assertTrue(heartbeats, f"no heartbeat fired; got: {captured}")
+        # First heartbeat reports current size (no delta yet).
+        self.assertIn("3 MB on disk", heartbeats[0])
+
+    def test_heartbeat_suppressed_when_subprocess_chats(self) -> None:
+        """A subprocess that produces output and exits promptly should
+        NOT trigger heartbeats — the watchdog only fires during silence.
+        Simulates a small clone that finishes naturally."""
+        class ChattyFakeProc:
+            returncode = 0
+
+            def __init__(self) -> None:
+                lines = b"\n".join(
+                    f"Resolving deltas: {p}%".encode() for p in range(0, 100, 10)
+                ) + b"\n"
+                self.stdout = io.BytesIO(b"")
+                self.stderr = io.BytesIO(lines)
+                self._done = threading.Event()
+                # Exit before the silent gap exceeds the heartbeat
+                # threshold (0.15s). Mirrors a real fast clone where
+                # stderr finishes a few ms before proc.wait returns.
+                threading.Timer(0.05, self._done.set).start()
+
+            def wait(self) -> int:
+                self._done.wait()
+                return 0
+
+        captured: list[str] = []
+        with mock.patch.object(clone_mod, "_STALL_HEARTBEAT_SECS", 0.15):
+            with mock.patch.object(clone_mod, "_log", side_effect=captured.append):
+                with mock.patch.object(subprocess, "Popen", return_value=ChattyFakeProc()):
+                    clone_mod._run_git_streaming("ignored")
+
+        heartbeats = [m for m in captured if "still working" in m]
+        self.assertEqual(
+            len(heartbeats), 0,
+            f"watchdog fired during active output: {captured}",
+        )
+        git_lines = [m for m in captured if "Resolving deltas" in m]
+        self.assertEqual(len(git_lines), 10, f"missing git lines: {captured}")
 
 
 if __name__ == "__main__":

--- a/justfile
+++ b/justfile
@@ -5,5 +5,5 @@ setup:
     uv sync
     cd web && npm install
 
-dev:
+dev: setup
     uv run codecity --dev


### PR DESCRIPTION
## Summary

- Large `--filter=blob:none` clones (e.g. `https://github.com/Infisical/infisical`) appeared to hang at `Resolving deltas: 100% done` for many minutes. Root cause: git's on-demand promisor fetch — kicked off internally to materialize the working tree — doesn't inherit `--progress`, so codecity was forwarding silence for the entire blob-download phase.
- Added a stall watchdog to `_run_git_streaming` that emits `[clone] still working… (Xs silent, N MB on disk (+M MB since last tick))` every ~5s when git falls silent. Surfaces actual download throughput via pack-dir size sampling.
- Bonus: `just dev` now depends on `just setup` so a fresh checkout doesn't try to run with stale deps.

## Test plan

- [x] All 220 existing tests still pass
- [x] 5 new tests cover: `_pack_dir_bytes` sums + missing dir, heartbeat fires on silence, heartbeat includes pack size, heartbeat suppressed during active output
- [x] End-to-end verified against `https://github.com/Infisical/infisical` — heartbeats fired throughout the previously-silent ~7 minute blob-fetch phase, showing live MB/s growth from 47 MB → 1012 MB, then `Updating files: …` → `clone complete` → success

Example output during the formerly-silent phase:
```
[clone] Resolving deltas: 100% (186902/186902), done.
[clone] still working… (5s silent, 47 MB on disk)
[clone] still working… (5s silent, 58 MB on disk (+11.4 MB since last tick))
[clone] still working… (5s silent, 67 MB on disk (+9.3 MB since last tick))
…
[clone] still working… (5s silent, 1012 MB on disk (+17.6 MB since last tick))
[clone] Updating files: 100% (12003/12003), done.
[clone] clone complete
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)