### PR TITLE
trees: shrink canopy width by height so young trees aren't adult-wide

### DIFF
--- a/app/src/config/components/trees.ts
+++ b/app/src/config/components/trees.ts
@@ -106,6 +106,12 @@ export interface TreesConfig {
   /** Fraction of base saturation retained at the NEWEST commit's age
    *  (percent, 0-100). 100 = colors at full strength. */
   TREE_AGE_SATURATION_MAX: number;
+
+  /** Floor that file-driven canopy width is multiplied by at the
+   *  SHORTEST (newest) tree. Width at tallest = full file-driven nominal;
+   *  width at shortest = floor × nominal. 1.0 = no shrink; 0.5 = 50% at
+   *  shortest; 0.0 = strict proportional (sapling-thin). */
+  TREE_WIDTH_AGE_FLOOR: number;
 }
 
 export const TREES = map<TreesConfig>({
@@ -138,6 +144,7 @@ export const TREES = map<TreesConfig>({
   TREE_AGE_DESAT_ENABLED: false,
   TREE_AGE_SATURATION_MIN: 50,
   TREE_AGE_SATURATION_MAX: 100,
+  TREE_WIDTH_AGE_FLOOR: 0.5,
 });
 
 // ─── Hover / select wireframe outlines ─────────────────────────────────────

--- a/app/src/scene/components/trees/treeRenderer.ts
+++ b/app/src/scene/components/trees/treeRenderer.ts
@@ -259,12 +259,24 @@ export function createTreeRenderer(
   }
 
   // WIDTH (canopy XZ radius) is driven by FILES: more files = wider.
+  // Attenuated by AGE via TREE_WIDTH_AGE_FLOOR so short young trees
+  // don't render adult-wide (a brand-new commit touching many files
+  // would otherwise be a squat lollipop). floor=1.0 disables the
+  // attenuation (byte-identical to pre-feature rendering).
   function perTreeRadius(i: number): number {
+    let baseRadius: number;
     if (commits && placements[i].commitIndex >= 0 && placements[i].commitIndex < commits.length) {
       const t = sizeT(commits[placements[i].commitIndex], sizeRange);
-      return minRadius + t * (maxRadius - minRadius);
+      baseRadius = minRadius + t * (maxRadius - minRadius);
+    } else {
+      baseRadius = (minRadius + maxRadius) * 0.5;
     }
-    return (minRadius + maxRadius) * 0.5;
+    // Clamp height range to avoid divide-by-zero when min == max.
+    const heightRange = Math.max(0.001, maxHeight - minHeight);
+    const heightRatio = (perTreeHeight(i) - minHeight) / heightRange;
+    const floor = Math.max(0, Math.min(1, cfg.TREE_WIDTH_AGE_FLOOR));
+    const ageAttenuation = floor + (1 - floor) * heightRatio;
+    return baseRadius * ageAttenuation;
   }
 
   // FACETS are driven by FILES too: bigger commits get more subdivisions.

--- a/app/src/store/configCommitReactions.ts
+++ b/app/src/store/configCommitReactions.ts
@@ -287,6 +287,7 @@ export function attachCommitReactions({ world, applyTheme }: CommitReactionsOpts
         'EDGE_INSET_PERCENT',
         'TREE_DENSITY_FALLOFF',
         'SCATTER_FOOTPRINT_FRAC_OF_MAX_WIDTH',
+        'TREE_WIDTH_AGE_FLOOR',
       ],
       scheduleRebuild
     )

--- a/app/src/views/panes/controlsPane.ts
+++ b/app/src/views/panes/controlsPane.ts
@@ -563,6 +563,9 @@ function _buildTreesSection(): HTMLElement {
           tip: 'Trunk XZ radius as a fraction of canopy radius. Wider canopies get thicker trunks proportionally. Rebuild on change.',
         }
       ),
+      _slider('Age shrink floor', TREES, 'TREE_WIDTH_AGE_FLOOR', 0, 1, 0.05, {
+        tip: 'Multiplier on file-driven canopy width at the SHORTEST (newest) tree. 1 = no shrink; 0.5 = half-width saplings; 0 = strict height-proportional. Tallest trees always render at full width. Rebuild on change.',
+      }),
     ])
   );
 

--- a/app/tests/_helpers/cityFixtures.ts
+++ b/app/tests/_helpers/cityFixtures.ts
@@ -127,6 +127,7 @@ export function resetTreesConfig(): void {
     TREE_AGE_DESAT_ENABLED: false,
     TREE_AGE_SATURATION_MIN: 20,
     TREE_AGE_SATURATION_MAX: 100,
+    TREE_WIDTH_AGE_FLOOR: 1.0,
   });
 }
 

--- a/app/tests/scene/trees/treeRenderer.test.ts
+++ b/app/tests/scene/trees/treeRenderer.test.ts
@@ -41,6 +41,7 @@ function resetStores() {
     TREE_AGE_DESAT_ENABLED: false,
     TREE_AGE_SATURATION_MIN: 20,
     TREE_AGE_SATURATION_MAX: 100,
+    TREE_WIDTH_AGE_FLOOR: 1.0,
   });
   BUILDING_DIMENSIONS.set({
     MIN_FLOORS: 2,

--- a/app/tests/scene/trees/treeRendererCommitLookup.test.ts
+++ b/app/tests/scene/trees/treeRendererCommitLookup.test.ts
@@ -34,6 +34,7 @@ function resetStores() {
     TREE_AGE_DESAT_ENABLED: false,
     TREE_AGE_SATURATION_MIN: 20,
     TREE_AGE_SATURATION_MAX: 100,
+    TREE_WIDTH_AGE_FLOOR: 1.0,
   });
   BUILDING_DIMENSIONS.set({
     MIN_FLOORS: 2,
@@ -210,6 +211,111 @@ describe('Trees commit lookups', () => {
     const trees = createTreeRenderer(placements, commits);
     const out = new THREE.Matrix4();
     expect(trees.getInstanceTransform('f'.repeat(40), out)).toBe(false);
+  });
+
+  it('TREE_WIDTH_AGE_FLOOR = 1.0 preserves file-driven canopy width unchanged', () => {
+    // Two commits, same file count, different ages. With floor=1.0 the
+    // attenuation is constant 1, so both trees should have the same
+    // canopy XZ scale.
+    TREES.setKey('TREE_WIDTH_AGE_FLOOR', 1.0);
+    const commits = [commit(0), commit(1)];
+    // Force same file count so file-driven radius matches.
+    commits[0].files = 5;
+    commits[1].files = 5;
+    const placements = [placement(0, 0), placement(1, 1)];
+    const trees = createTreeRenderer(placements, commits);
+
+    const hit0 = trees.findTreeBySha(commits[0].sha)!;
+    const hit1 = trees.findTreeBySha(commits[1].sha)!;
+    const m0 = new THREE.Matrix4();
+    const m1 = new THREE.Matrix4();
+    hit0.mesh.getMatrixAt(hit0.instanceId, m0);
+    hit1.mesh.getMatrixAt(hit1.instanceId, m1);
+    const s0 = new THREE.Vector3();
+    const s1 = new THREE.Vector3();
+    m0.decompose(new THREE.Vector3(), new THREE.Quaternion(), s0);
+    m1.decompose(new THREE.Vector3(), new THREE.Quaternion(), s1);
+
+    expect(s0.x).toBeCloseTo(s1.x, 3);
+    expect(s0.z).toBeCloseTo(s1.z, 3);
+  });
+
+  it('TREE_WIDTH_AGE_FLOOR = 0.5 halves the shortest tree canopy width', () => {
+    // Three commits, same file count. With ageT mapping oldest→0, newest→1,
+    // the renderer assigns commits[2] (newest) min height (heightRatio=0)
+    // → attenuation = 0.5; commits[0] (oldest) max height (heightRatio=1)
+    // → attenuation = 1.
+    TREES.setKey('TREE_WIDTH_AGE_FLOOR', 0.5);
+    const commits = [commit(0), commit(1), commit(2)];
+    for (const c of commits) c.files = 5;
+    const placements = [placement(0, 0), placement(1, 1), placement(2, 2)];
+    const trees = createTreeRenderer(placements, commits);
+
+    // Find the oldest (commits[0]) and newest (commits[2]) trees.
+    const oldHit = trees.findTreeBySha(commits[0].sha)!;
+    const newHit = trees.findTreeBySha(commits[2].sha)!;
+    const mOld = new THREE.Matrix4();
+    const mNew = new THREE.Matrix4();
+    oldHit.mesh.getMatrixAt(oldHit.instanceId, mOld);
+    newHit.mesh.getMatrixAt(newHit.instanceId, mNew);
+    const sOld = new THREE.Vector3();
+    const sNew = new THREE.Vector3();
+    mOld.decompose(new THREE.Vector3(), new THREE.Quaternion(), sOld);
+    mNew.decompose(new THREE.Vector3(), new THREE.Quaternion(), sNew);
+
+    // Newest tree width should be ~50% of oldest tree width.
+    expect(sNew.x).toBeCloseTo(sOld.x * 0.5, 2);
+    expect(sNew.z).toBeCloseTo(sOld.z * 0.5, 2);
+  });
+
+  it('TREE_WIDTH_AGE_FLOOR = 0.0 produces near-zero width on shortest tree', () => {
+    TREES.setKey('TREE_WIDTH_AGE_FLOOR', 0.0);
+    const commits = [commit(0), commit(1), commit(2)];
+    for (const c of commits) c.files = 5;
+    const placements = [placement(0, 0), placement(1, 1), placement(2, 2)];
+    const trees = createTreeRenderer(placements, commits);
+
+    const oldHit = trees.findTreeBySha(commits[0].sha)!;
+    const newHit = trees.findTreeBySha(commits[2].sha)!;
+    const mOld = new THREE.Matrix4();
+    const mNew = new THREE.Matrix4();
+    oldHit.mesh.getMatrixAt(oldHit.instanceId, mOld);
+    newHit.mesh.getMatrixAt(newHit.instanceId, mNew);
+    const sOld = new THREE.Vector3();
+    const sNew = new THREE.Vector3();
+    mOld.decompose(new THREE.Vector3(), new THREE.Quaternion(), sOld);
+    mNew.decompose(new THREE.Vector3(), new THREE.Quaternion(), sNew);
+
+    // Newest tree should be at least 10× narrower than oldest.
+    expect(sNew.x * 10).toBeLessThan(sOld.x);
+    expect(sNew.z * 10).toBeLessThan(sOld.z);
+  });
+
+  it('degenerate height range (min == max) does not produce NaN canopy matrices', () => {
+    // When TREE_MIN_HEIGHT == TREE_MAX_HEIGHT, the heightRatio computation
+    // would divide by zero without a clamp. Verify the renderer constructs
+    // and all canopy instance matrix elements stay finite.
+    TREES.setKey('TREE_MIN_HEIGHT', 32);
+    TREES.setKey('TREE_MAX_HEIGHT', 32);
+    TREES.setKey('TREE_WIDTH_AGE_FLOOR', 0.5);
+    const commits = [commit(0), commit(1)];
+    const placements = [placement(0, 0), placement(1, 1)];
+    const trees = createTreeRenderer(placements, commits);
+
+    const canopies = trees.group.children.filter((c) =>
+      c.name.startsWith('tree-canopy-')
+    ) as THREE.InstancedMesh[];
+    expect(canopies.length).toBeGreaterThan(0);
+
+    const m = new THREE.Matrix4();
+    for (const canopy of canopies) {
+      for (let k = 0; k < canopy.count; k++) {
+        canopy.getMatrixAt(k, m);
+        for (let i = 0; i < 16; i++) {
+          expect(Number.isFinite(m.elements[i])).toBe(true);
+        }
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Multiplies the file-driven tree canopy radius by a height-ratio attenuation (`floor + (1-floor) * heightRatio`) so brand-new commits touching many files don't render as short-but-adult-wide squat lollipops. Tallest (oldest) trees keep full file-driven width; shortest (newest) trees shrink toward `TREE_WIDTH_AGE_FLOOR` × nominal.
- New config knob `TREE_WIDTH_AGE_FLOOR` (default `0.5` = 50% width at the shortest tree). `1.0` = byte-identical to pre-feature rendering; `0.0` = strict height-proportional (sapling-thin).
- New `Age shrink floor` slider in `Trees > Width by files` controls subgroup. Wired into the structural `listenKeys` reaction list so Save triggers a full rebuild.

## Test plan

- [x] Vitest: 1911 passing (4 new tests: floor=1.0 no-op, floor=0.5 halves shortest, floor=0.0 near-zero shortest, degenerate min==max height no NaN)
- [x] Typecheck clean, prettier clean
- [ ] Manual: load a repo with mixed-age commits including a recent commit touching many files. With default floor=0.5, that recent commit's canopy should look proportionally narrower than its pre-change squat-lollipop self.
- [ ] Manual: drag `Trees > Width by files > Age shrink floor` to 1.0 and Save — recent-tall commits should snap back to full file-driven width. Drag to 0.0 and Save — recent-tall commits should collapse to near-point saplings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)