### PR TITLE
fix(api): scan.py — bypass git safe.directory so CI doesn't return empty manifests

### DIFF
--- a/api/scan.py
+++ b/api/scan.py
@@ -158,10 +158,21 @@ def _line_count(path: Path) -> int:
 
 
 def _run_git(root: Path, *args: str) -> str:
-    """Run git with CWD=root, return stdout. Empty string on failure."""
+    """Run git with CWD=root, return stdout. Empty string on failure.
+
+    Includes ``-c safe.directory=*`` so the scanner can read repos
+    whose ownership doesn't match the process uid — common in CI /
+    container setups where the bind-mounted workspace is owned by a
+    different user than the one running pytest. Without this, git
+    2.35+ refuses with "dubious ownership" and we silently get an
+    empty stdout, which manifests downstream as an empty manifest
+    (0 tracked files, 0 commits). codecity intentionally scans
+    arbitrary repos, so disabling the check globally for this
+    invocation is appropriate.
+    """
     try:
         return subprocess.run(
-            ["git", "-C", str(root), *args],
+            ["git", "-c", "safe.directory=*", "-C", str(root), *args],
             capture_output=True,
             text=True,
             check=False,
@@ -225,7 +236,8 @@ def _collect_git_dates_windowed(
     """
     window = _git_history_window(git_window)
     _log(f"  starting git log walk (--since={window or 'ALL'})…")
-    log_argv = ["git", "-C", str(root), "log",
+    # See _run_git docstring for why -c safe.directory=* is needed.
+    log_argv = ["git", "-c", "safe.directory=*", "-C", str(root), "log",
                 "--format=COMMIT:%aI%x09%H",
                 "--name-status",
                 "--no-renames",

--- a/api/tests/test_scan.py
+++ b/api/tests/test_scan.py
@@ -591,9 +591,14 @@ class GitMetadataParallelTests(_CacheRedirectMixin, unittest.TestCase):
         log_calls: list[list[str]] = []
 
         def _record_if_git_log(args) -> None:
+            # Match any invocation that runs `git ... log ...`. _run_git
+            # prepends `-c safe.directory=*` (and the log path also does
+            # so), so we can't assume a fixed position for "log" — just
+            # check the binary name and that "log" appears as a token.
             if (
                 isinstance(args, list)
-                and args[:2] == ["git", "-C"]
+                and len(args) > 0
+                and args[0] == "git"
                 and "log" in args
             ):
                 log_calls.append(list(args))


### PR DESCRIPTION
## Summary
- CI's pytest job has been failing on five `test_scan.py` tests ever since `5c1ad90` — each asserting that the scanner returns a non-empty manifest for the `sample-repo` fixture, but getting 0 files / 0 commits back.
- Root cause: `_run_git` invokes `git` against the fixture and captures only stdout with `check=False`. In containers where the workspace's uid doesn't match the process uid (GitHub Actions runners hit this), git 2.35+ refuses with "fatal: detected dubious ownership" on stderr — the function silently returns empty stdout, downstream code treats the repo as having no tracked files / no commits, and the manifest reports 0 descendants for a fixture that has 9 files.
- Fix: pass `-c safe.directory=*` to every git invocation in `scan.py` (`_run_git` + the streaming `git log` Popen). codecity intentionally scans arbitrary external repos; disabling the ownership check for these read-only operations is correct semantically.
- One existing test (`test_single_walk_invocation`) asserted git's argv started with `["git", "-C", ...]`; loosened the predicate to match the new `["git", "-c", "safe.directory=*", "-C", ...]` shape.

## Test plan
- [x] `docker compose -f docker-compose.test.yml run --rm pytest` → 230 passed, 0 failed locally.
- [ ] CI green on this PR (will be the empirical check that the safe.directory hypothesis was right).

This same fix is also included in #37 (the floating repo-label feature PR) so that PR's CI passes too. When this lands, the duplicate commit in #37 will fall out on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)