### PR TITLE
Tree hover/select outline (replaces canopy color inversion)

### DIFF
--- a/app/src/config/components/trees.ts
+++ b/app/src/config/components/trees.ts
@@ -139,3 +139,22 @@ export const TREES = map<TreesConfig>({
   TREE_AGE_SATURATION_MIN: 50,
   TREE_AGE_SATURATION_MAX: 100,
 });
+
+// ─── Hover / select wireframe outlines ─────────────────────────────────────
+// Two persistent LineSegments2 meshes (hover + selected) snap to the active
+// tree's transform per frame — see scene/effects/treeOutlineRenderer.ts.
+// One shared WIDTH for both; hover/selected differentiate via color (white for
+// hover, animated rainbow for selected via RAINBOW). Mirrors BUILDING_OUTLINE.
+export interface TreeOutlineConfig {
+  WIDTH: number;
+  HOVER_COLOR: string;
+  HOVER_OPACITY: number;
+  SELECTED_OPACITY: number;
+}
+
+export const TREE_OUTLINE = map<TreeOutlineConfig>({
+  WIDTH: 3,
+  HOVER_COLOR: '#ffffff',
+  HOVER_OPACITY: 0.5,
+  SELECTED_OPACITY: 1.0,
+});

--- a/app/src/constants/render.ts
+++ b/app/src/constants/render.ts
@@ -41,4 +41,11 @@ export const RENDER_ORDERS = {
   // Foliage (matte tree canopies + trunks) draws after the city.
   // Depth-tested normally so buildings occlude foliage that's behind them.
   PARK_FOLIAGE: 10,
+  // Tree outlines — must draw above PARK_FOLIAGE so the wireframe reads
+  // on top of the canopy. Hover beneath selected so a tree that is both
+  // hovered and selected (rare; coordinator dedup already prevents it for
+  // buildings — see comments in outlineRenderer.ts) shows the selected
+  // rainbow on top.
+  HOVER_TREE_OUTLINE: 11,
+  SELECTED_TREE_OUTLINE: 12,
 } as const;

--- a/app/src/coordinator.ts
+++ b/app/src/coordinator.ts
@@ -359,12 +359,6 @@ export function createCoordinator({
     // hover is active the hover subscriber already owns the footer.
     _updateFooterFromState();
 
-    // Tree canopy selection tint.
-    const trees = world.getTrees();
-    if (trees) {
-      trees.setSelectionSha(sel && sel.kind === NodeKind.Commit ? sel.commit.sha : null);
-    }
-
     // Right sidebar pane choice mirrors selection kind. File → preview,
     // Commit → commit pane, anything else closes the sidebar.
     if (sel && sel.kind === NodeKind.File) sidebarPane = 'file';
@@ -382,12 +376,6 @@ export function createCoordinator({
     // Footer follows hover in real time; when hover clears (h === null)
     // _updateFooterFromState falls back to the current selection.
     _updateFooterFromState();
-
-    // Tree canopy hover tint.
-    const trees = world.getTrees();
-    if (trees) {
-      trees.setHoverSha(h && h.kind === NodeKind.Commit ? h.commit.sha : null);
-    }
   });
 
   // Push the freshly-applied manifest into the Info pane so an edited

--- a/app/src/scene/components/trees/treeRenderer.ts
+++ b/app/src/scene/components/trees/treeRenderer.ts
@@ -69,6 +69,11 @@ export interface Trees {
   /** Set which sha is currently selected (null clears). Repaints that
    *  tree's canopy with the same inverse treatment as hover. */
   setSelectionSha(sha: string | null): void;
+  /** Write the canopy instance matrix for `sha` into `out`. Returns true
+   *  when a tree was found, false otherwise. Used by treeOutlineRenderer
+   *  to snap the hover/selected outline mesh's transform to the active
+   *  tree without an extra Matrix4 allocation per frame. */
+  getInstanceTransform(sha: string, out: THREE.Matrix4): boolean;
 }
 
 /** Minimum sRGB luminance gap between base and inverse. If the raw RGB
@@ -85,6 +90,26 @@ type DetailLevel = (typeof DETAIL_LEVELS)[number];
 function setColorFromHex(target: THREE.Color, hex: string): void {
   target.setStyle(hex, THREE.LinearSRGBColorSpace);
 }
+
+/** Lathe control points for the canopy silhouette: hand-picked (radius, height)
+ *  pairs producing a low-poly Christmas-tree shape. Bottom→top. Both axes
+ *  normalized to [0,1] so a single profile drives any detail tier. Shared by
+ *  `buildCanopyGeometry` (the rendered canopy) and `buildCanopyEdges` (the
+ *  outline wireframe) — keep these two in sync. */
+const CANOPY_PROFILE: readonly THREE.Vector2[] = [
+  new THREE.Vector2(0, 0),
+  new THREE.Vector2(0.85, 0),
+  new THREE.Vector2(1.0, 0.1),
+  new THREE.Vector2(0.95, 0.25),
+  new THREE.Vector2(0.82, 0.42),
+  new THREE.Vector2(0.66, 0.58),
+  new THREE.Vector2(0.5, 0.72),
+  new THREE.Vector2(0.36, 0.82),
+  new THREE.Vector2(0.24, 0.89),
+  new THREE.Vector2(0.14, 0.94),
+  new THREE.Vector2(0.06, 0.98),
+  new THREE.Vector2(0, 1.0),
+];
 
 /** Build a unit-height (Y ∈ [0,1]), unit-radius teardrop canopy
  *  geometry at the given subdivision detail.
@@ -111,28 +136,7 @@ function buildCanopyGeometry(detail: DetailLevel): THREE.BufferGeometry {
   //     A lathe profile must converge to a point on the axis, but
   //     dense vertical samples near the apex make the silhouette read
   //     as a smooth dome rather than a sharp spike.
-  // CANOPY_PROFILE: control points (radius, height) for the lathe.
-  // Hand-picked by eye to produce a low-poly Christmas-tree silhouette
-  // — there's no formula, each point sculpts the curve in a chosen
-  // place. Both axes are normalized to [0,1] (radius 1 = world radius
-  // `r`, height 1 = world height `h`) so the renderer can scale a
-  // single shared geometry per detail level. Insertion order = bottom
-  // → top.
-  const CANOPY_PROFILE: THREE.Vector2[] = [
-    new THREE.Vector2(0, 0), // axis — caps the base
-    new THREE.Vector2(0.85, 0), // bottom rim (slightly inset)
-    new THREE.Vector2(1.0, 0.1), // widest, just above the base
-    new THREE.Vector2(0.95, 0.25),
-    new THREE.Vector2(0.82, 0.42),
-    new THREE.Vector2(0.66, 0.58),
-    new THREE.Vector2(0.5, 0.72),
-    new THREE.Vector2(0.36, 0.82),
-    new THREE.Vector2(0.24, 0.89), // upper shoulder
-    new THREE.Vector2(0.14, 0.94), // dense samples
-    new THREE.Vector2(0.06, 0.98), // near-apex
-    new THREE.Vector2(0, 1.0), // apex
-  ];
-  const profile = CANOPY_PROFILE;
+  const profile = CANOPY_PROFILE as THREE.Vector2[];
   const cfg = TREES.get();
   const segments =
     detail === 0 ? cfg.TREE_FACETS_LOW : detail === 1 ? cfg.TREE_FACETS_MID : cfg.TREE_FACETS_HIGH;
@@ -143,6 +147,31 @@ function buildCanopyGeometry(detail: DetailLevel): THREE.BufferGeometry {
   geom.dispose();
   flat.computeVertexNormals();
   return flat;
+}
+
+/** Build a clean wireframe `EdgesGeometry` for the canopy silhouette at
+ *  the given detail level. Uses the SAME profile + segment count as
+ *  `buildCanopyGeometry`, but on the indexed lathe (no `toNonIndexed`)
+ *  so adjacent triangles share vertex normals — that lets `EdgesGeometry`
+ *  collapse coplanar interior edges and emit only the ring boundaries.
+ *
+ *  Consumed by `scene/effects/treeOutlineRenderer.ts`. */
+export function buildCanopyEdges(detail: DetailLevel): THREE.EdgesGeometry {
+  const cfg = TREES.get();
+  const segments =
+    detail === 0
+      ? cfg.TREE_FACETS_LOW
+      : detail === 1
+        ? cfg.TREE_FACETS_MID
+        : cfg.TREE_FACETS_HIGH;
+  const lathe = new THREE.LatheGeometry(CANOPY_PROFILE as THREE.Vector2[], segments);
+  // Default 1° threshold keeps any edge whose adjacent face normals differ
+  // by >1° — for the canopy this means ring boundaries (profile slope
+  // changes) plus the lathe's wrap seam. The result reads as a wireframe
+  // silhouette covering both the outer outline and a few interior facet rings.
+  const edges = new THREE.EdgesGeometry(lathe, 1);
+  lathe.dispose();
+  return edges;
 }
 
 /** Bake per-vertex color attribute on a unit-height canopy geometry.
@@ -501,6 +530,13 @@ export function createTreeRenderer(
     return _treeIndexBySha.get(sha) ?? null;
   }
 
+  function getInstanceTransform(sha: string, out: THREE.Matrix4): boolean {
+    const idx = _treeIndexBySha.get(sha);
+    if (!idx) return false;
+    idx.mesh.getMatrixAt(idx.instanceId, out);
+    return true;
+  }
+
   function colorForSha(sha: string): string | null {
     return _baseColorBySha.get(sha) ?? null;
   }
@@ -595,6 +631,7 @@ export function createTreeRenderer(
     dispose,
     commitForInstance,
     findTreeBySha,
+    getInstanceTransform,
     colorForSha,
     setHoverSha,
     setSelectionSha,

--- a/app/src/scene/components/trees/treeRenderer.ts
+++ b/app/src/scene/components/trees/treeRenderer.ts
@@ -148,11 +148,7 @@ function buildCanopyGeometry(detail: DetailLevel): THREE.BufferGeometry {
 export function buildCanopyEdges(detail: DetailLevel): THREE.EdgesGeometry {
   const cfg = TREES.get();
   const segments =
-    detail === 0
-      ? cfg.TREE_FACETS_LOW
-      : detail === 1
-        ? cfg.TREE_FACETS_MID
-        : cfg.TREE_FACETS_HIGH;
+    detail === 0 ? cfg.TREE_FACETS_LOW : detail === 1 ? cfg.TREE_FACETS_MID : cfg.TREE_FACETS_HIGH;
   const lathe = new THREE.LatheGeometry(CANOPY_PROFILE as THREE.Vector2[], segments);
   // Default 1° threshold keeps any edge whose adjacent face normals differ
   // by >1° — for the canopy this means ring boundaries (profile slope

--- a/app/src/scene/components/trees/treeRenderer.ts
+++ b/app/src/scene/components/trees/treeRenderer.ts
@@ -63,23 +63,12 @@ export interface Trees {
    *  the InstancedMesh that renders it. Returns a CSS hex string (e.g.
    *  "#5e8a3a") or null when the sha can't be found. */
   colorForSha(sha: string): string | null;
-  /** Set which sha is currently hovered (null clears). Repaints that
-   *  tree's canopy with a high-contrast inverse of its base color. */
-  setHoverSha(sha: string | null): void;
-  /** Set which sha is currently selected (null clears). Repaints that
-   *  tree's canopy with the same inverse treatment as hover. */
-  setSelectionSha(sha: string | null): void;
   /** Write the canopy instance matrix for `sha` into `out`. Returns true
    *  when a tree was found, false otherwise. Used by treeOutlineRenderer
    *  to snap the hover/selected outline mesh's transform to the active
    *  tree without an extra Matrix4 allocation per frame. */
   getInstanceTransform(sha: string, out: THREE.Matrix4): boolean;
 }
-
-/** Minimum sRGB luminance gap between base and inverse. If the raw RGB
- *  inverse lands closer than this (e.g. base near mid-gray), push the
- *  hover/selection toward black or white so contrast is guaranteed. */
-const INVERSE_MIN_LUMINANCE_DELTA = 0.4;
 
 /** Three subdivision tiers for the LatheGeometry canopy. File count
  *  drives which tier each tree lands in. Segment counts live in TREES
@@ -378,7 +367,7 @@ export function createTreeRenderer(
 
   // O(1) index from sha → canopy instance. Populated in the bake loop
   // alongside _baseColorBySha, cleared + rebuilt on refresh(). Lets
-  // findTreeBySha, _applyInverse, and _restoreBase skip nested loops.
+  // findTreeBySha and getInstanceTransform skip nested loops.
   const _treeIndexBySha = new Map<
     string,
     { mesh: THREE.InstancedMesh; instanceId: number; commit: CommitEntry }
@@ -494,12 +483,6 @@ export function createTreeRenderer(
       }
       if (rec.mesh.instanceColor) rec.mesh.instanceColor.needsUpdate = true;
     }
-
-    // Re-apply hover / selection tints after the base colors are baked.
-    // Apply hover first then selected so selected wins when both apply
-    // (currently the same paint, but priority still matters if they diverge).
-    if (_hoverSha) _applyInverse(_hoverSha);
-    if (_selectedSha) _applyInverse(_selectedSha);
   }
 
   function dispose(): void {
@@ -541,90 +524,6 @@ export function createTreeRenderer(
     return _baseColorBySha.get(sha) ?? null;
   }
 
-  // ── Hover / selection tint state machine ─────────────────────────────
-  const _tintTmp = new THREE.Color();
-  let _hoverSha: string | null = null;
-  let _selectedSha: string | null = null;
-
-  /** Paint the canopy with the sRGB inverse (1−r, 1−g, 1−b) of its base
-   *  color. If the inverse ends up too close in luminance to the base
-   *  (e.g. base near mid-gray), pull it halfway toward black or white so
-   *  contrast holds. Operating on sRGB hex bytes — not the linear-RGB
-   *  working space — matches what users perceive as "inverse" (the same
-   *  transform CSS `filter: invert()` applies).
-   *
-   *  Used for both hover and selection so the two states share one visual
-   *  treatment. Uses addUpdateRange for a partial GPU upload (3 floats
-   *  instead of the full buffer). */
-  function _applyInverse(sha: string): void {
-    const idx = _treeIndexBySha.get(sha);
-    if (!idx) return;
-    const hex = _baseColorBySha.get(sha);
-    if (!hex) return;
-    const baseR = parseInt(hex.slice(1, 3), 16) / 255;
-    const baseG = parseInt(hex.slice(3, 5), 16) / 255;
-    const baseB = parseInt(hex.slice(5, 7), 16) / 255;
-    let invR = 1 - baseR;
-    let invG = 1 - baseG;
-    let invB = 1 - baseB;
-    const baseLum = 0.2126 * baseR + 0.7152 * baseG + 0.0722 * baseB;
-    const invLum = 0.2126 * invR + 0.7152 * invG + 0.0722 * invB;
-    if (Math.abs(invLum - baseLum) < INVERSE_MIN_LUMINANCE_DELTA) {
-      const target = baseLum < 0.5 ? 1 : 0;
-      invR = invR * 0.5 + target * 0.5;
-      invG = invG * 0.5 + target * 0.5;
-      invB = invB * 0.5 + target * 0.5;
-    }
-    _tintTmp.setRGB(invR, invG, invB, THREE.SRGBColorSpace);
-    idx.mesh.setColorAt(idx.instanceId, _tintTmp);
-    const colorAttr = idx.mesh.instanceColor!;
-    colorAttr.addUpdateRange(idx.instanceId * 3, 3);
-    colorAttr.needsUpdate = true;
-  }
-
-  /** Restore the cached base color for the canopy instance of `sha`.
-   *  Uses addUpdateRange for a partial GPU upload. */
-  function _restoreBase(sha: string): void {
-    const idx = _treeIndexBySha.get(sha);
-    if (!idx) return;
-    const hex = _baseColorBySha.get(sha);
-    if (!hex) return;
-    _tintTmp.setStyle(hex, THREE.SRGBColorSpace);
-    idx.mesh.setColorAt(idx.instanceId, _tintTmp);
-    const colorAttr = idx.mesh.instanceColor!;
-    colorAttr.addUpdateRange(idx.instanceId * 3, 3);
-    colorAttr.needsUpdate = true;
-  }
-
-  /** Re-derive and apply whichever state is currently "winning" for `sha`.
-   *  Priority: selected > hovered > base. Hover and selection currently
-   *  share the same paint, but the priority ordering is preserved so the
-   *  two can diverge again without rewiring the state machine. */
-  function _applyStateFor(sha: string | null): void {
-    if (!sha) return;
-    if (sha === _selectedSha || sha === _hoverSha) {
-      _applyInverse(sha);
-    } else {
-      _restoreBase(sha);
-    }
-  }
-
-  function setHoverSha(sha: string | null): void {
-    if (sha === _hoverSha) return;
-    const prev = _hoverSha;
-    _hoverSha = sha;
-    _applyStateFor(prev);
-    _applyStateFor(sha);
-  }
-
-  function setSelectionSha(sha: string | null): void {
-    if (sha === _selectedSha) return;
-    const prev = _selectedSha;
-    _selectedSha = sha;
-    _applyStateFor(prev);
-    _applyStateFor(sha);
-  }
-
   return {
     group,
     refresh,
@@ -633,7 +532,5 @@ export function createTreeRenderer(
     findTreeBySha,
     getInstanceTransform,
     colorForSha,
-    setHoverSha,
-    setSelectionSha,
   };
 }

--- a/app/src/scene/components/trees/treeRenderer.ts
+++ b/app/src/scene/components/trees/treeRenderer.ts
@@ -361,8 +361,7 @@ export function createTreeRenderer(
 
   // Base color cache: keyed by commit SHA, value is the hex color string
   // (e.g. "#5e8a3a") computed during bake. Populated below and rebuilt
-  // on every refresh(). colorForSha reads from here, not the instance
-  // buffer, so hover/select tints never bleed into the returned value.
+  // on every refresh(). colorForSha reads from here, not the instance buffer.
   const _baseColorBySha = new Map<string, string>();
 
   // O(1) index from sha → canopy instance. Populated in the bake loop

--- a/app/src/scene/effects/treeOutlineRenderer.ts
+++ b/app/src/scene/effects/treeOutlineRenderer.ts
@@ -173,7 +173,7 @@ export function createTreeOutlineRenderer({ canvas, scene, picker, getTrees }: C
     const rb = RAINBOW.get();
     // One hue per segment, rotating around the silhouette over time.
     for (let i = 0; i < _selSegCount; i++) {
-      const hue = ((t + i / _selSegCount) % 1 + 1) % 1;
+      const hue = (((t + i / _selSegCount) % 1) + 1) % 1;
       _tmpHsl.setHSL(hue, rb.SATURATION, rb.LIGHTNESS);
       const k = i * 6;
       _selColorBuf[k] = _tmpHsl.r;

--- a/app/src/scene/effects/treeOutlineRenderer.ts
+++ b/app/src/scene/effects/treeOutlineRenderer.ts
@@ -1,0 +1,242 @@
+// scene/effects/treeOutlineRenderer.ts — owns:
+//   • the shared tree hover outline mesh (white LineSegments2 silhouette
+//     around the hovered tree's canopy)
+//   • the shared tree selected outline mesh (rainbow-chasing silhouette)
+//
+// Mirrors scene/effects/outlineRenderer.ts but for tree canopies.
+// Exactly two LineSegments2 meshes exist regardless of tree count;
+// transforms are snapped per frame to the 0-2 currently-active outlines.
+//
+// Subscribes to picker.hover and picker.selection. Hover deduplicates
+// against selection by sha so a tree that is both hovered and selected
+// shows only the selected outline.
+//
+// refreshMaterials() is called by applyTheme() to push TREE_OUTLINE
+// config changes into the two outline materials.
+
+import * as THREE from 'three';
+import { LineSegments2 } from 'three/addons/lines/LineSegments2.js';
+import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
+import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
+
+import { TREE_OUTLINE } from '@/config/components/trees.js';
+import { RAINBOW } from '@/config/effects/effects.js';
+import { RENDER_ORDERS } from '@/constants';
+import { NodeKind } from '@/types';
+import { buildCanopyEdges } from '@/scene/components/trees/treeRenderer.js';
+import type { PickTarget } from '@/types/picker.js';
+import type { ReadableAtom } from 'nanostores';
+
+interface TreesHandle {
+  getInstanceTransform(sha: string, out: THREE.Matrix4): boolean;
+  findTreeBySha(sha: string): { mesh: THREE.InstancedMesh; instanceId: number } | null;
+}
+
+/** Minimal picker surface consumed by this renderer (hover + selection atoms). */
+interface PickerAtoms {
+  hover: ReadableAtom<PickTarget | null>;
+  selection: ReadableAtom<PickTarget | null>;
+}
+
+interface CreateArgs {
+  canvas: HTMLCanvasElement;
+  scene: THREE.Scene;
+  picker: PickerAtoms;
+  /** Late-bound: trees are built after this renderer is created. Returns
+   *  null when no manifest has been applied yet. */
+  getTrees: () => TreesHandle | null;
+}
+
+export function createTreeOutlineRenderer({ canvas, scene, picker, getTrees }: CreateArgs) {
+  const _cfg = TREE_OUTLINE.get();
+
+  // Build one EdgesGeometry per detail tier. The active outline mesh
+  // points at whichever tier matches the active tree's mesh on snap.
+  // Wrapped in LineSegmentsGeometry (line2 addon's flat-array format).
+  const _edgesByDetail: LineSegmentsGeometry[] = [0, 1, 2].map((d) => {
+    const edges = buildCanopyEdges(d as 0 | 1 | 2);
+    const positions = edges.getAttribute('position').array as Float32Array;
+    const lsg = new LineSegmentsGeometry();
+    lsg.setPositions(positions);
+    edges.dispose();
+    return lsg;
+  });
+
+  // ── Hover outline ─────────────────────────────────────────────────────
+  const hoverLineMat = new LineMaterial({
+    color: new THREE.Color(_cfg.HOVER_COLOR),
+    linewidth: _cfg.WIDTH,
+    transparent: true,
+    opacity: _cfg.HOVER_OPACITY,
+    depthTest: true,
+    worldUnits: false,
+  });
+  hoverLineMat.resolution.set(canvas.clientWidth, canvas.clientHeight);
+  const hoverOutline = new LineSegments2(_edgesByDetail[0], hoverLineMat);
+  hoverOutline.visible = false;
+  hoverOutline.renderOrder = RENDER_ORDERS.HOVER_TREE_OUTLINE;
+  hoverOutline.matrixAutoUpdate = false;
+  scene.add(hoverOutline);
+
+  // ── Selected outline (rainbow vertex colors) ──────────────────────────
+  const selectedLineMat = new LineMaterial({
+    vertexColors: true,
+    linewidth: _cfg.WIDTH,
+    transparent: true,
+    opacity: _cfg.SELECTED_OPACITY,
+    depthTest: true,
+    worldUnits: false,
+  });
+  selectedLineMat.resolution.set(canvas.clientWidth, canvas.clientHeight);
+  const selectedOutline = new LineSegments2(_edgesByDetail[0], selectedLineMat);
+  selectedOutline.visible = false;
+  selectedOutline.renderOrder = RENDER_ORDERS.SELECTED_TREE_OUTLINE;
+  selectedOutline.matrixAutoUpdate = false;
+  scene.add(selectedOutline);
+
+  const _tmpHsl = new THREE.Color();
+  const _tmpMatrix = new THREE.Matrix4();
+
+  /** Detail level (0/1/2) inferred from the canopy mesh name. The names
+   *  are assigned in treeRenderer: `tree-canopy-d{0,1,2}`. */
+  function _detailOfMesh(mesh: THREE.InstancedMesh): 0 | 1 | 2 {
+    const n = mesh.name;
+    if (n.endsWith('-d2')) return 2;
+    if (n.endsWith('-d1')) return 1;
+    return 0;
+  }
+
+  /** Swap the outline's geometry to the detail tier matching the active
+   *  tree's canopy mesh, then write its instance matrix into the outline. */
+  function _syncOutline(outline: LineSegments2, sha: string): boolean {
+    const trees = getTrees();
+    if (!trees) return false;
+    const hit = trees.findTreeBySha(sha);
+    if (!hit) return false;
+    const wantDetail = _detailOfMesh(hit.mesh);
+    if (outline.geometry !== _edgesByDetail[wantDetail]) {
+      outline.geometry = _edgesByDetail[wantDetail];
+    }
+    if (!trees.getInstanceTransform(sha, _tmpMatrix)) return false;
+    outline.matrix.copy(_tmpMatrix);
+    outline.matrixWorldNeedsUpdate = true;
+    return true;
+  }
+
+  /** True iff hover and selection are the same tree (so hover should hide). */
+  function _hoverIsSelected(): boolean {
+    const sel = picker.selection.get();
+    const hov = picker.hover.get();
+    if (!sel || sel.kind !== NodeKind.Commit) return false;
+    if (!hov || hov.kind !== NodeKind.Commit) return false;
+    return sel.commit.sha === hov.commit.sha;
+  }
+
+  picker.selection.subscribe((sel) => {
+    if (sel && sel.kind === NodeKind.Commit) {
+      const ok = _syncOutline(selectedOutline, sel.commit.sha);
+      selectedOutline.visible = ok;
+    } else {
+      selectedOutline.visible = false;
+    }
+  });
+
+  picker.hover.subscribe((h) => {
+    if (h && h.kind === NodeKind.Commit && !_hoverIsSelected()) {
+      const ok = _syncOutline(hoverOutline, h.commit.sha);
+      hoverOutline.visible = ok;
+    } else {
+      hoverOutline.visible = false;
+    }
+  });
+
+  // Rainbow color buffer for the selected outline. Sized at first update
+  // to match the active geometry's segment count (which depends on the
+  // active tree's detail tier). Reallocated when the active detail changes.
+  let _selColorBuf: Float32Array | null = null;
+  let _selSegCount = 0;
+
+  function _ensureColorBuffer(geom: LineSegmentsGeometry): void {
+    // Each segment has start RGB + end RGB = 6 floats.
+    const startAttr = geom.attributes.instanceStart;
+    if (!startAttr) return;
+    const segCount = startAttr.count;
+    if (segCount === _selSegCount && _selColorBuf) return;
+    _selSegCount = segCount;
+    _selColorBuf = new Float32Array(segCount * 6);
+    for (let i = 0; i < _selColorBuf.length; i++) _selColorBuf[i] = 1;
+    geom.setColors(_selColorBuf);
+  }
+
+  function _writeRainbow(t: number): void {
+    if (!_selColorBuf) return;
+    const rb = RAINBOW.get();
+    // One hue per segment, rotating around the silhouette over time.
+    for (let i = 0; i < _selSegCount; i++) {
+      const hue = ((t + i / _selSegCount) % 1 + 1) % 1;
+      _tmpHsl.setHSL(hue, rb.SATURATION, rb.LIGHTNESS);
+      const k = i * 6;
+      _selColorBuf[k] = _tmpHsl.r;
+      _selColorBuf[k + 1] = _tmpHsl.g;
+      _selColorBuf[k + 2] = _tmpHsl.b;
+      _selColorBuf[k + 3] = _tmpHsl.r;
+      _selColorBuf[k + 4] = _tmpHsl.g;
+      _selColorBuf[k + 5] = _tmpHsl.b;
+    }
+    const geom = selectedOutline.geometry as LineSegmentsGeometry;
+    const colorAttr = geom.attributes.instanceColorStart as THREE.InterleavedBufferAttribute;
+    colorAttr.data.array.set(_selColorBuf);
+    colorAttr.data.needsUpdate = true;
+  }
+
+  function update(_dtMs: number): void {
+    // Selected: re-snap transform (in case the tree's instance matrix
+    // changed via a refresh / animation) and advance rainbow chase.
+    const sel = picker.selection.get();
+    if (sel && sel.kind === NodeKind.Commit) {
+      _syncOutline(selectedOutline, sel.commit.sha);
+      _ensureColorBuffer(selectedOutline.geometry as LineSegmentsGeometry);
+      const t = performance.now() * RAINBOW.get().SPEED;
+      _writeRainbow(t);
+    }
+
+    // Hover: re-snap in case the tree moved.
+    const hov = picker.hover.get();
+    if (hov && hov.kind === NodeKind.Commit && !_hoverIsSelected()) {
+      _syncOutline(hoverOutline, hov.commit.sha);
+    }
+  }
+
+  function refreshMaterials(): void {
+    const c = TREE_OUTLINE.get();
+    hoverLineMat.color.set(c.HOVER_COLOR);
+    hoverLineMat.linewidth = c.WIDTH;
+    hoverLineMat.opacity = c.HOVER_OPACITY;
+    selectedLineMat.linewidth = c.WIDTH;
+    selectedLineMat.opacity = c.SELECTED_OPACITY;
+  }
+
+  function onResize(): void {
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    hoverLineMat.resolution.set(w, h);
+    selectedLineMat.resolution.set(w, h);
+  }
+
+  function dispose(): void {
+    if (hoverOutline.parent) hoverOutline.parent.remove(hoverOutline);
+    if (selectedOutline.parent) selectedOutline.parent.remove(selectedOutline);
+    for (const g of _edgesByDetail) g.dispose();
+    hoverLineMat.dispose();
+    selectedLineMat.dispose();
+  }
+
+  return {
+    update,
+    refreshMaterials,
+    onResize,
+    dispose,
+    hoverOutline,
+    selectedOutline,
+  };
+}

--- a/app/src/scene/renderLoop.ts
+++ b/app/src/scene/renderLoop.ts
@@ -30,6 +30,7 @@ import { createPicker } from './system/picker.js';
 import { createInputHandlers } from './system/inputHandlers.js';
 import { createBuildingFader } from './effects/buildingFader.js';
 import { createOutlineRenderer } from './effects/outlineRenderer.js';
+import { createTreeOutlineRenderer } from './effects/treeOutlineRenderer.js';
 import { createGhostRenderer } from './effects/ghostRenderer.js';
 import { createPathLineRenderer } from './effects/pathLineRenderer.js';
 import { createCoordinator } from '../coordinator.js';
@@ -161,6 +162,12 @@ export async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manif
     world,
     picker,
   });
+  const treeOutlineRenderer = createTreeOutlineRenderer({
+    canvas,
+    scene,
+    picker,
+    getTrees: () => world.getTrees(),
+  });
   const ghostRenderer = createGhostRenderer({ scene, world, picker });
   const pathLineRenderer = createPathLineRenderer({
     canvas,
@@ -244,6 +251,7 @@ export async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manif
     scene.background = new THREE.Color(SKY.get().COLOR);
 
     outlineRenderer.refreshMaterials();
+    treeOutlineRenderer.refreshMaterials();
     pathLineRenderer.refreshMaterials();
     refreshBuildingMaterial();
     postFx.refresh();
@@ -384,6 +392,7 @@ export async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manif
       const ch = canvas.clientHeight;
       postFx.setSize(cw, ch);
       outlineRenderer.onResize();
+      treeOutlineRenderer.onResize();
       pathLineRenderer.onResize();
       // Synchronous paint to avoid a single-frame blank/cleared canvas
       // between the resize and the next animate() tick. The render path
@@ -429,6 +438,7 @@ export async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manif
         camera.updateProjectionMatrix();
         postFx.setSize(cw, ch);
         outlineRenderer.onResize();
+        treeOutlineRenderer.onResize();
         pathLineRenderer.onResize();
       }
     }
@@ -467,6 +477,7 @@ export async function startRenderLoop(canvas: HTMLCanvasElement, manifest: Manif
     }
     fader.update(0); // body opacity per fade tier
     outlineRenderer.update(0); // hover/selected outline transforms + rainbow chase
+    treeOutlineRenderer.update(0); // tree hover/selected outline transforms + rainbow chase
     ghostRenderer.update(0); // hover ghost transform
     pathLineRenderer.update(0); // selection path line rainbow chase
     // Street labels are world-space text on the asphalt — orient toward

--- a/app/src/store/configCommitReactions.ts
+++ b/app/src/store/configCommitReactions.ts
@@ -60,6 +60,10 @@ import {
   // Cyberpunk Valley — trees (structural in TREES → rebuild):
   TREES,
 
+  // Cyberpunk Valley — tree hover/select outlines (material-only via
+  // treeOutlineRenderer.refreshMaterials() inside applyTheme()):
+  TREE_OUTLINE,
+
   // Cyberpunk Valley — footprint (HALO_WIDTH bakes into instance
   // matrices → rebuild; COLOR/ENABLED → material-only via footprint.refresh()):
   FOOTPRINT,
@@ -239,6 +243,10 @@ export function attachCommitReactions({ world, applyTheme }: CommitReactionsOpts
     // mesh swap inside refresh(); the others update uniforms or the
     // group transform directly. No applyManifest rebuild needed.
     REPO_LABEL,
+    // TREE_OUTLINE — WIDTH, HOVER_COLOR, HOVER_OPACITY, SELECTED_OPACITY
+    // all push through treeOutlineRenderer.refreshMaterials() inside
+    // applyTheme(). No rebuild needed.
+    TREE_OUTLINE,
   ];
 
   const unsubs: Array<() => void> = [];

--- a/app/src/types/picker.ts
+++ b/app/src/types/picker.ts
@@ -80,6 +80,7 @@ export interface PickerWorld {
       instanceId: number;
       commit: CommitEntry;
     } | null;
+    getInstanceTransform(sha: string, out: THREE.Matrix4): boolean;
     colorForSha(sha: string): string | null;
     setHoverSha(sha: string | null): void;
     setSelectionSha(sha: string | null): void;

--- a/app/src/types/picker.ts
+++ b/app/src/types/picker.ts
@@ -82,7 +82,5 @@ export interface PickerWorld {
     } | null;
     getInstanceTransform(sha: string, out: THREE.Matrix4): boolean;
     colorForSha(sha: string): string | null;
-    setHoverSha(sha: string | null): void;
-    setSelectionSha(sha: string | null): void;
   } | null;
 }

--- a/app/src/views/panes/controlsPane.ts
+++ b/app/src/views/panes/controlsPane.ts
@@ -54,7 +54,7 @@ import { SKY, SKY_STARS } from '@/config/components/sky.js';
 import { REPO_LABEL } from '@/config/components/repoLabel.js';
 import { ISLAND_GEOMETRY, ISLAND_MATERIALS } from '@/config/components/island.js';
 import { WORLD } from '@/config/world/world.js';
-import { TREES } from '@/config/components/trees.js';
+import { TREES, TREE_OUTLINE } from '@/config/components/trees.js';
 import { FOOTPRINT } from '@/config/components/footprint.js';
 import { FACADE_GEOMETRY, FACADE_DETAIL, WINDOW_LIGHTING } from '@/config/components/facade.js';
 import { AD_PANEL } from '@/config/components/adPanels.js';
@@ -576,6 +576,21 @@ function _buildTreesSection(): HTMLElement {
       }),
       _slider('High-tier facets', TREES, 'TREE_FACETS_HIGH', 3, 32, 1, {
         tip: 'Radial segment count for the largest-commit tier. Highest tier has the fewest tree instances so this is the cheapest knob to push high.',
+      }),
+    ])
+  );
+
+  section.appendChild(
+    _collapsibleSubgroup('trees-outlines', 'Outlines', () => [
+      _number('Linewidth', TREE_OUTLINE, 'WIDTH', 1, 10, 1, {
+        tip: 'Pixel thickness shared by hover and selected canopy outlines.',
+      }),
+      _color('Hover color', TREE_OUTLINE, 'HOVER_COLOR', {
+        tip: 'Outline color when a tree is hovered (not selected).',
+      }),
+      _slider('Hover opacity', TREE_OUTLINE, 'HOVER_OPACITY', 0, 1, 0.05, {}),
+      _slider('Selected opacity', TREE_OUTLINE, 'SELECTED_OPACITY', 0, 1, 0.05, {
+        tip: 'Selected outline uses an animated rainbow color — see Effects > Rainbow.',
       }),
     ])
   );

--- a/app/tests/scene/effects/treeOutlineRenderer.test.ts
+++ b/app/tests/scene/effects/treeOutlineRenderer.test.ts
@@ -29,11 +29,7 @@ function fakeTrees(activeSha: string, matrix: THREE.Matrix4) {
     findTreeBySha: (sha: string) => {
       if (sha !== activeSha) return null;
       return {
-        mesh: new THREE.InstancedMesh(
-          new THREE.BufferGeometry(),
-          new THREE.MeshBasicMaterial(),
-          1
-        ),
+        mesh: new THREE.InstancedMesh(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial(), 1),
         instanceId: 0,
         commit: { sha, date: '2026-05-27', files: 1 },
       };
@@ -50,11 +46,7 @@ function fakePicker() {
 function commitTarget(sha: string): PickTarget {
   return {
     kind: NodeKind.Commit,
-    mesh: new THREE.InstancedMesh(
-      new THREE.BufferGeometry(),
-      new THREE.MeshBasicMaterial(),
-      1
-    ),
+    mesh: new THREE.InstancedMesh(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial(), 1),
     instanceId: 0,
     commit: { sha, date: '2026-05-27', files: 1 },
   };
@@ -164,11 +156,7 @@ describe('treeOutlineRenderer', () => {
     });
     picker.hover.set({
       kind: NodeKind.File,
-      mesh: new THREE.InstancedMesh(
-        new THREE.BufferGeometry(),
-        new THREE.MeshBasicMaterial(),
-        1
-      ),
+      mesh: new THREE.InstancedMesh(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial(), 1),
       data: {} as never,
       file: { path: 'foo' } as never,
     });

--- a/app/tests/scene/effects/treeOutlineRenderer.test.ts
+++ b/app/tests/scene/effects/treeOutlineRenderer.test.ts
@@ -1,0 +1,200 @@
+// Verifies treeOutlineRenderer wiring: subscriptions toggle visibility,
+// transform snaps to the active tree's instance matrix, and rainbow
+// colors advance frame-over-frame.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as THREE from 'three';
+import { atom } from 'nanostores';
+import { createTreeOutlineRenderer } from '@/scene/effects/treeOutlineRenderer.js';
+import { TREE_OUTLINE } from '@/config/components/trees.js';
+import { RAINBOW } from '@/config/effects/effects.js';
+import { NodeKind } from '@/types';
+import type { PickTarget } from '@/types/picker.js';
+
+function fakeCanvas(): HTMLCanvasElement {
+  const c = document.createElement('canvas');
+  Object.defineProperty(c, 'clientWidth', { value: 800 });
+  Object.defineProperty(c, 'clientHeight', { value: 600 });
+  return c;
+}
+
+function fakeTrees(activeSha: string, matrix: THREE.Matrix4) {
+  return {
+    getInstanceTransform: (sha: string, out: THREE.Matrix4) => {
+      if (sha !== activeSha) return false;
+      out.copy(matrix);
+      return true;
+    },
+    findTreeBySha: (sha: string) => {
+      if (sha !== activeSha) return null;
+      return {
+        mesh: new THREE.InstancedMesh(
+          new THREE.BufferGeometry(),
+          new THREE.MeshBasicMaterial(),
+          1
+        ),
+        instanceId: 0,
+        commit: { sha, date: '2026-05-27', files: 1 },
+      };
+    },
+  };
+}
+
+function fakePicker() {
+  const hover = atom<PickTarget | null>(null);
+  const selection = atom<PickTarget | null>(null);
+  return { hover, selection };
+}
+
+function commitTarget(sha: string): PickTarget {
+  return {
+    kind: NodeKind.Commit,
+    mesh: new THREE.InstancedMesh(
+      new THREE.BufferGeometry(),
+      new THREE.MeshBasicMaterial(),
+      1
+    ),
+    instanceId: 0,
+    commit: { sha, date: '2026-05-27', files: 1 },
+  };
+}
+
+describe('treeOutlineRenderer', () => {
+  beforeEach(() => {
+    TREE_OUTLINE.set({
+      WIDTH: 3,
+      HOVER_COLOR: '#ffffff',
+      HOVER_OPACITY: 0.5,
+      SELECTED_OPACITY: 1.0,
+    });
+    RAINBOW.set({ SPEED: 0.001, SATURATION: 1, LIGHTNESS: 0.5 });
+  });
+
+  it('hover outline is hidden when picker.hover is null', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+    const matrix = new THREE.Matrix4().makeTranslation(10, 20, 30);
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => fakeTrees('a', matrix),
+    });
+    expect(r.hoverOutline.visible).toBe(false);
+    r.dispose();
+  });
+
+  it('hover outline becomes visible and transform matches active tree', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+    const matrix = new THREE.Matrix4()
+      .makeTranslation(10, 20, 30)
+      .multiply(new THREE.Matrix4().makeScale(2, 3, 4));
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => fakeTrees('a', matrix),
+    });
+    picker.hover.set(commitTarget('a'));
+    expect(r.hoverOutline.visible).toBe(true);
+    for (let i = 0; i < 16; i++) {
+      expect(r.hoverOutline.matrix.elements[i]).toBeCloseTo(matrix.elements[i], 5);
+    }
+    r.dispose();
+  });
+
+  it('hover outline hides again when hover clears', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => fakeTrees('a', new THREE.Matrix4()),
+    });
+    picker.hover.set(commitTarget('a'));
+    picker.hover.set(null);
+    expect(r.hoverOutline.visible).toBe(false);
+    r.dispose();
+  });
+
+  it('selected outline tracks picker.selection the same way', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => fakeTrees('a', new THREE.Matrix4().makeTranslation(5, 0, 0)),
+    });
+    expect(r.selectedOutline.visible).toBe(false);
+    picker.selection.set(commitTarget('a'));
+    expect(r.selectedOutline.visible).toBe(true);
+    picker.selection.set(null);
+    expect(r.selectedOutline.visible).toBe(false);
+    r.dispose();
+  });
+
+  it('hover outline hides when hover sha is null but selection is set (no double-paint)', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => fakeTrees('a', new THREE.Matrix4()),
+    });
+    picker.selection.set(commitTarget('a'));
+    picker.hover.set(commitTarget('a')); // same as selected
+    expect(r.selectedOutline.visible).toBe(true);
+    expect(r.hoverOutline.visible).toBe(false);
+    r.dispose();
+  });
+
+  it('hovering a non-Commit target does not show the tree outline', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => fakeTrees('a', new THREE.Matrix4()),
+    });
+    picker.hover.set({
+      kind: NodeKind.File,
+      mesh: new THREE.InstancedMesh(
+        new THREE.BufferGeometry(),
+        new THREE.MeshBasicMaterial(),
+        1
+      ),
+      data: {} as never,
+      file: { path: 'foo' } as never,
+    });
+    expect(r.hoverOutline.visible).toBe(false);
+    r.dispose();
+  });
+
+  it('refreshMaterials pushes WIDTH and opacity updates into both materials', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => fakeTrees('a', new THREE.Matrix4()),
+    });
+    TREE_OUTLINE.set({
+      WIDTH: 7,
+      HOVER_COLOR: '#ff00ff',
+      HOVER_OPACITY: 0.25,
+      SELECTED_OPACITY: 0.9,
+    });
+    r.refreshMaterials();
+    expect((r.hoverOutline.material as { linewidth: number }).linewidth).toBe(7);
+    expect((r.hoverOutline.material as { opacity: number }).opacity).toBeCloseTo(0.25, 5);
+    expect((r.selectedOutline.material as { linewidth: number }).linewidth).toBe(7);
+    expect((r.selectedOutline.material as { opacity: number }).opacity).toBeCloseTo(0.9, 5);
+    r.dispose();
+  });
+});

--- a/app/tests/scene/effects/treeOutlineRenderer.test.ts
+++ b/app/tests/scene/effects/treeOutlineRenderer.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import * as THREE from 'three';
 import { atom } from 'nanostores';
+import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
 import { createTreeOutlineRenderer } from '@/scene/effects/treeOutlineRenderer.js';
 import { TREE_OUTLINE } from '@/config/components/trees.js';
 import { RAINBOW } from '@/config/effects/effects.js';
@@ -195,6 +196,83 @@ describe('treeOutlineRenderer', () => {
     expect((r.hoverOutline.material as { opacity: number }).opacity).toBeCloseTo(0.25, 5);
     expect((r.selectedOutline.material as { linewidth: number }).linewidth).toBe(7);
     expect((r.selectedOutline.material as { opacity: number }).opacity).toBeCloseTo(0.9, 5);
+    r.dispose();
+  });
+
+  it('update advances selected outline rainbow colors over time', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => fakeTrees('a', new THREE.Matrix4()),
+    });
+    picker.selection.set(commitTarget('a'));
+
+    // First frame: paint colors from the current time stamp.
+    r.update(0);
+    const geom = r.selectedOutline.geometry as LineSegmentsGeometry;
+    const colorAttr = geom.attributes.instanceColorStart as THREE.InterleavedBufferAttribute;
+    const before = Float32Array.from(colorAttr.data.array as Float32Array);
+
+    // Advance time by enough to clear floating-point noise (~200ms) and re-paint.
+    const tStart = performance.now();
+    while (performance.now() - tStart < 200) {
+      // busy wait — vitest's fake timers wouldn't move performance.now()
+    }
+    r.update(0);
+    const after = colorAttr.data.array as Float32Array;
+
+    let diffs = 0;
+    for (let i = 0; i < before.length; i++) {
+      if (Math.abs(before[i] - after[i]) > 1e-4) diffs++;
+    }
+    expect(diffs).toBeGreaterThan(0);
+
+    r.dispose();
+  });
+
+  it('selecting a d2-tier tree swaps the outline geometry to the d2 tier', () => {
+    const scene = new THREE.Scene();
+    const picker = fakePicker();
+
+    // Build a fake whose findTreeBySha returns an InstancedMesh named with
+    // the d2 suffix, so _detailOfMesh resolves to detail tier 2.
+    const d2Mesh = new THREE.InstancedMesh(
+      new THREE.BufferGeometry(),
+      new THREE.MeshBasicMaterial(),
+      1
+    );
+    d2Mesh.name = 'tree-canopy-d2';
+
+    const trees = {
+      getInstanceTransform: (sha: string, out: THREE.Matrix4) => {
+        if (sha !== 'a') return false;
+        out.identity();
+        return true;
+      },
+      findTreeBySha: (sha: string) => {
+        if (sha !== 'a') return null;
+        return { mesh: d2Mesh, instanceId: 0 };
+      },
+    };
+
+    const r = createTreeOutlineRenderer({
+      canvas: fakeCanvas(),
+      scene,
+      picker,
+      getTrees: () => trees,
+    });
+
+    const initialGeom = r.selectedOutline.geometry;
+    picker.selection.set(commitTarget('a'));
+
+    // After selecting a d2-tier tree, the outline geometry should differ
+    // from the initial (d0) one.
+    expect(r.selectedOutline.geometry).not.toBe(initialGeom);
+    expect(r.selectedOutline.visible).toBe(true);
+
     r.dispose();
   });
 });

--- a/app/tests/scene/system/picker-commit.test.ts
+++ b/app/tests/scene/system/picker-commit.test.ts
@@ -40,8 +40,6 @@ interface FakeTrees {
   } | null;
   getInstanceTransform: (sha: string, out: THREE.Matrix4) => boolean;
   colorForSha: (sha: string) => string | null;
-  setHoverSha: (sha: string | null) => void;
-  setSelectionSha: (sha: string | null) => void;
 }
 
 function makeFakeTrees(
@@ -71,8 +69,6 @@ function makeFakeTrees(
       const idx = commits.findIndex((c) => c.sha === sha);
       return idx === -1 ? null : '#abcdef';
     },
-    setHoverSha(_sha) {},
-    setSelectionSha(_sha) {},
   };
 }
 

--- a/app/tests/scene/system/picker-commit.test.ts
+++ b/app/tests/scene/system/picker-commit.test.ts
@@ -38,6 +38,7 @@ interface FakeTrees {
     instanceId: number;
     commit: CommitEntry;
   } | null;
+  getInstanceTransform: (sha: string, out: THREE.Matrix4) => boolean;
   colorForSha: (sha: string) => string | null;
   setHoverSha: (sha: string | null) => void;
   setSelectionSha: (sha: string | null) => void;
@@ -61,6 +62,10 @@ function makeFakeTrees(
       const idx = commits.findIndex((c) => c.sha === sha);
       if (idx === -1) return null;
       return { mesh: canopy, instanceId: idx, commit: commits[idx] };
+    },
+    getInstanceTransform(sha, _out) {
+      const idx = commits.findIndex((c) => c.sha === sha);
+      return idx !== -1;
     },
     colorForSha(sha) {
       const idx = commits.findIndex((c) => c.sha === sha);

--- a/app/tests/scene/trees/treeRendererCommitLookup.test.ts
+++ b/app/tests/scene/trees/treeRendererCommitLookup.test.ts
@@ -308,4 +308,43 @@ describe('Trees commit lookups', () => {
     hit1.mesh.getColorAt(hit1.instanceId, tmp);
     expect(Math.abs(tmp.r - selectedR)).toBeLessThan(0.001); // still selected-tinted
   });
+
+  it('getInstanceTransform writes the canopy instance matrix into the out param', () => {
+    const commits = [commit(0), commit(1)];
+    const placements = [placement(0, 0), placement(3, 1)];
+    const trees = createTreeRenderer(placements, commits);
+
+    const hit = trees.findTreeBySha(commits[1].sha)!;
+    const expected = new THREE.Matrix4();
+    hit.mesh.getMatrixAt(hit.instanceId, expected);
+
+    const out = new THREE.Matrix4();
+    const ok = trees.getInstanceTransform(commits[1].sha, out);
+    expect(ok).toBe(true);
+    for (let i = 0; i < 16; i++) {
+      expect(out.elements[i]).toBeCloseTo(expected.elements[i], 5);
+    }
+  });
+
+  it('getInstanceTransform returns false for unknown sha', () => {
+    const commits = [commit(0)];
+    const placements = [placement(0, 0)];
+    const trees = createTreeRenderer(placements, commits);
+    const out = new THREE.Matrix4();
+    expect(trees.getInstanceTransform('f'.repeat(40), out)).toBe(false);
+  });
+});
+
+it('buildCanopyEdges returns non-empty EdgesGeometry for each detail level', async () => {
+  const { buildCanopyEdges } = await import(
+    '@/scene/components/trees/treeRenderer.js'
+  );
+  for (const detail of [0, 1, 2] as const) {
+    const geom = buildCanopyEdges(detail);
+    expect(geom).toBeInstanceOf(THREE.EdgesGeometry);
+    const positions = geom.getAttribute('position');
+    expect(positions).toBeDefined();
+    expect(positions.count).toBeGreaterThan(0);
+    geom.dispose();
+  }
 });

--- a/app/tests/scene/trees/treeRendererCommitLookup.test.ts
+++ b/app/tests/scene/trees/treeRendererCommitLookup.test.ts
@@ -214,9 +214,7 @@ describe('Trees commit lookups', () => {
 });
 
 it('buildCanopyEdges returns non-empty EdgesGeometry for each detail level', async () => {
-  const { buildCanopyEdges } = await import(
-    '@/scene/components/trees/treeRenderer.js'
-  );
+  const { buildCanopyEdges } = await import('@/scene/components/trees/treeRenderer.js');
   for (const detail of [0, 1, 2] as const) {
     const geom = buildCanopyEdges(detail);
     expect(geom).toBeInstanceOf(THREE.EdgesGeometry);

--- a/app/tests/scene/trees/treeRendererCommitLookup.test.ts
+++ b/app/tests/scene/trees/treeRendererCommitLookup.test.ts
@@ -175,27 +175,6 @@ describe('Trees commit lookups', () => {
     expect(color).toMatch(/^#[0-9a-f]{6}$/);
   });
 
-  it('colorForSha returns the base color even when the tree is hovered', () => {
-    const commits = [commit(0), commit(1)];
-    const placements = [placement(0, 0), placement(1, 1)];
-    const trees = createTreeRenderer(placements, commits);
-
-    const base = trees.colorForSha(commits[1].sha);
-    expect(base).toMatch(/^#[0-9a-f]{6}$/);
-
-    trees.setHoverSha(commits[1].sha);
-    const duringHover = trees.colorForSha(commits[1].sha);
-    expect(duringHover).toBe(base);
-
-    trees.setSelectionSha(commits[1].sha);
-    const duringSelect = trees.colorForSha(commits[1].sha);
-    expect(duringSelect).toBe(base);
-
-    trees.setHoverSha(null);
-    trees.setSelectionSha(null);
-    expect(trees.colorForSha(commits[1].sha)).toBe(base);
-  });
-
   it('colorForSha returns null for an unknown sha', () => {
     const commits = [commit(0)];
     const placements = [placement(0, 0)];
@@ -206,107 +185,6 @@ describe('Trees commit lookups', () => {
   it('colorForSha returns null when commits is null', () => {
     const trees = createTreeRenderer([placement(0, 0)], null);
     expect(trees.colorForSha('a'.repeat(40))).toBeNull();
-  });
-
-  it('setHoverSha tints the canopy instance with a contrasting inverse color', () => {
-    const commits = [commit(0), commit(1)];
-    const placements = [placement(0, 0), placement(1, 1)];
-    const trees = createTreeRenderer(placements, commits);
-
-    const tmp = new THREE.Color();
-    const hit = trees.findTreeBySha(commits[1].sha)!;
-    hit.mesh.getColorAt(hit.instanceId, tmp);
-    const baseR = tmp.r;
-    const baseG = tmp.g;
-    const baseB = tmp.b;
-
-    trees.setHoverSha(commits[1].sha);
-    hit.mesh.getColorAt(hit.instanceId, tmp);
-    // The new tinting algorithm (PR 5c1ad90) paints the canopy with the
-    // sRGB inverse of its base color (with a contrast-pull when the raw
-    // inverse is too close to the base in luminance). The tinted color
-    // may be either brighter or darker than baseline depending on the
-    // base color, so just assert a meaningful color change in any
-    // channel rather than a directional brightness shift.
-    const channelDelta =
-      Math.abs(tmp.r - baseR) + Math.abs(tmp.g - baseG) + Math.abs(tmp.b - baseB);
-    expect(channelDelta).toBeGreaterThan(0.1);
-  });
-
-  it('setHoverSha(null) restores the baseline color', () => {
-    const commits = [commit(0), commit(1)];
-    const placements = [placement(0, 0), placement(1, 1)];
-    const trees = createTreeRenderer(placements, commits);
-
-    const tmp = new THREE.Color();
-    const hit = trees.findTreeBySha(commits[1].sha)!;
-    hit.mesh.getColorAt(hit.instanceId, tmp);
-    const baseR = tmp.r;
-
-    trees.setHoverSha(commits[1].sha);
-    trees.setHoverSha(null);
-    hit.mesh.getColorAt(hit.instanceId, tmp);
-    expect(Math.abs(tmp.r - baseR)).toBeLessThan(0.001);
-  });
-
-  it('setSelectionSha paints the canopy with the same tint as setHoverSha', () => {
-    const commits = [commit(0), commit(1)];
-    const placements = [placement(0, 0), placement(1, 1)];
-    const trees = createTreeRenderer(placements, commits);
-
-    const tmp = new THREE.Color();
-    const hit = trees.findTreeBySha(commits[1].sha)!;
-
-    trees.setHoverSha(commits[1].sha);
-    hit.mesh.getColorAt(hit.instanceId, tmp);
-    const hoverR = tmp.r;
-    const hoverG = tmp.g;
-    const hoverB = tmp.b;
-
-    trees.setHoverSha(null);
-    trees.setSelectionSha(commits[1].sha);
-    hit.mesh.getColorAt(hit.instanceId, tmp);
-    // PR 5c1ad90: hover and selection share one paint (the contrasting
-    // inverse). Priority semantics (selection wins over hover) are still
-    // exercised by the dedicated tests below.
-    expect(Math.abs(tmp.r - hoverR)).toBeLessThan(0.001);
-    expect(Math.abs(tmp.g - hoverG)).toBeLessThan(0.001);
-    expect(Math.abs(tmp.b - hoverB)).toBeLessThan(0.001);
-  });
-
-  it('selection wins over hover when both apply to the same tree', () => {
-    const commits = [commit(0), commit(1)];
-    const placements = [placement(0, 0), placement(1, 1)];
-    const trees = createTreeRenderer(placements, commits);
-
-    const tmp = new THREE.Color();
-    const hit = trees.findTreeBySha(commits[1].sha)!;
-
-    trees.setSelectionSha(commits[1].sha);
-    hit.mesh.getColorAt(hit.instanceId, tmp);
-    const selectedR = tmp.r;
-
-    trees.setHoverSha(commits[1].sha); // hover same tree
-    hit.mesh.getColorAt(hit.instanceId, tmp);
-    expect(Math.abs(tmp.r - selectedR)).toBeLessThan(0.001);
-  });
-
-  it('moving hover from selected tree to another reverts the previous to selected', () => {
-    const commits = [commit(0), commit(1), commit(2)];
-    const placements = [placement(0, 0), placement(1, 1), placement(2, 2)];
-    const trees = createTreeRenderer(placements, commits);
-
-    const tmp = new THREE.Color();
-    const hit1 = trees.findTreeBySha(commits[1].sha)!;
-
-    trees.setSelectionSha(commits[1].sha);
-    hit1.mesh.getColorAt(hit1.instanceId, tmp);
-    const selectedR = tmp.r;
-
-    trees.setHoverSha(commits[1].sha); // hover === selected, no change
-    trees.setHoverSha(commits[2].sha); // hover moves to a different tree
-    hit1.mesh.getColorAt(hit1.instanceId, tmp);
-    expect(Math.abs(tmp.r - selectedR)).toBeLessThan(0.001); // still selected-tinted
   });
 
   it('getInstanceTransform writes the canopy instance matrix into the out param', () => {


### PR DESCRIPTION
## Summary

- Replaces the tree canopy color-inversion hover/select treatment with a wireframe outline that snaps to the active tree's transform (mirrors the building outline pattern in `outlineRenderer.ts`). Fixes the original report that tan/cream canopies inverted to near-black and disappeared against the dark island ground.
- Adds `treeOutlineRenderer.ts`: two persistent `LineSegments2` meshes (hover = white, selected = rainbow chase via shared `RAINBOW`) subscribed to `picker.hover` / `picker.selection`. Builds one `EdgesGeometry` per canopy detail tier from a shared `CANOPY_PROFILE` const (lifted out of `buildCanopyGeometry` so the rendered canopy and the outline can't drift).
- New `TREE_OUTLINE` config (`WIDTH`, `HOVER_COLOR`, `HOVER_OPACITY`, `SELECTED_OPACITY`) + `Trees > Outlines` controls subgroup mirroring `BUILDING_OUTLINE`. Wired into the Save → `applyTheme` reaction chain.

## Test plan

- [x] Vitest: 1907 passing (9 new `treeOutlineRenderer` tests covering visibility toggle, transform snap, hover/select dedup, detail-tier swap, rainbow advance, `refreshMaterials`; existing 6 canopy-inversion tests removed)
- [x] Typecheck clean
- [x] Manual: hover/select tan tree shows white/rainbow outline (the original bug case) — confirmed
- [x] Manual: `Trees > Outlines` slider live-updates outline thickness/color/opacity on Save — confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)