### PR TITLE
chore: harden release recipe, fixture sentinel, prettier ignore

### DIFF
--- a/api/tests/test_scan.py
+++ b/api/tests/test_scan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import os
 import shutil
 import subprocess
@@ -94,28 +95,46 @@ def _ensure_fixture() -> None:
     exclusive file lock and gate the skip-decision on a sentinel
     file that's only written after setup.sh completes successfully —
     `.git` existence alone is not enough.
+
+    The sentinel records the sha256 of setup.sh, not just existence.
+    Any change to setup.sh (new commits, new files, renamed authors)
+    invalidates the on-disk fixture and forces a rebuild. Without this,
+    an older fixture from before a setup.sh edit silently survives and
+    causes assertion failures that look like product bugs.
     """
     sentinel = FIXTURES_DIR / ".sample-repo-ready"
     lockfile_path = FIXTURES_DIR / ".sample-repo-setup.lock"
+    setup_script = FIXTURES_DIR / "setup.sh"
+    setup_hash = hashlib.sha256(setup_script.read_bytes()).hexdigest()
     lockfile_path.touch(exist_ok=True)
     with open(lockfile_path) as fp:
         fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
         try:
-            if not sentinel.is_file():
+            recorded = sentinel.read_text().strip() if sentinel.is_file() else ""
+            if recorded != setup_hash:
                 # Wipe any partial state from an interrupted prior run
                 # so setup.sh's `rm -rf` isn't the only safety net.
                 if _CANONICAL_FIXTURE.exists():
                     shutil.rmtree(_CANONICAL_FIXTURE)
-                subprocess.check_call(["bash", str(FIXTURES_DIR / "setup.sh")])
-                sentinel.touch()
+                subprocess.check_call(["bash", str(setup_script)])
+                sentinel.write_text(setup_hash)
         finally:
             fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
-    # Per-worker copy: safe outside the lock because the sentinel now
-    # guards future setup.sh runs (nothing else can mutate the canonical)
-    # and each worker writes to its own unique FIXTURE path.
-    if FIXTURE != _CANONICAL_FIXTURE and not (FIXTURE / ".git").is_dir():
-        FIXTURE.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(_CANONICAL_FIXTURE, FIXTURE)
+    # Per-worker copy: safe outside the lock because the canonical sentinel
+    # now guards future setup.sh runs (nothing else can mutate the canonical)
+    # and each worker writes to its own unique FIXTURE path. The per-worker
+    # marker tracks the same setup.sh hash so an edit between pytest runs
+    # invalidates stale worker copies too (without this, .git-exists alone
+    # would silently reuse a copy made from the prior setup.sh).
+    if FIXTURE != _CANONICAL_FIXTURE:
+        worker_marker = FIXTURE.parent / ".sample-repo-ready"
+        recorded = worker_marker.read_text().strip() if worker_marker.is_file() else ""
+        if recorded != setup_hash or not (FIXTURE / ".git").is_dir():
+            if FIXTURE.exists():
+                shutil.rmtree(FIXTURE)
+            FIXTURE.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(_CANONICAL_FIXTURE, FIXTURE)
+            worker_marker.write_text(setup_hash)
 
 
 class _CacheRedirectMixin:

--- a/app/.prettierignore
+++ b/app/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 ../api/static
 package-lock.json
 coverage
+dist

--- a/justfile
+++ b/justfile
@@ -112,7 +112,11 @@ install-hooks:
 # which builds the multi-arch image, signs it, smoke-tests, and creates the
 # GitHub Release. VERSION must look like v1.2.3 or v1.2.3-alpha-4 / v1.2.3-rc.1.
 # Refuses to tag unless: on main, working tree clean, in sync with origin/main,
-# and the tag doesn't already exist locally or on origin.
+# and the tag doesn't already exist on origin. If the local tag already exists
+# at HEAD (resumable state from a prior push failure — e.g. pre-push hook
+# failed after `git tag -a` succeeded), pushes it without re-tagging. If push
+# fails after this run created the tag, the local tag is rolled back so the
+# recipe can be retried cleanly.
 release VERSION:
     @set -e ; \
      VERSION="{{VERSION}}" ; \
@@ -132,16 +136,29 @@ release VERSION:
      if [ "$LOCAL" != "$REMOTE" ]; then \
          echo "[just] error: local main ($LOCAL) is not in sync with origin/main ($REMOTE); pull/push first" >&2 ; exit 1 ; \
      fi ; \
-     if git rev-parse --verify --quiet "refs/tags/$VERSION" >/dev/null; then \
-         echo "[just] error: tag $VERSION already exists locally" >&2 ; exit 1 ; \
-     fi ; \
      if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then \
          echo "[just] error: tag $VERSION already exists on origin" >&2 ; exit 1 ; \
      fi ; \
-     echo "[just] tagging $VERSION at $LOCAL" ; \
-     git tag -a "$VERSION" -m "Release $VERSION" ; \
+     CREATED_TAG=no ; \
+     if git rev-parse --verify --quiet "refs/tags/$VERSION" >/dev/null; then \
+         TAG_COMMIT=$(git rev-parse "refs/tags/$VERSION^{commit}") ; \
+         if [ "$TAG_COMMIT" != "$LOCAL" ]; then \
+             echo "[just] error: local tag $VERSION points to $TAG_COMMIT, not current main ($LOCAL); 'git tag -d $VERSION' and retry" >&2 ; exit 1 ; \
+         fi ; \
+         echo "[just] tag $VERSION already exists locally at $LOCAL — resuming push" ; \
+     else \
+         echo "[just] tagging $VERSION at $LOCAL" ; \
+         git tag -a "$VERSION" -m "Release $VERSION" ; \
+         CREATED_TAG=yes ; \
+     fi ; \
      echo "[just] pushing $VERSION to origin" ; \
-     git push origin "$VERSION" ; \
+     if ! git push origin "$VERSION"; then \
+         if [ "$CREATED_TAG" = "yes" ]; then \
+             echo "[just] push failed; rolling back local tag $VERSION" >&2 ; \
+             git tag -d "$VERSION" >/dev/null ; \
+         fi ; \
+         exit 1 ; \
+     fi ; \
      REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "<owner>/<repo>") ; \
      echo "[just] released — watch: https://github.com/$REPO/actions/workflows/release.yml"
 


### PR DESCRIPTION
## Summary

Three issues surfaced while shipping `v0.0.0-alpha-6`:

- **`justfile`** — `release` recipe is now resumable. A prior push failure that left an orphan local tag at HEAD no longer blocks retries; the recipe pushes the existing tag instead of erroring. If push fails on a tag this run created, the local tag is rolled back so the next attempt starts clean.
- **`api/tests/test_scan.py`** — fixture sentinel was a touchfile, so any edit to `setup.sh` (e.g. PR #42 adding the second-author commit) left local fixtures stale and silently broke scanner tests for everyone who pulled main. Sentinel now records `sha256(setup.sh)`; both the canonical fixture and per-worker xdist copies invalidate when the script changes.
- **`app/.prettierignore`** — `dist` was missing, so anyone with build artifacts around tripped `prettier --check` in the pre-push gate.

## Test plan
- [x] Local pytest passes (`docker compose -f docker-compose.test.yml run --rm pytest api/tests/test_scan.py api/tests/test_server_commit.py` → 62 passed)
- [x] Pre-push hook (all 5 steps) passes
- [x] `just --list` parses
- [x] Manual: deleted local sentinel + dist, full quality gate ran clean
- [ ] CI on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)