### PR TITLE
feat(web): R and gem reset view only; centralize resetView

### DIFF
--- a/web/src/constants/keyboard.ts
+++ b/web/src/constants/keyboard.ts
@@ -14,8 +14,9 @@ export interface KeyBinding {
 }
 
 export const KEY_BINDINGS: Record<string, KeyBinding> = {
-  /** Refresh — rebuild the city manifest AND reset the camera framing.
-   *  Mirrors the header gem button and clicking the gem in the city. */
+  /** Reset the camera framing to the current mode's default pose.
+   *  Mirrors the header gem button and clicking the gem in the city.
+   *  Does NOT rebuild the city manifest — reload the page for that. */
   RESET_VIEW: { label: 'R', keys: ['r', 'R', 'Home'] },
   /** Focus camera on the current selection. */
   FOCUS_SELECTION: { label: 'F', keys: ['f', 'F'] },

--- a/web/src/coordinator.ts
+++ b/web/src/coordinator.ts
@@ -27,7 +27,6 @@ import {
   REBUILD_STATUS,
   LAST_REBUILD_ERROR,
   LAST_UPDATED_AT,
-  refreshManifest,
 } from './store/liveStatus.js';
 import { DateSource, NodeKind } from './types';
 import type { DirNode, FileNode, PickTarget, TreeNode } from './types';
@@ -41,10 +40,13 @@ interface CoordinatorOpts {
   picker: ReturnType<typeof createPicker>;
   rig: ReturnType<typeof createCameraRig>;
   flyControls: ReturnType<typeof createFlyControls>;
+  /** Mode-aware reset for the camera. Forwarded to the header gem button so
+   *  it stays consistent with the R key and the in-scene gem click. */
+  resetView: () => void;
   applyTheme: () => void;
 }
 
-export function createCoordinator({ world, picker, rig, flyControls, applyTheme }: CoordinatorOpts) {
+export function createCoordinator({ world, picker, rig, flyControls, resetView, applyTheme }: CoordinatorOpts) {
   // Right sidebar opens on file selection and closes via its × button.
   // The previous header-toggle was removed, so the boot state is simply
   // "closed" — the first file selection will open it.
@@ -112,14 +114,7 @@ export function createCoordinator({ world, picker, rig, flyControls, applyTheme 
       const fn = (window as Window & { __openSourcePicker?: () => void }).__openSourcePicker;
       fn?.();
     },
-    // Refresh button (header far left) — equivalent of a page reload:
-    // kicks off a manifest re-fetch / rebuild AND resets the camera to
-    // its default pose. refreshManifest is async; we don't await it here
-    // because REBUILD_STATUS already reflects the in-flight state.
-    onRefresh() {
-      void refreshManifest();
-      rig.reset();
-    },
+    onResetView: resetView,
     // Focus button next to the selected path — mirrors pressing F on the
     // canvas. Looks at the current picker selection and dispatches the
     // matching camera-rig call.

--- a/web/src/scene/renderLoop.ts
+++ b/web/src/scene/renderLoop.ts
@@ -18,7 +18,6 @@ import {
   GEM_SIZING,
   BLOOM,
 } from '../config/index.js';
-import { refreshManifest } from '../store/liveStatus.js';
 import { NodeKind, StreetAxis } from '../types';
 import type { Manifest } from '../types';
 
@@ -111,6 +110,18 @@ export async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manif
     world,
   });
 
+  // Single mode-aware reset shared by every entry point: R key, header gem
+  // button, in-scene gem click/dblclick. In orbit mode resets the rig; in
+  // fly mode returns the fly camera to its default pose. Does NOT rebuild
+  // the city manifest — a page reload is required for that.
+  function resetView(): void {
+    if (flyControls.isActive()) {
+      flyControls.resetToDefault();
+    } else {
+      rig.reset();
+    }
+  }
+
   // -- 4b. Post-processing -----------------------------------------------------
   // UnrealBloomPass on top of the main render so emissive windows actually
   // glow into the surrounding pixels (cyberpunk neon look). Cost is screen-
@@ -168,6 +179,7 @@ export async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manif
     picker,
     rig,
     flyControls,
+    resetView,
     applyTheme,
   });
 
@@ -348,18 +360,7 @@ export async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manif
       // must match animate() so bloom shows immediately on the new size.
       postFx.render();
     },
-    // Same action as the header gem button: rebuild the manifest +
-    // reset the camera to the current mode's default pose. Fired by R,
-    // by clicking the root gem mesh in the scene, and by the header
-    // refresh button.
-    onRefresh() {
-      void refreshManifest();
-      if (flyControls.isActive()) {
-        flyControls.resetToDefault();
-      } else {
-        rig.reset();
-      }
-    },
+    onResetView: resetView,
     getRootName: () => world.getRoot()?.name ?? null,
   });
 

--- a/web/src/scene/system/inputHandlers.ts
+++ b/web/src/scene/system/inputHandlers.ts
@@ -28,7 +28,7 @@ export function createInputHandlers({
   showTooltip,
   hideTooltip,
   onResize,
-  onRefresh,
+  onResetView,
   getRootName,
 }: {
   canvas: HTMLCanvasElement;
@@ -40,11 +40,10 @@ export function createInputHandlers({
   showTooltip: (text: string, x: number, y: number) => void;
   hideTooltip: () => void;
   onResize: () => void;
-  /** Refresh action triggered by R / gem-click in ORBIT mode only.
-   *  Rebuilds the manifest and resets the orbit camera. Fly mode
-   *  routes those same gestures to flyControls.resetToDefault()
-   *  instead — no manifest refresh, no orbit reset. */
-  onRefresh: () => void;
+  /** Reset-view action triggered by R / gem-click. In orbit mode this
+   *  resets the camera; in fly mode it routes to flyControls.resetToDefault().
+   *  Does NOT rebuild the manifest — a page reload is required for that. */
+  onResetView: () => void;
   /** Resolve the current root directory name for hover-tooltip prefixing.
    * Called lazily on each hover so it stays in sync after manifest reloads. */
   getRootName: () => string | null;
@@ -179,10 +178,10 @@ export function createInputHandlers({
     }
     if (hit.object.userData.type === NodeKind.Gem) {
       picker.setSelection(null);
-      // Gem click = refresh + reset, same as the R key and the header
-      // refresh button. The mode-aware reset (orbit reset vs fly-mode
-      // resetToDefault) is decided inside onRefresh.
-      onRefresh();
+      // Gem click = reset view, same as the R key and the header gem
+      // button. The mode-aware reset (orbit reset vs fly-mode
+      // resetToDefault) is decided inside onResetView.
+      onResetView();
       return;
     }
     // Clicking the currently-selected building/street is a no-op — matches
@@ -200,7 +199,7 @@ export function createInputHandlers({
     if (!hit) return;
     const ud = hit.object.userData;
     if (ud.type === NodeKind.Gem) {
-      onRefresh();
+      onResetView();
       return;
     }
     // Route through picker.interpretHit so InstancedMesh hits resolve to a
@@ -299,8 +298,9 @@ export function createInputHandlers({
       picker.setSelection(null);
       picker.setHover(null);
     } else if (KEY_BINDINGS.RESET_VIEW.keys.includes(ev.key)) {
-      // Same behaviour in both modes: refresh + reset to current-mode default.
-      onRefresh();
+      // Same behaviour in both modes: reset to current-mode default. No
+      // manifest rebuild — reload the page for that.
+      onResetView();
     } else if (KEY_BINDINGS.FOCUS_SELECTION.keys.includes(ev.key)) {
       const sel = picker.selection.get();
       if (!sel) return;

--- a/web/src/views/panes/controlsPane.ts
+++ b/web/src/views/panes/controlsPane.ts
@@ -244,7 +244,7 @@ function _buildShortcutsSection(): HTMLElement {
   );
   section.appendChild(
     _subgroup('General', _buildShortcutsList([
-      { kbd: [KEY_BINDINGS.RESET_VIEW.label], action: 'Refresh — rebuild the city and reset the view' },
+      { kbd: [KEY_BINDINGS.RESET_VIEW.label], action: 'Reset the camera view' },
       { kbd: [KEY_BINDINGS.FOCUS_SELECTION.label], action: 'Focus camera on the current selection' },
       { kbd: [KEY_BINDINGS.CLEAR_SELECTION.label], action: 'Clear selection' },
       { kbd: [KEY_BINDINGS.TOGGLE_FLY_MODE.label], action: 'Toggle fly mode' },

--- a/web/src/views/shell/appHeader.ts
+++ b/web/src/views/shell/appHeader.ts
@@ -32,8 +32,11 @@ interface InitAppHeaderOpts {
   onSegmentClick?: ((path: string) => void) | null;
   /** fires when the user clicks the project button in the header */
   onSwitchSource?: () => void;
-  /** fires when the user clicks the refresh button in the header (far left) */
-  onRefresh?: () => void;
+  /** Fires when the user clicks the reset-view (gem) button in the header
+   *  (far left). Mirrors the R keyboard shortcut and clicking the gem in
+   *  the city. Caller must pass the same mode-aware reset function used by
+   *  the canvas-side input handlers, so all entry points stay consistent. */
+  onResetView?: () => void;
   /** fires when the user clicks the focus button next to the selected path —
    *  mirrors pressing F on the canvas. Caller looks at the current selection
    *  and calls rig.focusBuilding / rig.focusStreet as appropriate. */
@@ -48,7 +51,7 @@ interface InitAppHeaderOpts {
 
 /**
  * Initialise the sitewide header. Layout (left → right):
- *   refresh (gem) icon button   — far left
+ *   reset-view (gem) icon button   — far left
  *   project button (icon + label + @branch pill)
  *   repo link icon (if git url)
  *   #app-title slot (chip + path segments + copy) — empty at root
@@ -58,7 +61,7 @@ interface InitAppHeaderOpts {
  * extension hue or the asphalt color in Controls live-repaints the badge.
  */
 export function initAppHeader(opts: InitAppHeaderOpts = {}) {
-  const { rootLabel = '', rootPath = '', onSegmentClick = null, onSwitchSource, onRefresh, onFocus, onToggleFly } = opts;
+  const { rootLabel = '', rootPath = '', onSegmentClick = null, onSwitchSource, onResetView, onFocus, onToggleFly } = opts;
 
   const titleEl = document.getElementById('app-title');
   if (!titleEl) {
@@ -312,19 +315,19 @@ export function initAppHeader(opts: InitAppHeaderOpts = {}) {
     _syncRepoLink();
   }
 
-  // Refresh button — sits at the FAR LEFT of the header row, prepended
+  // Reset-view button — sits at the FAR LEFT of the header row, prepended
   // before the project button. Same action as the R keyboard shortcut
-  // and as clicking the gem in the city: rebuild the manifest and
-  // reset the camera view.
-  if (onRefresh) {
+  // and as clicking the gem in the city: reset the camera view. Does NOT
+  // rebuild the city — reload the page for that.
+  if (onResetView) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'btn-icon btn-icon--no-drag btn-icon--rainbow';
-    btn.title = 'Refresh — rebuild the city and reset the view (R)';
-    btn.setAttribute('aria-label', 'Refresh');
+    btn.title = 'Reset view (R)';
+    btn.setAttribute('aria-label', 'Reset view');
     btn.appendChild(makeLucideIcon('gem'));
     btn.dataset.appHeaderInjected = '1';
-    btn.addEventListener('click', () => onRefresh());
+    btn.addEventListener('click', () => onResetView());
     titleEl.parentElement?.prepend(btn);
   }
 

--- a/web/tests/views/sourcePicker.test.ts
+++ b/web/tests/views/sourcePicker.test.ts
@@ -44,6 +44,8 @@ describe('sourcePicker', () => {
     const onSubmit = vi.fn();
     const p = createSourcePicker({ onSubmit });
     p.open();
+    // Default tab is "git"; switch to local before setting the path field.
+    (root.querySelector('[data-tab="local"]') as HTMLButtonElement).click();
     const input = root.querySelector('[data-field="path"]') as HTMLInputElement;
     input.value = '/Users/foo/bar';
     (root.querySelector('button.submit') as HTMLButtonElement).click();


### PR DESCRIPTION
## Summary
- **R key, header gem button, and clicking the in-scene gem now only reset the camera view** — no manifest rebuild. Page reload is required to rebuild the city.
- **Centralizes** the reset into a single mode-aware `resetView()` in `renderLoop`, shared by all three entry points. Fixes a quiet inconsistency where the header gem button bypassed fly-mode handling (called `rig.reset()` directly instead of `flyControls.resetToDefault()`).
- **Renames** `onRefresh` → `onResetView` across `appHeader`, `coordinator`, `renderLoop`, `inputHandlers` to match the new behavior. Updates button title/aria-label to "Reset view" and the Controls pane help row.
- **Drive-by:** fixes a pre-existing test failure in `sourcePicker.test.ts` — commit e54d6be moved the default tab to "git", which made the local-path submit test silently no-op.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 1878/1878 pass
- [ ] In a browser, in **orbit** mode: press R, click the header gem, click the in-scene gem — all three only reset the camera, no rebuild flash
- [ ] In a browser, in **fly** mode: same three gestures should all call `flyControls.resetToDefault()` (previously the header gem incorrectly orbit-reset)
- [ ] Verify the Controls pane shortcut list reads "Reset the camera view" for R

🤖 Generated with [Claude Code](https://claude.com/claude-code)