### PR TITLE
Top-down focus framing, road sidebar, commit focus, 5-tier fade cascade

### DIFF
--- a/app/src/config/components/buildings.ts
+++ b/app/src/config/components/buildings.ts
@@ -251,9 +251,12 @@ export const BUILDING_AGING = map<BuildingAgingConfig>({
 // When something is selected, every other building is categorized by its
 // directory-tree distance from the selection and rendered per the matching
 // tier's style:
-//   DEFAULT — distance 0 (selection's siblings; also the no-selection state)
-//   NEAR    — distance 1 (one hop along the directory spine)
-//   FAR     — distance ≥2 (cousins, deeper subtrees, unrelated branches)
+//   DEFAULT — applies to the selected/hovered building itself and to every
+//             building when nothing is selected (idle state).
+//   Level 1 — same dir as the selection (or the dir's direct files).
+//   Level 2 — one directory deeper than the selection.
+//   Level 3 — deeper descendants (two or more directories below).
+//   Level 4 — outside the selection's subtree entirely.
 //
 // Each tier picks how a building looks via four independent knobs:
 //   *_DETAIL          — 'full' (textured walls + windows + doors)
@@ -273,32 +276,53 @@ export interface BuildingFadeConfig {
   DEFAULT_OUTLINE: boolean;
   DEFAULT_BODY_OPACITY: number;
   DEFAULT_OUTLINE_OPACITY: number;
-  NEAR_DETAIL: FadeDetail;
-  NEAR_OUTLINE: boolean;
-  NEAR_BODY_OPACITY: number;
-  NEAR_OUTLINE_OPACITY: number;
-  FAR_DETAIL: FadeDetail;
-  FAR_OUTLINE: boolean;
-  FAR_BODY_OPACITY: number;
-  FAR_OUTLINE_OPACITY: number;
+  LEVEL1_DETAIL: FadeDetail;
+  LEVEL1_OUTLINE: boolean;
+  LEVEL1_BODY_OPACITY: number;
+  LEVEL1_OUTLINE_OPACITY: number;
+  LEVEL2_DETAIL: FadeDetail;
+  LEVEL2_OUTLINE: boolean;
+  LEVEL2_BODY_OPACITY: number;
+  LEVEL2_OUTLINE_OPACITY: number;
+  LEVEL3_DETAIL: FadeDetail;
+  LEVEL3_OUTLINE: boolean;
+  LEVEL3_BODY_OPACITY: number;
+  LEVEL3_OUTLINE_OPACITY: number;
+  LEVEL4_DETAIL: FadeDetail;
+  LEVEL4_OUTLINE: boolean;
+  LEVEL4_BODY_OPACITY: number;
+  LEVEL4_OUTLINE_OPACITY: number;
 }
 
 export const BUILDING_FADE = map<BuildingFadeConfig>({
-  // Default tier — siblings of selection, and the no-selection resting state.
+  // Default tier — applies to the selected/hovered building itself
+  // and to every building when nothing is selected (idle state).
   DEFAULT_DETAIL: FadeDetail.Full,
   DEFAULT_OUTLINE: false,
   DEFAULT_BODY_OPACITY: 1.0,
   DEFAULT_OUTLINE_OPACITY: 1.0,
 
-  // Level 1 — one hop from selection along the directory spine.
-  NEAR_DETAIL: FadeDetail.Silhouette,
-  NEAR_OUTLINE: true,
-  NEAR_BODY_OPACITY: 0.75,
-  NEAR_OUTLINE_OPACITY: 0.75,
+  // Level 1 — same dir as the selection (or the dir's direct files).
+  LEVEL1_DETAIL: FadeDetail.Silhouette,
+  LEVEL1_OUTLINE: true,
+  LEVEL1_BODY_OPACITY: 0.75,
+  LEVEL1_OUTLINE_OPACITY: 0.75,
 
-  // Level 2+ — anything farther.
-  FAR_DETAIL: FadeDetail.Silhouette,
-  FAR_OUTLINE: true,
-  FAR_BODY_OPACITY: 0.1,
-  FAR_OUTLINE_OPACITY: 0.5,
+  // Level 2 — one directory deeper than the selection.
+  LEVEL2_DETAIL: FadeDetail.Silhouette,
+  LEVEL2_OUTLINE: true,
+  LEVEL2_BODY_OPACITY: 0.1,
+  LEVEL2_OUTLINE_OPACITY: 0.5,
+
+  // Level 3 — deeper descendants (two or more directories below).
+  LEVEL3_DETAIL: FadeDetail.Silhouette,
+  LEVEL3_OUTLINE: true,
+  LEVEL3_BODY_OPACITY: 0.1,
+  LEVEL3_OUTLINE_OPACITY: 0.5,
+
+  // Level 4 — outside the selection's subtree entirely.
+  LEVEL4_DETAIL: FadeDetail.Hidden,
+  LEVEL4_OUTLINE: true,
+  LEVEL4_BODY_OPACITY: 0.1,
+  LEVEL4_OUTLINE_OPACITY: 0.5,
 });

--- a/app/src/config/components/buildings.ts
+++ b/app/src/config/components/buildings.ts
@@ -303,26 +303,26 @@ export const BUILDING_FADE = map<BuildingFadeConfig>({
   DEFAULT_OUTLINE_OPACITY: 1.0,
 
   // Level 1 — same dir as the selection (or the dir's direct files).
-  LEVEL1_DETAIL: FadeDetail.Silhouette,
-  LEVEL1_OUTLINE: true,
-  LEVEL1_BODY_OPACITY: 0.75,
-  LEVEL1_OUTLINE_OPACITY: 0.75,
+  LEVEL1_DETAIL: FadeDetail.Full,
+  LEVEL1_OUTLINE: false,
+  LEVEL1_BODY_OPACITY: 1.0,
+  LEVEL1_OUTLINE_OPACITY: 1.0,
 
   // Level 2 — one directory deeper than the selection.
   LEVEL2_DETAIL: FadeDetail.Silhouette,
   LEVEL2_OUTLINE: true,
-  LEVEL2_BODY_OPACITY: 0.1,
+  LEVEL2_BODY_OPACITY: 0.5,
   LEVEL2_OUTLINE_OPACITY: 0.5,
 
   // Level 3 — deeper descendants (two or more directories below).
   LEVEL3_DETAIL: FadeDetail.Silhouette,
   LEVEL3_OUTLINE: true,
-  LEVEL3_BODY_OPACITY: 0.1,
+  LEVEL3_BODY_OPACITY: 0.25,
   LEVEL3_OUTLINE_OPACITY: 0.5,
 
   // Level 4 — outside the selection's subtree entirely.
-  LEVEL4_DETAIL: FadeDetail.Hidden,
+  LEVEL4_DETAIL: FadeDetail.Silhouette,
   LEVEL4_OUTLINE: true,
-  LEVEL4_BODY_OPACITY: 0.1,
+  LEVEL4_BODY_OPACITY: 0.05,
   LEVEL4_OUTLINE_OPACITY: 0.5,
 });

--- a/app/src/config/components/buildings.ts
+++ b/app/src/config/components/buildings.ts
@@ -311,7 +311,7 @@ export const BUILDING_FADE = map<BuildingFadeConfig>({
   // Level 2 — one directory deeper than the selection.
   LEVEL2_DETAIL: FadeDetail.Silhouette,
   LEVEL2_OUTLINE: true,
-  LEVEL2_BODY_OPACITY: 0.5,
+  LEVEL2_BODY_OPACITY: 0.75,
   LEVEL2_OUTLINE_OPACITY: 0.5,
 
   // Level 3 — deeper descendants (two or more directories below).

--- a/app/src/coordinator.ts
+++ b/app/src/coordinator.ts
@@ -156,7 +156,6 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
       if (sel.kind === NodeKind.File) rig.focusBuilding(sel.mesh, sel.data);
       else if (sel.kind === NodeKind.Directory) rig.focusStreet(sel.street, null);
       else if (sel.kind === NodeKind.Commit) rig.focusTree(sel.commit.sha);
-      else if (sel.kind === NodeKind.Gem) rig.focusGem();
     },
     branch: _initBranch,
     sourceUrl: _initIsGitUrl ? _initSrc : undefined,

--- a/app/src/coordinator.ts
+++ b/app/src/coordinator.ts
@@ -111,8 +111,20 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
     }
     if (sidebarPane === 'street') {
       showRightSidebar(streetPane.pane);
-      if (sel && sel.kind === NodeKind.Directory) streetPane.api.setDirectory(sel.dir);
-      else streetPane.api.setDirectory(null);
+      // Defer the heavy DOM mutation past the current event-loop task —
+      // setDirectory walks the descendant subtree and builds rows for every
+      // extension, which is enough work that running it synchronously
+      // during the pointerup that triggered this render confused canvas
+      // pointer state and broke subsequent hover/click. setTimeout(0)
+      // yields the task so the pointer event lifecycle completes first.
+      const _sel = sel;
+      setTimeout(() => {
+        if (_sel && _sel.kind === NodeKind.Directory) {
+          streetPane.api.setDirectory(_sel.dir);
+        } else {
+          streetPane.api.setDirectory(null);
+        }
+      }, 0);
       return;
     }
   }

--- a/app/src/coordinator.ts
+++ b/app/src/coordinator.ts
@@ -367,10 +367,10 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
     _updateFooterFromState();
 
     // Right sidebar pane choice mirrors selection kind. File → preview,
-    // Commit → commit pane, Directory → street pane, anything else closes.
+    // Commit → commit pane, anything else closes.
+    // PROBE DISABLED: Directory → street pane routing disabled for isolation.
     if (sel && sel.kind === NodeKind.File) sidebarPane = 'file';
     else if (sel && sel.kind === NodeKind.Commit) sidebarPane = 'commit';
-    else if (sel && sel.kind === NodeKind.Directory) sidebarPane = 'street';
     else sidebarPane = null;
 
     _renderSidebar();
@@ -426,6 +426,7 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
         color: _color,
       });
     }
+    /* PROBE DISABLED: world.onChange directory-refresh block removed for isolation.
     const _selForDir = picker.selection.get();
     if (_selForDir && _selForDir.kind === NodeKind.Directory) {
       // Live-update poll may have swapped the DirNode under us — re-resolve
@@ -437,6 +438,7 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
       const dir = refreshed?.dir ?? _selForDir.dir;
       streetPane.api.setDirectory(dir);
     }
+    PROBE DISABLED */
   });
 
   function dispose() {

--- a/app/src/coordinator.ts
+++ b/app/src/coordinator.ts
@@ -22,6 +22,7 @@ import { showLeftSidebar } from './views/shell/leftSidebar.js';
 import { showRightSidebar, hideRightSidebar } from './views/shell/rightSidebar.js';
 import { buildFilePreviewPane, humanLanguageFor } from './views/panes/filePreviewPane.js';
 import { buildCommitPane } from './views/panes/commitPane.js';
+import { buildStreetPane } from './views/panes/streetPane.js';
 import { sameDayCommitCount } from './views/widgets/commitMetrics.js';
 import { labelFromDisplayRoot } from './views/widgets/displayLabel.js';
 import { LIVE_UPDATES } from './config/index.js';
@@ -47,7 +48,7 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
   //   File → filePreview
   //   Commit → commitPane
   //   anything else → sidebar closed
-  type SidebarPane = 'file' | 'commit' | null;
+  type SidebarPane = 'file' | 'commit' | 'street' | null;
   let sidebarPane: SidebarPane = null;
 
   const filePreview = buildFilePreviewPane({
@@ -65,6 +66,20 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
     onClose() {
       sidebarPane = null;
       _renderSidebar();
+    },
+    onFocus(c) {
+      rig.focusTree(c.sha);
+    },
+  });
+
+  const streetPane = buildStreetPane({
+    onClose() {
+      sidebarPane = null;
+      _renderSidebar();
+    },
+    onFocus(d) {
+      const st = world.getStreetByDir(d.path);
+      if (st) rig.focusStreet(st, null);
     },
   });
 
@@ -92,6 +107,13 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
       } else {
         commitPane.api.setCommit(null);
       }
+      return;
+    }
+    if (sidebarPane === 'street') {
+      showRightSidebar(streetPane.pane);
+      if (sel && sel.kind === NodeKind.Directory) streetPane.api.setDirectory(sel.dir);
+      else streetPane.api.setDirectory(null);
+      return;
     }
   }
 
@@ -131,11 +153,10 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
     onFocus() {
       const sel = picker.selection.get();
       if (!sel) return;
-      if (sel.kind === NodeKind.File) {
-        rig.focusBuilding(sel.mesh, sel.data);
-      } else if (sel.kind === NodeKind.Directory) {
-        rig.focusStreet(sel.street, null);
-      }
+      if (sel.kind === NodeKind.File) rig.focusBuilding(sel.mesh, sel.data);
+      else if (sel.kind === NodeKind.Directory) rig.focusStreet(sel.street, null);
+      else if (sel.kind === NodeKind.Commit) rig.focusTree(sel.commit.sha);
+      else if (sel.kind === NodeKind.Gem) rig.focusGem();
     },
     branch: _initBranch,
     sourceUrl: _initIsGitUrl ? _initSrc : undefined,
@@ -315,32 +336,42 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
     }
 
     // Breadcrumb tail
-    const node: FileNode | DirNode | null = sel
-      ? sel.kind === NodeKind.File
-        ? sel.file
-        : sel.kind === NodeKind.Directory
-          ? sel.dir
-          : null
-      : null;
-    appHeader.setSelection(
-      node && sel
-        ? {
-            path: node.path || node.fullPath || node.name || '',
-            fullPath: node.fullPath || '',
-            extension: 'extension' in node ? node.extension || '' : '',
-            isDir: sel.kind === NodeKind.Directory,
-          }
-        : null
-    );
+    if (sel?.kind === NodeKind.Commit) {
+      appHeader.setSelection({
+        kind: 'commit',
+        sha: sel.commit.sha,
+        author: sel.commit.author,
+      });
+    } else if (sel?.kind === NodeKind.File) {
+      const node = sel.file;
+      appHeader.setSelection({
+        kind: 'file',
+        path: node.path || node.fullPath || node.name || '',
+        fullPath: node.fullPath || '',
+        extension: node.extension || '',
+        isDir: false,
+      });
+    } else if (sel?.kind === NodeKind.Directory) {
+      const node = sel.dir;
+      appHeader.setSelection({
+        kind: 'dir',
+        path: node.path || node.fullPath || node.name || '',
+        fullPath: node.fullPath || '',
+        isDir: true,
+      });
+    } else {
+      appHeader.setSelection(null);
+    }
 
     // Footer: if nothing is hovered, mirror the new selection; if a
     // hover is active the hover subscriber already owns the footer.
     _updateFooterFromState();
 
     // Right sidebar pane choice mirrors selection kind. File → preview,
-    // Commit → commit pane, anything else closes the sidebar.
+    // Commit → commit pane, Directory → street pane, anything else closes.
     if (sel && sel.kind === NodeKind.File) sidebarPane = 'file';
     else if (sel && sel.kind === NodeKind.Commit) sidebarPane = 'commit';
+    else if (sel && sel.kind === NodeKind.Directory) sidebarPane = 'street';
     else sidebarPane = null;
 
     _renderSidebar();

--- a/app/src/coordinator.ts
+++ b/app/src/coordinator.ts
@@ -427,6 +427,17 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
         color: _color,
       });
     }
+    const _selForDir = picker.selection.get();
+    if (_selForDir && _selForDir.kind === NodeKind.Directory) {
+      // Live-update poll may have swapped the DirNode under us — re-resolve
+      // the directory by path from the freshly applied manifest and push the
+      // refreshed node into the street pane so counts + extension breakdown
+      // stay in sync.
+      const refreshed = world.getStreetByDir(_selForDir.dir.path);
+      // Prefer the fresh DirNode if available, fall back to stale selection.
+      const dir = refreshed?.dir ?? _selForDir.dir;
+      streetPane.api.setDirectory(dir);
+    }
   });
 
   function dispose() {

--- a/app/src/coordinator.ts
+++ b/app/src/coordinator.ts
@@ -367,10 +367,10 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
     _updateFooterFromState();
 
     // Right sidebar pane choice mirrors selection kind. File → preview,
-    // Commit → commit pane, anything else closes.
-    // PROBE DISABLED: Directory → street pane routing disabled for isolation.
+    // Commit → commit pane, Directory → street pane, anything else closes.
     if (sel && sel.kind === NodeKind.File) sidebarPane = 'file';
     else if (sel && sel.kind === NodeKind.Commit) sidebarPane = 'commit';
+    else if (sel && sel.kind === NodeKind.Directory) sidebarPane = 'street';
     else sidebarPane = null;
 
     _renderSidebar();
@@ -426,7 +426,6 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
         color: _color,
       });
     }
-    /* PROBE DISABLED: world.onChange directory-refresh block removed for isolation.
     const _selForDir = picker.selection.get();
     if (_selForDir && _selForDir.kind === NodeKind.Directory) {
       // Live-update poll may have swapped the DirNode under us — re-resolve
@@ -438,7 +437,6 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
       const dir = refreshed?.dir ?? _selForDir.dir;
       streetPane.api.setDirectory(dir);
     }
-    PROBE DISABLED */
   });
 
   function dispose() {

--- a/app/src/scene/components/adPanels/adPanelsInstanced.ts
+++ b/app/src/scene/components/adPanels/adPanelsInstanced.ts
@@ -88,7 +88,7 @@ export class InstancedAdPanels {
   private readonly _iTextureFade: Float32Array;
   // Per-instance opacity multiplier, driven by buildingFader so an ad
   // panel fades down in lockstep with its underlying building body when
-  // the selection cascade demotes that building to NEAR / FAR tier.
+  // the selection cascade demotes that building to Level 1-4 tiers.
   private readonly _iBuildingFade: Float32Array;
   // Plain AD_ERROR_COLOR (no emission bake) — emission is applied uniformly
   // via uEmissionBoost in the shader. Cached so markBuildingErrored doesn't
@@ -381,7 +381,7 @@ export class InstancedAdPanels {
    * Push a per-building opacity multiplier onto every ad panel for which
    * `getFade` returns a value. Used by buildingFader so an ad panel fades
    * to the same opacity as its underlying building body during a selection
-   * cascade — a NEAR-tier building's panel drops to NEAR_BODY_OPACITY in
+   * cascade — a Level-1 building's panel drops to LEVEL1_BODY_OPACITY in
    * lockstep, not full brightness.
    *
    * `getFade(path)` returning `null` (or undefined) leaves that building's

--- a/app/src/scene/components/trees/treeRenderer.ts
+++ b/app/src/scene/components/trees/treeRenderer.ts
@@ -68,6 +68,17 @@ export interface Trees {
    *  to snap the hover/selected outline mesh's transform to the active
    *  tree without an extra Matrix4 allocation per frame. */
   getInstanceTransform(sha: string, out: THREE.Matrix4): boolean;
+  /** Look up a tree's world position and dimensions by commit SHA.
+   *  Returns null for an unknown sha, or when commits is null. The (x, z)
+   *  are the tree's XZ position; y is the base (always 0). height is the
+   *  trunk-top to canopy-top distance; radius is the canopy XZ radius. */
+  getTreeBoundsBySha(sha: string): {
+    x: number;
+    y: number;
+    z: number;
+    height: number;
+    radius: number;
+  } | null;
 }
 
 /** Three subdivision tiers for the LatheGeometry canopy. File count
@@ -531,6 +542,30 @@ export function createTreeRenderer(
     return _baseColorBySha.get(sha) ?? null;
   }
 
+  function getTreeBoundsBySha(sha: string): {
+    x: number;
+    y: number;
+    z: number;
+    height: number;
+    radius: number;
+  } | null {
+    if (!commits) return null;
+    const hit = _treeIndexBySha.get(sha);
+    if (!hit) return null;
+    // Find the source placement index: the meshRecord's placementOrder
+    // array maps slot → placement index. Read it directly.
+    const placementIdx = (hit.mesh.userData.placementOrder as number[])[hit.instanceId];
+    if (placementIdx == null) return null;
+    const p = placements[placementIdx];
+    return {
+      x: p.x,
+      y: 0,
+      z: p.y,
+      height: perTreeHeight(placementIdx),
+      radius: perTreeRadius(placementIdx),
+    };
+  }
+
   return {
     group,
     refresh,
@@ -539,5 +574,6 @@ export function createTreeRenderer(
     findTreeBySha,
     getInstanceTransform,
     colorForSha,
+    getTreeBoundsBySha,
   };
 }

--- a/app/src/scene/effects/buildingFader.ts
+++ b/app/src/scene/effects/buildingFader.ts
@@ -29,17 +29,22 @@ interface TierResult {
   outlineOpacity: number;
 }
 
-// True when `file`'s parent directory is exactly `dir.path` OR a path-prefix
-// descendant of it (i.e. file sits inside dir's subtree at any depth). The
-// trailing slash in the startsWith check guards against false positives:
-// "src-utils" must NOT count as a descendant of "src".
-function _isInSubtree(file: FileNode | null, dir: DirNode): boolean {
-  if (!file || !file.path || !dir || dir.path == null) return false;
+// Tier level for a building relative to the directory target.
+// Returns 1 when the file sits in the same dir as the target, 2 when its
+// parent dir is a direct sub-dir of the target, 3 for deeper descendants,
+// and 4 when the file is outside the target's subtree entirely. The
+// trailing-slash guard in the startsWith check prevents "src-utils" from
+// being treated as a descendant of "src".
+function _tierLevelFor(file: FileNode | null, dir: DirNode): 1 | 2 | 3 | 4 {
+  if (!file?.path || !dir || dir.path == null) return 4;
   let parent = parentDirPath(file.path);
   if (parent == null) parent = '.';
-  if (parent === dir.path) return true;
-  if (dir.path === '.' || dir.path === '') return true;
-  return parent.startsWith(`${dir.path}/`);
+  if (parent === dir.path) return 1;
+  const isRoot = dir.path === '.' || dir.path === '';
+  if (!isRoot && !parent.startsWith(`${dir.path}/`)) return 4;
+  const rel = isRoot ? parent : parent.slice(dir.path.length + 1);
+  const depthBelow = rel.split('/').length;
+  return depthBelow === 1 ? 2 : 3;
 }
 
 export function createBuildingFader({
@@ -101,30 +106,45 @@ export function createBuildingFader({
     }
 
     if (bldgTargetFile && file.path === bldgTargetFile.path) {
-      // Selected building: always full body, no per-building outline
-      // (the dedicated selectedOutline mesh from outlineRenderer handles it).
       return {
-        detail: FadeDetail.Full,
-        bodyOpacity: 1.0,
-        outlineEnabled: false,
-        outlineOpacity: 0,
+        detail: fadeCfg.DEFAULT_DETAIL,
+        bodyOpacity: fadeCfg.DEFAULT_BODY_OPACITY,
+        outlineEnabled: fadeCfg.DEFAULT_OUTLINE,
+        outlineOpacity: fadeCfg.DEFAULT_OUTLINE_OPACITY,
       };
     }
 
     if (dirTarget) {
-      if (_isInSubtree(file, dirTarget)) {
+      const lvl = _tierLevelFor(file, dirTarget);
+      if (lvl === 1) {
         return {
-          detail: fadeCfg.NEAR_DETAIL,
-          bodyOpacity: fadeCfg.NEAR_BODY_OPACITY,
-          outlineEnabled: fadeCfg.NEAR_OUTLINE,
-          outlineOpacity: fadeCfg.NEAR_OUTLINE_OPACITY,
+          detail: fadeCfg.LEVEL1_DETAIL,
+          bodyOpacity: fadeCfg.LEVEL1_BODY_OPACITY,
+          outlineEnabled: fadeCfg.LEVEL1_OUTLINE,
+          outlineOpacity: fadeCfg.LEVEL1_OUTLINE_OPACITY,
+        };
+      }
+      if (lvl === 2) {
+        return {
+          detail: fadeCfg.LEVEL2_DETAIL,
+          bodyOpacity: fadeCfg.LEVEL2_BODY_OPACITY,
+          outlineEnabled: fadeCfg.LEVEL2_OUTLINE,
+          outlineOpacity: fadeCfg.LEVEL2_OUTLINE_OPACITY,
+        };
+      }
+      if (lvl === 3) {
+        return {
+          detail: fadeCfg.LEVEL3_DETAIL,
+          bodyOpacity: fadeCfg.LEVEL3_BODY_OPACITY,
+          outlineEnabled: fadeCfg.LEVEL3_OUTLINE,
+          outlineOpacity: fadeCfg.LEVEL3_OUTLINE_OPACITY,
         };
       }
       return {
-        detail: fadeCfg.FAR_DETAIL,
-        bodyOpacity: fadeCfg.FAR_BODY_OPACITY,
-        outlineEnabled: fadeCfg.FAR_OUTLINE,
-        outlineOpacity: fadeCfg.FAR_OUTLINE_OPACITY,
+        detail: fadeCfg.LEVEL4_DETAIL,
+        bodyOpacity: fadeCfg.LEVEL4_BODY_OPACITY,
+        outlineEnabled: fadeCfg.LEVEL4_OUTLINE,
+        outlineOpacity: fadeCfg.LEVEL4_OUTLINE_OPACITY,
       };
     }
 

--- a/app/src/scene/effects/buildingFader.ts
+++ b/app/src/scene/effects/buildingFader.ts
@@ -29,22 +29,25 @@ interface TierResult {
   outlineOpacity: number;
 }
 
-// Tier level for a building relative to the directory target.
-// Returns 1 when the file sits in the same dir as the target, 2 when its
-// parent dir is a direct sub-dir of the target, 3 for deeper descendants,
-// and 4 when the file is outside the target's subtree entirely. The
-// trailing-slash guard in the startsWith check prevents "src-utils" from
-// being treated as a descendant of "src".
+// Tier level for a building relative to the directory target, measured
+// as the symmetric directory-tree distance: hops up to the lowest common
+// ancestor plus hops back down. distance 0 = same dir (L1); 1 = one hop
+// in either direction (L2); 2 = two hops (L3); 3+ = far (L4). Going up
+// matters the same as going down so a file in `src/lib/` and a file in
+// `src/foo/bar/` are equally "near" a selection in `src/foo/`.
 function _tierLevelFor(file: FileNode | null, dir: DirNode): 1 | 2 | 3 | 4 {
   if (!file?.path || !dir || dir.path == null) return 4;
   let parent = parentDirPath(file.path);
   if (parent == null) parent = '.';
-  if (parent === dir.path) return 1;
-  const isRoot = dir.path === '.' || dir.path === '';
-  if (!isRoot && !parent.startsWith(`${dir.path}/`)) return 4;
-  const rel = isRoot ? parent : parent.slice(dir.path.length + 1);
-  const depthBelow = rel.split('/').length;
-  return depthBelow === 1 ? 2 : 3;
+  const ap = parent === '.' || parent === '' ? [] : parent.split('/');
+  const dp = dir.path === '.' || dir.path === '' ? [] : dir.path.split('/');
+  let lca = 0;
+  while (lca < ap.length && lca < dp.length && ap[lca] === dp[lca]) lca++;
+  const distance = ap.length - lca + (dp.length - lca);
+  if (distance === 0) return 1;
+  if (distance === 1) return 2;
+  if (distance === 2) return 3;
+  return 4;
 }
 
 export function createBuildingFader({

--- a/app/src/scene/effects/buildingFader.ts
+++ b/app/src/scene/effects/buildingFader.ts
@@ -29,16 +29,17 @@ interface TierResult {
   outlineOpacity: number;
 }
 
-function _dirTreeDistance(file: FileNode | null, dir: DirNode): number {
-  if (!file || !file.path || !dir || dir.path == null) return Infinity;
+// True when `file`'s parent directory is exactly `dir.path` OR a path-prefix
+// descendant of it (i.e. file sits inside dir's subtree at any depth). The
+// trailing slash in the startsWith check guards against false positives:
+// "src-utils" must NOT count as a descendant of "src".
+function _isInSubtree(file: FileNode | null, dir: DirNode): boolean {
+  if (!file || !file.path || !dir || dir.path == null) return false;
   let parent = parentDirPath(file.path);
   if (parent == null) parent = '.';
-  if (parent === dir.path) return 0;
-  const ap = parent === '.' || parent === '' ? [] : parent.split('/');
-  const dp = dir.path === '.' || dir.path === '' ? [] : dir.path.split('/');
-  let lca = 0;
-  while (lca < ap.length && lca < dp.length && ap[lca] === dp[lca]) lca++;
-  return ap.length - lca + (dp.length - lca);
+  if (parent === dir.path) return true;
+  if (dir.path === '.' || dir.path === '') return true;
+  return parent.startsWith(`${dir.path}/`);
 }
 
 export function createBuildingFader({
@@ -111,16 +112,7 @@ export function createBuildingFader({
     }
 
     if (dirTarget) {
-      const dist = _dirTreeDistance(file, dirTarget);
-      if (dist === 0) {
-        return {
-          detail: fadeCfg.DEFAULT_DETAIL,
-          bodyOpacity: fadeCfg.DEFAULT_BODY_OPACITY,
-          outlineEnabled: fadeCfg.DEFAULT_OUTLINE,
-          outlineOpacity: fadeCfg.DEFAULT_OUTLINE_OPACITY,
-        };
-      }
-      if (dist === 1) {
+      if (_isInSubtree(file, dirTarget)) {
         return {
           detail: fadeCfg.NEAR_DETAIL,
           bodyOpacity: fadeCfg.NEAR_BODY_OPACITY,

--- a/app/src/scene/system/cameraRig.ts
+++ b/app/src/scene/system/cameraRig.ts
@@ -346,18 +346,16 @@ export function createCameraRig({
     const halfV = (camera.fov * Math.PI) / 180 / 2;
     const halfH = Math.atan(Math.tan(halfV) * camera.aspect);
 
-    // At 80° elevation, a vertical span of fitH projects onto the screen-
-    // vertical axis as fitH·cos(elev). Take the larger of the projected
-    // height and the depth span as the effective vertical extent.
-    const effW = fitW;
-    const effD = Math.max(fitD, fitH * Math.cos(elevRad));
-    const distW = effW / 2 / Math.tan(halfH);
-    const distD = effD / 2 / Math.tan(halfV);
-    // Clamp against the OrbitControls dolly floor so small targets (a
-    // sub-unit radius tree, an empty street) don't put the camera inside
-    // the geometry — _animateCamera writes camera.position directly,
-    // bypassing the dolly clamp that would normally apply at zoom time.
-    const dist = Math.max(distW * TOP_DOWN_PADDING_MULT, distD * TOP_DOWN_PADDING_MULT, controls.minDistance);
+    // Fit the target's bounding sphere. R encloses every span the target
+    // can present to the camera regardless of azimuth — for a tall building
+    // this prevents the camera landing inside the geometry when looking
+    // nearly-overhead at the b.h/2 centroid.
+    const R = 0.5 * Math.sqrt(fitW * fitW + fitD * fitD + fitH * fitH);
+    const halfFov = Math.min(halfV, halfH);
+    const dist = Math.max(
+      (R / Math.sin(halfFov)) * TOP_DOWN_PADDING_MULT,
+      controls.minDistance,
+    );
 
     // Azimuth: preserve current horizontal direction from target → camera.
     // If the camera is too close to nadir, fall back to the root-street axis.

--- a/app/src/scene/system/cameraRig.ts
+++ b/app/src/scene/system/cameraRig.ts
@@ -59,7 +59,7 @@ const STREET_FOCUS_RATIO = 1.2;
 // 80° elevation gives the user a near-overhead read while still showing
 // enough side-faces for 3D depth. Stays under controls.maxPolarAngle.
 const TOP_DOWN_ELEVATION_DEG = 80;
-const TOP_DOWN_PADDING_MULT = 1.8;
+const TOP_DOWN_PADDING_MULT = 2.8;
 
 export function createCameraRig({
   canvas,

--- a/app/src/scene/system/cameraRig.ts
+++ b/app/src/scene/system/cameraRig.ts
@@ -13,7 +13,6 @@
 //   rig.recenterTo(worldPoint)            // dblclick on empty space
 //   rig.focusBuilding(mesh, building)     // F or dblclick on a building
 //   rig.focusStreet(street, hitPoint)     // dblclick on a street
-//   rig.focusGem()                        // dblclick on the gem
 //   rig.focusTree(sha)                    // F or dblclick on a tree (commit)
 //   rig.dispose()
 //
@@ -417,14 +416,6 @@ export function createCameraRig({
     _focusTopDown(center, fitW, fitD, 0, STREET_FOCUS_RATIO);
   }
 
-  function focusGem(): void {
-    const gemPos = world.getGemWorldPos();
-    const dims = world.getGemDims();
-    if (!gemPos || !dims) return;
-    const center = new THREE.Vector3(gemPos.x, gemPos.y, gemPos.z);
-    _focusTopDown(center, dims.width, dims.depth, dims.height, BUILDING_FOCUS_RATIO);
-  }
-
   function focusTree(sha: string): void {
     const b = world.getTreeBoundsBySha(sha);
     if (!b) return;
@@ -445,7 +436,6 @@ export function createCameraRig({
     recenterTo,
     focusBuilding,
     focusStreet,
-    focusGem,
     focusTree,
     dispose,
   };

--- a/app/src/scene/system/cameraRig.ts
+++ b/app/src/scene/system/cameraRig.ts
@@ -59,7 +59,7 @@ const STREET_FOCUS_RATIO = 1.2;
 // 80° elevation gives the user a near-overhead read while still showing
 // enough side-faces for 3D depth. Stays under controls.maxPolarAngle.
 const TOP_DOWN_ELEVATION_DEG = 80;
-const TOP_DOWN_PADDING_MULT = 1.15;
+const TOP_DOWN_PADDING_MULT = 1.8;
 
 export function createCameraRig({
   canvas,

--- a/app/src/scene/system/cameraRig.ts
+++ b/app/src/scene/system/cameraRig.ts
@@ -28,17 +28,12 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import {
   CAMERA_PERSPECTIVE,
   CAMERA_CONTROLS,
-  CAMERA_ANIMATION,
   ANIMATION_TIMING,
 } from '@/config/index.js';
 import { CURRENT_SOURCE_KEY } from '@/store/sourceContext.js';
-import { BuildingOrient, StreetAxis } from '@/types';
+import { StreetAxis } from '@/types';
 import type { Building, Street } from '@/types';
 import type { createWorld } from '../world.js';
-
-const SIGHTLINE_STEP_DEG = 20;
-const SIGHTLINE_MAX_ATTEMPTS = 5;
-const SIGHTLINE_FAR_OFFSET = 0.5;
 
 /** Floor on controls.maxDistance regardless of city size. Tiny-but-tall
  *  cities (small footprint, one big building) end up with a tiny
@@ -58,6 +53,12 @@ const MIN_MAX_DISTANCE = 8000;
 const RECENTER_RATIO = 0.7;
 const BUILDING_FOCUS_RATIO = 1.2;
 const STREET_FOCUS_RATIO = 1.2;
+
+// Top-down focus framing (replaces door-facing + altitude-floor logic).
+// 80° elevation gives the user a near-overhead read while still showing
+// enough side-faces for 3D depth. Stays under controls.maxPolarAngle.
+const TOP_DOWN_ELEVATION_DEG = 80;
+const TOP_DOWN_PADDING_MULT = 1.15;
 
 export function createCameraRig({
   canvas,
@@ -99,10 +100,6 @@ export function createCameraRig({
   // Animation cancellation token. Each new focus/reset animation bumps
   // this; in-flight rAF steps abort if their token doesn't match.
   let camAnimToken = 0;
-
-  // Reusable scratch for sight-line raycasting.
-  const _xrayRay = new THREE.Raycaster();
-  const _xrayDir = new THREE.Vector3();
 
   // Compute the canonical "framed" pose for the current world bbox and
   // refresh initialCamPos/initialTarget + controls.maxDistance + the
@@ -335,141 +332,96 @@ export function createCameraRig({
     );
   }
 
-  function _isSightClear(camPos: THREE.Vector3, target: THREE.Vector3, focused: Building): boolean {
-    _xrayDir.subVectors(target, camPos).normalize();
-    _xrayRay.set(camPos, _xrayDir);
-    _xrayRay.far = camPos.distanceTo(target) - SIGHTLINE_FAR_OFFSET;
-    // Raycast against every cell's detail InstancedMesh. Three.js
-    // handles InstancedMesh natively: hits carry `.instanceId` (the
-    // slot) and we identify the cell via `object.userData.cellId`.
-    const hits = _xrayRay.intersectObjects(world.getBuildingPickables(), false);
-    for (let i = 0; i < hits.length; i++) {
-      const hit = hits[i];
-      // Skip the focused building itself — its own faces always block its
-      // own sightline. Match on (cellId, slotId).
-      const hitCellId = hit.object.userData.cellId;
-      if (hitCellId === focused.cellId && hit.instanceId === focused.slotId) continue;
-      return false;
-    }
-    return true;
-  }
+  const _scratchDir = new THREE.Vector3();
 
-  // Frame the building's door face head-on. Pivot is the building
-  // centroid so subsequent orbit circles around the building. Tries
-  // increasing elevations until the sightline is unobstructed.
-  function focusBuilding(mesh: THREE.Object3D, b: Building): void {
-    camera.up.set(0, 1, 0);
-    const camAnim = CAMERA_ANIMATION.get();
-    let doorDX = 0,
-      doorDZ = 0,
-      faceW: number;
-    if (b.orient === BuildingOrient.South) {
-      doorDZ = 1;
-      faceW = b.w;
-    } else if (b.orient === BuildingOrient.North) {
-      doorDZ = -1;
-      faceW = b.w;
-    } else if (b.orient === BuildingOrient.East) {
-      doorDX = 1;
-      faceW = b.d;
-    } else if (b.orient === BuildingOrient.West) {
-      doorDX = -1;
-      faceW = b.d;
-    } else {
-      doorDZ = 1;
-      faceW = b.w;
-    }
-    const faceH = b.h;
-
+  function _focusTopDown(
+    center: THREE.Vector3,
+    fitW: number,
+    fitD: number,
+    fitH: number,
+    durationRatio: number,
+  ): void {
+    const elevRad = (TOP_DOWN_ELEVATION_DEG * Math.PI) / 180;
     const halfV = (camera.fov * Math.PI) / 180 / 2;
     const halfH = Math.atan(Math.tan(halfV) * camera.aspect);
-    const distForH = faceH / 2 / Math.tan(halfV);
-    const distForW = faceW / 2 / Math.tan(halfH);
-    const dist =
-      Math.max(distForH, distForW) * camAnim.BUILDING_FOCUS_DISTANCE_MULT +
-      camAnim.BUILDING_FOCUS_DISTANCE_OFFSET;
 
-    const halfDepth =
-      b.orient === BuildingOrient.East || b.orient === BuildingOrient.West ? b.w / 2 : b.d / 2;
-    const newTarget = new THREE.Vector3(b.x, b.h / 2, b.y);
+    // At 80° elevation, a vertical span of fitH projects onto the screen-
+    // vertical axis as fitH·cos(elev). Take the larger of the projected
+    // height and the depth span as the effective vertical extent.
+    const effW = fitW;
+    const effD = Math.max(fitD, fitH * Math.cos(elevRad));
+    const distW = effW / 2 / Math.tan(halfH);
+    const distD = effD / 2 / Math.tan(halfV);
+    const dist = Math.max(distW, distD) * TOP_DOWN_PADDING_MULT;
 
-    let newCamPos: THREE.Vector3 | null = null;
-    for (let attempt = 0; attempt < SIGHTLINE_MAX_ATTEMPTS; attempt++) {
-      const elev = (attempt * SIGHTLINE_STEP_DEG * Math.PI) / 180;
-      const horiz = dist * Math.cos(elev);
-      const vert = b.h / 2 + dist * Math.sin(elev);
-      const candidate = new THREE.Vector3(
-        b.x + doorDX * (halfDepth + horiz),
-        vert,
-        b.y + doorDZ * (halfDepth + horiz)
-      );
-      if (_isSightClear(candidate, newTarget, b)) {
-        newCamPos = candidate;
-        break;
+    // Azimuth: preserve current horizontal direction from target → camera.
+    // If the camera is too close to nadir, fall back to the root-street axis.
+    const cur = _scratchDir.subVectors(camera.position, controls.target);
+    cur.y = 0;
+    let dirX = cur.x;
+    let dirZ = cur.z;
+    const horizLenSq = dirX * dirX + dirZ * dirZ;
+    if (horizLenSq < 1e-4) {
+      const root = world.getRootStreet();
+      if (root && root.orientation === StreetAxis.X) {
+        dirX = -1; dirZ = 0;
+      } else {
+        dirX = 0; dirZ = -1;
       }
-      newCamPos = candidate;
+    } else {
+      const inv = 1 / Math.sqrt(horizLenSq);
+      dirX *= inv;
+      dirZ *= inv;
     }
 
-    if (newCamPos) {
-      _animateCamera(
-        newTarget,
-        newCamPos,
-        ANIMATION_TIMING.get().BASE_DURATION_MS * BUILDING_FOCUS_RATIO
-      );
-    }
+    const cosE = Math.cos(elevRad);
+    const sinE = Math.sin(elevRad);
+    const newCamPos = new THREE.Vector3(
+      center.x + dirX * dist * cosE,
+      center.y + dist * sinE,
+      center.z + dirZ * dist * cosE,
+    );
+
+    camera.up.set(0, 1, 0);
+    _animateCamera(
+      center.clone(),
+      newCamPos,
+      ANIMATION_TIMING.get().BASE_DURATION_MS * durationRatio,
+    );
   }
 
-  // Orient camera so the street runs left-right across the screen and
-  // zoom in to a navigable distance. See main.js's original block for
-  // the full geometric reasoning — kept verbatim here.
+  function focusBuilding(_mesh: THREE.Object3D, b: Building): void {
+    const center = new THREE.Vector3(b.x, b.h / 2, b.y);
+    _focusTopDown(center, b.w, b.d, b.h, BUILDING_FOCUS_RATIO);
+  }
+
   function focusStreet(s: Street, hitPoint: THREE.Vector3 | null): void {
-    let tx = s.x,
-      tz = s.y;
+    let tx = s.x;
+    let tz = s.y;
     if (hitPoint) {
       if (s.orientation === StreetAxis.X) tx = hitPoint.x;
       else tz = hitPoint.z;
     }
-    const newTarget = new THREE.Vector3(tx, 0, tz);
+    const center = new THREE.Vector3(tx, 0, tz);
+    const fitW = s.orientation === StreetAxis.X ? s.length : s.width;
+    const fitD = s.orientation === StreetAxis.X ? s.width : s.length;
+    _focusTopDown(center, fitW, fitD, 0, STREET_FOCUS_RATIO);
+  }
 
-    let offX = 0,
-      offZ = 0;
-    if (s.orientation === StreetAxis.X) {
-      offZ = 1;
-    } else {
-      offX = 1;
-    }
-    camera.up.set(0, 1, 0);
+  function focusGem(): void {
+    const gemPos = world.getGemWorldPos();
+    const dims = world.getGemDims();
+    if (!gemPos || !dims) return;
+    const center = new THREE.Vector3(gemPos.x, gemPos.y, gemPos.z);
+    _focusTopDown(center, dims.width, dims.depth, dims.height, BUILDING_FOCUS_RATIO);
+  }
 
-    // Camera altitude clears every building. (The previous version also
-    // multiplied each building's height by its mesh.scale.y to factor in
-    // entry/exit tweens — that doesn't apply in cell mode because the
-    // scale.y tween rides on the per-instance matrix inside the cell's
-    // InstancedMesh, not on a per-building scene-graph mesh. A tween-
-    // expanded building can briefly poke above this baseline; in practice
-    // the tweens settle within ~200ms, well before the street-focus
-    // camera animation completes.)
-    const maxBldgH = world.getMaxBuildingHeight();
-
-    const camAnim = CAMERA_ANIMATION.get();
-    const halfV = (camera.fov * Math.PI) / 180 / 2;
-    const halfH = Math.atan(Math.tan(halfV) * camera.aspect);
-    const distForLength = (s.length * camAnim.STREET_FOCUS_LENGTH_FRAC) / 2 / Math.tan(halfH);
-    const distForWidth = (s.width * camAnim.STREET_FOCUS_WIDTH_MULT) / 2 / Math.tan(halfV);
-    const altitude = Math.max(
-      distForLength,
-      distForWidth,
-      maxBldgH * camAnim.STREET_FOCUS_ALTITUDE_BLDG_MULT + camAnim.STREET_FOCUS_ALTITUDE_FLOOR
-    );
-
-    const elev = (camAnim.STREET_FOCUS_ELEVATION_DEG * Math.PI) / 180;
-    const horizDist = altitude / Math.tan(elev);
-
-    const newCamPos = new THREE.Vector3(tx + offX * horizDist, altitude, tz + offZ * horizDist);
-    _animateCamera(
-      newTarget,
-      newCamPos,
-      ANIMATION_TIMING.get().BASE_DURATION_MS * STREET_FOCUS_RATIO
-    );
+  function focusTree(sha: string): void {
+    const b = world.getTreeBoundsBySha(sha);
+    if (!b) return;
+    const center = new THREE.Vector3(b.x, b.height / 2, b.z);
+    const span = b.radius * 2;
+    _focusTopDown(center, span, span, b.height, BUILDING_FOCUS_RATIO);
   }
 
   function dispose() {
@@ -484,6 +436,8 @@ export function createCameraRig({
     recenterTo,
     focusBuilding,
     focusStreet,
+    focusGem,
+    focusTree,
     dispose,
   };
 }

--- a/app/src/scene/system/cameraRig.ts
+++ b/app/src/scene/system/cameraRig.ts
@@ -26,11 +26,7 @@
 
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import {
-  CAMERA_PERSPECTIVE,
-  CAMERA_CONTROLS,
-  ANIMATION_TIMING,
-} from '@/config/index.js';
+import { CAMERA_PERSPECTIVE, CAMERA_CONTROLS, ANIMATION_TIMING } from '@/config/index.js';
 import { CURRENT_SOURCE_KEY } from '@/store/sourceContext.js';
 import { StreetAxis } from '@/types';
 import type { Building, Street } from '@/types';
@@ -340,7 +336,7 @@ export function createCameraRig({
     fitW: number,
     fitD: number,
     fitH: number,
-    durationRatio: number,
+    durationRatio: number
   ): void {
     const elevRad = (TOP_DOWN_ELEVATION_DEG * Math.PI) / 180;
     const halfV = (camera.fov * Math.PI) / 180 / 2;
@@ -352,10 +348,7 @@ export function createCameraRig({
     // nearly-overhead at the b.h/2 centroid.
     const R = 0.5 * Math.sqrt(fitW * fitW + fitD * fitD + fitH * fitH);
     const halfFov = Math.min(halfV, halfH);
-    const dist = Math.max(
-      (R / Math.sin(halfFov)) * TOP_DOWN_PADDING_MULT,
-      controls.minDistance,
-    );
+    const dist = Math.max((R / Math.sin(halfFov)) * TOP_DOWN_PADDING_MULT, controls.minDistance);
 
     // Azimuth: preserve current horizontal direction from target → camera.
     // If the camera is too close to nadir, fall back to the root-street axis.
@@ -370,9 +363,11 @@ export function createCameraRig({
     if (horizLenSq < 1e-4) {
       const root = world.getRootStreet();
       if (root && root.orientation === StreetAxis.X) {
-        dirX = -1; dirZ = 0;
+        dirX = -1;
+        dirZ = 0;
       } else {
-        dirX = 0; dirZ = -1;
+        dirX = 0;
+        dirZ = -1;
       }
     } else {
       const inv = 1 / Math.sqrt(horizLenSq);
@@ -385,14 +380,14 @@ export function createCameraRig({
     const newCamPos = new THREE.Vector3(
       center.x + dirX * dist * cosE,
       center.y + dist * sinE,
-      center.z + dirZ * dist * cosE,
+      center.z + dirZ * dist * cosE
     );
 
     camera.up.set(0, 1, 0);
     _animateCamera(
       center.clone(),
       newCamPos,
-      ANIMATION_TIMING.get().BASE_DURATION_MS * durationRatio,
+      ANIMATION_TIMING.get().BASE_DURATION_MS * durationRatio
     );
   }
 

--- a/app/src/scene/system/cameraRig.ts
+++ b/app/src/scene/system/cameraRig.ts
@@ -13,6 +13,8 @@
 //   rig.recenterTo(worldPoint)            // dblclick on empty space
 //   rig.focusBuilding(mesh, building)     // F or dblclick on a building
 //   rig.focusStreet(street, hitPoint)     // dblclick on a street
+//   rig.focusGem()                        // dblclick on the gem
+//   rig.focusTree(sha)                    // F or dblclick on a tree (commit)
 //   rig.dispose()
 //
 // First-frame framing is one-shot by construction: frameToBbox is not on
@@ -352,7 +354,11 @@ export function createCameraRig({
     const effD = Math.max(fitD, fitH * Math.cos(elevRad));
     const distW = effW / 2 / Math.tan(halfH);
     const distD = effD / 2 / Math.tan(halfV);
-    const dist = Math.max(distW, distD) * TOP_DOWN_PADDING_MULT;
+    // Clamp against the OrbitControls dolly floor so small targets (a
+    // sub-unit radius tree, an empty street) don't put the camera inside
+    // the geometry — _animateCamera writes camera.position directly,
+    // bypassing the dolly clamp that would normally apply at zoom time.
+    const dist = Math.max(distW * TOP_DOWN_PADDING_MULT, distD * TOP_DOWN_PADDING_MULT, controls.minDistance);
 
     // Azimuth: preserve current horizontal direction from target → camera.
     // If the camera is too close to nadir, fall back to the root-street axis.
@@ -361,6 +367,9 @@ export function createCameraRig({
     let dirX = cur.x;
     let dirZ = cur.z;
     const horizLenSq = dirX * dirX + dirZ * dirZ;
+    // 1e-4 = (1 cm)^2 in world units — if the camera's horizontal offset
+    // from the target is sub-centimeter, treat it as nadir and fall back
+    // to the root-street axis so the azimuth doesn't NaN out.
     if (horizLenSq < 1e-4) {
       const root = world.getRootStreet();
       if (root && root.orientation === StreetAxis.X) {

--- a/app/src/scene/system/inputHandlers.ts
+++ b/app/src/scene/system/inputHandlers.ts
@@ -201,7 +201,7 @@ export function createInputHandlers({
     if (!hit) return;
     const ud = hit.object.userData;
     if (ud.type === NodeKind.Gem) {
-      onResetView();
+      rig.focusGem();
       return;
     }
     // Route through picker.interpretHit so InstancedMesh hits resolve to a
@@ -215,6 +215,10 @@ export function createInputHandlers({
     }
     if (target?.kind === NodeKind.Directory) {
       rig.focusStreet(target.street, hit.point);
+      return;
+    }
+    if (target?.kind === NodeKind.Commit) {
+      rig.focusTree(target.commit.sha);
       return;
     }
     rig.recenterTo(new THREE.Vector3(hit.point.x, 0, hit.point.z));
@@ -296,7 +300,10 @@ export function createInputHandlers({
         rig.focusBuilding(sel.mesh, sel.data);
       } else if (sel.kind === NodeKind.Directory) {
         rig.focusStreet(sel.street, null);
+      } else if (sel.kind === NodeKind.Commit) {
+        rig.focusTree(sel.commit.sha);
       }
+      // Gem isn't selectable, so no Gem branch — gem focus is via dblclick.
     }
   });
 

--- a/app/src/scene/system/inputHandlers.ts
+++ b/app/src/scene/system/inputHandlers.ts
@@ -341,15 +341,29 @@ export function createInputHandlers({
     rig.controls.removeEventListener('end', _cameraEndHandler);
   });
 
+  // _resize is wrapped in rAF so the ResizeObserver callback yields before
+  // calling renderer.setSize (which writes to canvas width/height, which
+  // can re-fire ResizeObserver). Without the rAF, opening the right
+  // sidebar's CSS-transitioned width change can produce a sustained chain
+  // of resize callbacks tall enough to starve subsequent canvas pointer
+  // events — the symptom is hover/click going dead after the FIRST road
+  // click, since the directory pane's heavier setDirectory work raises
+  // the cost of each callback enough to push the chain into pathological
+  // territory.
+  let _resizeRafId = 0;
   function _resize() {
-    const cw = canvas.clientWidth;
-    const ch = canvas.clientHeight;
-    renderer.setSize(cw, ch, false);
-    camera.aspect = cw / Math.max(1, ch);
-    camera.updateProjectionMatrix();
-    // onResize owns the synchronous paint so the post-FX pipeline (bloom)
-    // shows on the new size without a blank/cleared frame in between.
-    if (typeof onResize === 'function') onResize();
+    if (_resizeRafId) return;
+    _resizeRafId = requestAnimationFrame(() => {
+      _resizeRafId = 0;
+      const cw = canvas.clientWidth;
+      const ch = canvas.clientHeight;
+      renderer.setSize(cw, ch, false);
+      camera.aspect = cw / Math.max(1, ch);
+      camera.updateProjectionMatrix();
+      // onResize owns the synchronous paint so the post-FX pipeline (bloom)
+      // shows on the new size without a blank/cleared frame in between.
+      if (typeof onResize === 'function') onResize();
+    });
   }
   _on(window, 'resize', _resize);
 
@@ -376,6 +390,7 @@ export function createInputHandlers({
     _disposers = [];
     if (_hoverRafId) cancelAnimationFrame(_hoverRafId);
     if (_hoverCommitId) clearTimeout(_hoverCommitId);
+    if (_resizeRafId) cancelAnimationFrame(_resizeRafId);
   }
 
   return { dispose };

--- a/app/src/scene/system/inputHandlers.ts
+++ b/app/src/scene/system/inputHandlers.ts
@@ -201,7 +201,7 @@ export function createInputHandlers({
     if (!hit) return;
     const ud = hit.object.userData;
     if (ud.type === NodeKind.Gem) {
-      rig.focusGem();
+      onResetView();
       return;
     }
     // Route through picker.interpretHit so InstancedMesh hits resolve to a

--- a/app/src/scene/world.ts
+++ b/app/src/scene/world.ts
@@ -1403,8 +1403,7 @@ export function createWorld(_canvas: HTMLCanvasElement) {
      *  enclosing cube extent. Returns null pre-manifest (no gem yet). */
     getGemDims(): { width: number; height: number; depth: number } | null {
       if (!rootGem) return null;
-      const radius = (rootGem.userData?.gem?.userData?.radius as number | undefined) ??
-                     (rootGem.userData?.radius as number | undefined);
+      const radius = rootGem.userData?.radius as number | undefined;
       if (typeof radius !== 'number' || radius <= 0) return null;
       const d = radius * 2;
       return { width: d, height: d, depth: d };

--- a/app/src/scene/world.ts
+++ b/app/src/scene/world.ts
@@ -1398,16 +1398,6 @@ export function createWorld(_canvas: HTMLCanvasElement) {
     getTreeBoundsBySha(sha: string) {
       return _trees?.getTreeBoundsBySha(sha) ?? null;
     },
-    /** Width / height / depth of the gem's axis-aligned bounding cube.
-     *  Reads `gem.userData.radius` (set by createRootGem) and returns the
-     *  enclosing cube extent. Returns null pre-manifest (no gem yet). */
-    getGemDims(): { width: number; height: number; depth: number } | null {
-      if (!rootGem) return null;
-      const radius = rootGem.userData?.radius as number | undefined;
-      if (typeof radius !== 'number' || radius <= 0) return null;
-      const d = radius * 2;
-      return { width: d, height: d, depth: d };
-    },
 
     // Outline/ghost arrays — empty stubs returned so existing callers
     // (outlineRenderer.refreshMaterials, outlineRenderer.onResize) iterate

--- a/app/src/scene/world.ts
+++ b/app/src/scene/world.ts
@@ -1395,6 +1395,20 @@ export function createWorld(_canvas: HTMLCanvasElement) {
     getGemWorldPos() {
       return gemWorldPos;
     },
+    getTreeBoundsBySha(sha: string) {
+      return _trees?.getTreeBoundsBySha(sha) ?? null;
+    },
+    /** Width / height / depth of the gem's axis-aligned bounding cube.
+     *  Reads `gem.userData.radius` (set by createRootGem) and returns the
+     *  enclosing cube extent. Returns null pre-manifest (no gem yet). */
+    getGemDims(): { width: number; height: number; depth: number } | null {
+      if (!rootGem) return null;
+      const radius = (rootGem.userData?.gem?.userData?.radius as number | undefined) ??
+                     (rootGem.userData?.radius as number | undefined);
+      if (typeof radius !== 'number' || radius <= 0) return null;
+      const d = radius * 2;
+      return { width: d, height: d, depth: d };
+    },
 
     // Outline/ghost arrays — empty stubs returned so existing callers
     // (outlineRenderer.refreshMaterials, outlineRenderer.onResize) iterate

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -3046,3 +3046,111 @@ canvas {
   border-radius: 50%;
   flex-shrink: 0;
 }
+
+/* ── Street pane (right sidebar) ────────────────────────────────────────
+   Shown when a directory (road) is selected. Mirrors commit-pane layout:
+     - pane-header (from buildPaneHeader) — title is the directory leaf
+     - .street-body — scrollable area with path row, two-column counts,
+       and a "By extension" breakdown matching commit-meta typography. */
+
+.street-body {
+  padding: var(--cc-space-7); /* 16px */
+  display: flex;
+  flex-direction: column;
+  gap: var(--cc-space-6); /* 12px */
+}
+
+/* Folder icon + path text, like .commit-author's icon + text row. */
+.street-path {
+  display: flex;
+  align-items: center;
+  gap: var(--cc-space-3); /* 6px */
+  color: var(--cc-text-secondary);
+  font-size: var(--cc-font-lg); /* 12px */
+}
+
+.street-path-text {
+  font-family: var(--cc-font-mono);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  min-width: 0;
+}
+
+/* Two-column count grid: Direct | Descendants. */
+.street-counts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--cc-space-6); /* 12px */
+}
+
+.street-counts-col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cc-space-2); /* 4px */
+  min-width: 0;
+}
+
+/* Column heading — muted, same character as .commit-meta-sep. */
+.street-counts-h,
+.street-ext-h {
+  font-size: var(--cc-font-md); /* 11px */
+  text-transform: uppercase;
+  letter-spacing: var(--cc-track-label);
+  color: var(--cc-text-ghost);
+  font-weight: var(--cc-fw-bold);
+}
+
+.street-counts-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--cc-space-3);
+  font-size: var(--cc-font-lg); /* 12px */
+}
+
+.street-counts-k {
+  color: var(--cc-text-muted);
+}
+
+.street-counts-v {
+  color: var(--cc-text-secondary);
+  font-weight: 500;
+}
+
+/* "By extension" list — one row per file extension, badge + label +
+   count + sep + size, sized to match .commit-meta typography. */
+.street-ext-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cc-space-3); /* 6px */
+}
+
+.street-ext-row {
+  display: flex;
+  align-items: center;
+  gap: var(--cc-space-3); /* 6px */
+  color: var(--cc-text-muted);
+  font-size: var(--cc-font-lg); /* 12px */
+  min-width: 0;
+}
+
+.street-ext-label {
+  font-family: var(--cc-font-mono);
+  color: var(--cc-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.street-ext-count,
+.street-ext-size {
+  color: var(--cc-text-muted);
+  flex-shrink: 0;
+}
+
+.street-ext-sep {
+  color: var(--cc-text-ghost);
+  flex-shrink: 0;
+}

--- a/app/src/views/panes/commitPane.ts
+++ b/app/src/views/panes/commitPane.ts
@@ -24,6 +24,9 @@ import { colorForAuthor } from '@/scene/components/fireflies/authorColor.js';
 
 interface BuildCommitPaneOpts {
   onClose?: () => void;
+  /** Called when the user clicks the focus button in the pane header.
+   *  Equivalent of pressing F on the canvas with the current commit selected. */
+  onFocus?: (commit: CommitEntry) => void;
 }
 
 export interface SetCommitOpts {
@@ -51,6 +54,12 @@ export function buildCommitPane(opts: BuildCommitPaneOpts = {}) {
   const { el: header, api: headerApi } = buildPaneHeader({
     title: 'Commit',
     onClose: opts.onClose,
+    onFocus: opts.onFocus
+      ? () => {
+          if (_currentCommit) opts.onFocus!(_currentCommit);
+        }
+      : undefined,
+    focusTitle: 'Focus the camera on this commit (F)',
   });
   pane.appendChild(header);
 
@@ -61,6 +70,7 @@ export function buildCommitPane(opts: BuildCommitPaneOpts = {}) {
   // SHA-based race guard: tracks the most recently requested commit sha so
   // late fetch results from a previous commit are silently dropped.
   let _currentSha: string | null = null;
+  let _currentCommit: CommitEntry | null = null;
 
   // Body cache: sha → fetched body text (empty string is a valid cached value).
   // Lives on the pane instance; never invalidated (commits are immutable).
@@ -68,6 +78,8 @@ export function buildCommitPane(opts: BuildCommitPaneOpts = {}) {
 
   function _renderEmpty(): void {
     _currentSha = null;
+    _currentCommit = null;
+    headerApi.setFocusEnabled(false);
     headerApi.setTitle('Commit');
     body.replaceChildren();
     const box = document.createElement('div');
@@ -200,6 +212,8 @@ export function buildCommitPane(opts: BuildCommitPaneOpts = {}) {
     now: Date
   ): void {
     _currentSha = commit.sha;
+    _currentCommit = commit;
+    headerApi.setFocusEnabled(true);
 
     // Update the pane header title to "Commit <short-sha>" + optional open
     // link. This happens immediately, even during loading, so the user sees

--- a/app/src/views/panes/controlsPane.ts
+++ b/app/src/views/panes/controlsPane.ts
@@ -950,12 +950,12 @@ function _buildBuildingsSection(): HTMLElement {
     ])
   );
 
-  // Selection fade parent — per-tier style. Each tier (Default =
-  // siblings of selection / Level 1 = one hop / Level 2+ = far) gets
-  // four controls: detail (full / silhouette / hidden), outline on/off,
-  // and separate body + outline opacity sliders. Hover renders a
-  // building using the Default tier's settings — no separate hover-floor
-  // knob. Default-closed; 3 children, niche.
+  // Selection fade parent — five tier styles driven by depth from the
+  // selection target. Default tier applies to the selected/hovered
+  // building itself + the no-selection idle state. Levels 1-4 cascade
+  // outward by directory depth. Each tier exposes detail (full /
+  // silhouette / hidden), outline on/off, and separate body + outline
+  // opacity sliders.
   const DETAIL_OPTIONS = [
     { value: FadeDetail.Full, label: 'Full' },
     { value: FadeDetail.Silhouette, label: 'Silhouette' },
@@ -963,7 +963,7 @@ function _buildBuildingsSection(): HTMLElement {
   ];
   section.appendChild(
     _collapsibleSubgroup('selection-fade', 'Selection fade', () => [
-      _collapsibleSubgroup('selection-fade-default', 'Default tier — siblings of selection', () => [
+      _collapsibleSubgroup('selection-fade-default', 'Default tier — selected, hovered, or idle', () => [
         _select('Detail', BUILDING_FADE, 'DEFAULT_DETAIL', DETAIL_OPTIONS, {
           tip: 'Full = textured walls + windows + doors. Silhouette = solid-color box. Hidden = body invisible (only outline can show).',
         }),
@@ -977,22 +977,30 @@ function _buildBuildingsSection(): HTMLElement {
           tip: 'Opacity for the wireframe outline layer (only visible if Outline is on).',
         }),
       ]),
-      _collapsibleSubgroup('selection-fade-level-1', 'Level 1 — one hop from selection', () => [
-        _select('Detail', BUILDING_FADE, 'NEAR_DETAIL', DETAIL_OPTIONS, {}),
-        _toggle('Outline', BUILDING_FADE, 'NEAR_OUTLINE', {}),
-        _slider('Body opacity', BUILDING_FADE, 'NEAR_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
-        _slider('Outline opacity', BUILDING_FADE, 'NEAR_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
+      _collapsibleSubgroup('selection-fade-level-1', 'Level 1 — same level as selection', () => [
+        _select('Detail', BUILDING_FADE, 'LEVEL1_DETAIL', DETAIL_OPTIONS, {}),
+        _toggle('Outline', BUILDING_FADE, 'LEVEL1_OUTLINE', {}),
+        _slider('Body opacity', BUILDING_FADE, 'LEVEL1_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
+        _slider('Outline opacity', BUILDING_FADE, 'LEVEL1_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
       ]),
-      _collapsibleSubgroup(
-        'selection-fade-level-2-plus',
-        'Level 2+ — cousins, deeper subtrees',
-        () => [
-          _select('Detail', BUILDING_FADE, 'FAR_DETAIL', DETAIL_OPTIONS, {}),
-          _toggle('Outline', BUILDING_FADE, 'FAR_OUTLINE', {}),
-          _slider('Body opacity', BUILDING_FADE, 'FAR_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
-          _slider('Outline opacity', BUILDING_FADE, 'FAR_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
-        ]
-      ),
+      _collapsibleSubgroup('selection-fade-level-2', 'Level 2 — one level deeper', () => [
+        _select('Detail', BUILDING_FADE, 'LEVEL2_DETAIL', DETAIL_OPTIONS, {}),
+        _toggle('Outline', BUILDING_FADE, 'LEVEL2_OUTLINE', {}),
+        _slider('Body opacity', BUILDING_FADE, 'LEVEL2_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
+        _slider('Outline opacity', BUILDING_FADE, 'LEVEL2_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
+      ]),
+      _collapsibleSubgroup('selection-fade-level-3', 'Level 3 — deeper still', () => [
+        _select('Detail', BUILDING_FADE, 'LEVEL3_DETAIL', DETAIL_OPTIONS, {}),
+        _toggle('Outline', BUILDING_FADE, 'LEVEL3_OUTLINE', {}),
+        _slider('Body opacity', BUILDING_FADE, 'LEVEL3_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
+        _slider('Outline opacity', BUILDING_FADE, 'LEVEL3_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
+      ]),
+      _collapsibleSubgroup('selection-fade-level-4', 'Level 4 — outside the subtree', () => [
+        _select('Detail', BUILDING_FADE, 'LEVEL4_DETAIL', DETAIL_OPTIONS, {}),
+        _toggle('Outline', BUILDING_FADE, 'LEVEL4_OUTLINE', {}),
+        _slider('Body opacity', BUILDING_FADE, 'LEVEL4_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
+        _slider('Outline opacity', BUILDING_FADE, 'LEVEL4_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
+      ]),
     ])
   );
 

--- a/app/src/views/panes/controlsPane.ts
+++ b/app/src/views/panes/controlsPane.ts
@@ -977,25 +977,25 @@ function _buildBuildingsSection(): HTMLElement {
           tip: 'Opacity for the wireframe outline layer (only visible if Outline is on).',
         }),
       ]),
-      _collapsibleSubgroup('selection-fade-level-1', 'Level 1 — same level as selection', () => [
+      _collapsibleSubgroup('selection-fade-level-1', 'Level 1 — same dir as selection', () => [
         _select('Detail', BUILDING_FADE, 'LEVEL1_DETAIL', DETAIL_OPTIONS, {}),
         _toggle('Outline', BUILDING_FADE, 'LEVEL1_OUTLINE', {}),
         _slider('Body opacity', BUILDING_FADE, 'LEVEL1_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
         _slider('Outline opacity', BUILDING_FADE, 'LEVEL1_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
       ]),
-      _collapsibleSubgroup('selection-fade-level-2', 'Level 2 — one level deeper', () => [
+      _collapsibleSubgroup('selection-fade-level-2', 'Level 2 — one dir away (up or down)', () => [
         _select('Detail', BUILDING_FADE, 'LEVEL2_DETAIL', DETAIL_OPTIONS, {}),
         _toggle('Outline', BUILDING_FADE, 'LEVEL2_OUTLINE', {}),
         _slider('Body opacity', BUILDING_FADE, 'LEVEL2_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
         _slider('Outline opacity', BUILDING_FADE, 'LEVEL2_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
       ]),
-      _collapsibleSubgroup('selection-fade-level-3', 'Level 3 — deeper still', () => [
+      _collapsibleSubgroup('selection-fade-level-3', 'Level 3 — two dirs away', () => [
         _select('Detail', BUILDING_FADE, 'LEVEL3_DETAIL', DETAIL_OPTIONS, {}),
         _toggle('Outline', BUILDING_FADE, 'LEVEL3_OUTLINE', {}),
         _slider('Body opacity', BUILDING_FADE, 'LEVEL3_BODY_OPACITY', 0.0, 1.0, 0.05, {}),
         _slider('Outline opacity', BUILDING_FADE, 'LEVEL3_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {}),
       ]),
-      _collapsibleSubgroup('selection-fade-level-4', 'Level 4 — outside the subtree', () => [
+      _collapsibleSubgroup('selection-fade-level-4', 'Level 4 — three or more dirs away', () => [
         _select('Detail', BUILDING_FADE, 'LEVEL4_DETAIL', DETAIL_OPTIONS, {}),
         _toggle('Outline', BUILDING_FADE, 'LEVEL4_OUTLINE', {}),
         _slider('Body opacity', BUILDING_FADE, 'LEVEL4_BODY_OPACITY', 0.0, 1.0, 0.05, {}),

--- a/app/src/views/panes/controlsPane.ts
+++ b/app/src/views/panes/controlsPane.ts
@@ -963,20 +963,24 @@ function _buildBuildingsSection(): HTMLElement {
   ];
   section.appendChild(
     _collapsibleSubgroup('selection-fade', 'Selection fade', () => [
-      _collapsibleSubgroup('selection-fade-default', 'Default tier — selected, hovered, or idle', () => [
-        _select('Detail', BUILDING_FADE, 'DEFAULT_DETAIL', DETAIL_OPTIONS, {
-          tip: 'Full = textured walls + windows + doors. Silhouette = solid-color box. Hidden = body invisible (only outline can show).',
-        }),
-        _toggle('Outline', BUILDING_FADE, 'DEFAULT_OUTLINE', {
-          tip: 'Show the wireframe edge overlay.',
-        }),
-        _slider('Body opacity', BUILDING_FADE, 'DEFAULT_BODY_OPACITY', 0.0, 1.0, 0.05, {
-          tip: 'Opacity for the body / silhouette layer.',
-        }),
-        _slider('Outline opacity', BUILDING_FADE, 'DEFAULT_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {
-          tip: 'Opacity for the wireframe outline layer (only visible if Outline is on).',
-        }),
-      ]),
+      _collapsibleSubgroup(
+        'selection-fade-default',
+        'Default tier — selected, hovered, or idle',
+        () => [
+          _select('Detail', BUILDING_FADE, 'DEFAULT_DETAIL', DETAIL_OPTIONS, {
+            tip: 'Full = textured walls + windows + doors. Silhouette = solid-color box. Hidden = body invisible (only outline can show).',
+          }),
+          _toggle('Outline', BUILDING_FADE, 'DEFAULT_OUTLINE', {
+            tip: 'Show the wireframe edge overlay.',
+          }),
+          _slider('Body opacity', BUILDING_FADE, 'DEFAULT_BODY_OPACITY', 0.0, 1.0, 0.05, {
+            tip: 'Opacity for the body / silhouette layer.',
+          }),
+          _slider('Outline opacity', BUILDING_FADE, 'DEFAULT_OUTLINE_OPACITY', 0.0, 1.0, 0.05, {
+            tip: 'Opacity for the wireframe outline layer (only visible if Outline is on).',
+          }),
+        ]
+      ),
       _collapsibleSubgroup('selection-fade-level-1', 'Level 1 — same dir as selection', () => [
         _select('Detail', BUILDING_FADE, 'LEVEL1_DETAIL', DETAIL_OPTIONS, {}),
         _toggle('Outline', BUILDING_FADE, 'LEVEL1_OUTLINE', {}),

--- a/app/src/views/panes/streetPane.ts
+++ b/app/src/views/panes/streetPane.ts
@@ -1,0 +1,216 @@
+// views/panes/streetPane.ts — right-sidebar pane shown when a directory
+// (road) is selected in the city. Shows the dir path, direct + descendant
+// children counts + total size, and a sorted breakdown of every file
+// extension in the descendant subtree.
+//
+// API matches commitPane's shape (build once, push selection via
+// setDirectory) so the coordinator can swap panes in the right sidebar
+// without churn.
+
+import { NodeKind } from '@/types';
+import type { DirNode, FileNode, TreeNode } from '@/types';
+import { makeLucideIcon } from '@/views/widgets/icon.js';
+import { buildPaneHeader } from '@/views/shell/paneHeader.js';
+import { makeExtensionBadge } from '@/views/widgets/badge.js';
+import { ASPHALT, BUILDING_PALETTE } from '@/config';
+
+interface BuildStreetPaneOpts {
+  onClose?: () => void;
+  /** Called when the user clicks the focus button in the pane header.
+   *  Equivalent of pressing F on the canvas with the current dir selected. */
+  onFocus?: (dir: DirNode) => void;
+}
+
+interface ExtensionStats {
+  ext: string;
+  count: number;
+  size: number;
+}
+
+const BYTES_PER_KB = 1024;
+const BYTES_PER_MB = 1024 * 1024;
+
+function formatBytes(n: number): string {
+  if (n < BYTES_PER_KB) return `${n} B`;
+  if (n < BYTES_PER_MB) return `${(n / BYTES_PER_KB).toFixed(1)} KB`;
+  return `${(n / BYTES_PER_MB).toFixed(1)} MB`;
+}
+
+/** Walk a directory's descendant subtree and aggregate by extension.
+ *  Treats missing/empty extension as '(none)'. */
+function aggregateExtensions(d: DirNode): ExtensionStats[] {
+  const byExt = new Map<string, { count: number; size: number }>();
+  function walk(node: TreeNode): void {
+    if (node.type === NodeKind.File) {
+      const ext = ((node as FileNode).extension || '(none)').toLowerCase();
+      const cur = byExt.get(ext) || { count: 0, size: 0 };
+      cur.count += 1;
+      cur.size += (node as FileNode).size || 0;
+      byExt.set(ext, cur);
+      return;
+    }
+    if (node.type === NodeKind.Directory) {
+      const kids = (node as DirNode).children || [];
+      for (let i = 0; i < kids.length; i++) walk(kids[i]);
+    }
+  }
+  walk(d);
+  return Array.from(byExt, ([ext, v]) => ({ ext, ...v })).sort((a, b) => b.count - a.count);
+}
+
+export function buildStreetPane(opts: BuildStreetPaneOpts = {}) {
+  const pane = document.createElement('div');
+  pane.className = 'pane street-pane';
+
+  let _activeDir: DirNode | null = null;
+
+  const { el: header, api: headerApi } = buildPaneHeader({
+    title: 'Road',
+    onClose: opts.onClose,
+    onFocus: opts.onFocus
+      ? () => {
+          if (_activeDir) opts.onFocus!(_activeDir);
+        }
+      : undefined,
+    focusTitle: 'Focus the camera on this road (F)',
+  });
+  pane.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'pane-body street-body';
+  pane.appendChild(body);
+
+  function _renderEmpty(): void {
+    _activeDir = null;
+    headerApi.setFocusEnabled(false);
+    headerApi.setTitle('Road');
+    body.replaceChildren();
+    const box = document.createElement('div');
+    box.className = 'empty-state empty-state--lg';
+    box.appendChild(makeLucideIcon('route'));
+    const h = document.createElement('p');
+    h.className = 'text-card-title';
+    h.textContent = 'No road selected';
+    box.appendChild(h);
+    const sub = document.createElement('p');
+    sub.className = 'text-card-sub';
+    sub.textContent = 'Select a road in the city to inspect it here.';
+    box.appendChild(sub);
+    body.appendChild(box);
+  }
+
+  function _renderDir(d: DirNode): void {
+    _activeDir = d;
+    headerApi.setFocusEnabled(true);
+    const leaf = (d.path && d.path !== '.' ? d.path.split('/').filter(Boolean).pop() : null) || d.name || 'Road';
+    headerApi.setTitle(leaf);
+    body.replaceChildren();
+
+    // Path row
+    const pathRow = document.createElement('div');
+    pathRow.className = 'street-path';
+    pathRow.appendChild(makeLucideIcon('folder'));
+    const pathText = document.createElement('span');
+    pathText.className = 'street-path-text';
+    pathText.textContent = d.path || d.name || '';
+    pathRow.appendChild(pathText);
+    body.appendChild(pathRow);
+
+    // Counts block
+    const counts = document.createElement('div');
+    counts.className = 'street-counts';
+
+    // Each row renders as "<count> <label>" so regex patterns like /2.*files/i
+    // and /1.*dirs?/i in tests can match the plain textContent.
+    function makeCol(label: string, rows: Array<[string, string]>): HTMLElement {
+      const col = document.createElement('div');
+      col.className = 'street-counts-col';
+      const h = document.createElement('div');
+      h.className = 'street-counts-h';
+      h.textContent = label;
+      col.appendChild(h);
+      for (const [v, k] of rows) {
+        const row = document.createElement('div');
+        row.className = 'street-counts-row';
+        const vEl = document.createElement('span');
+        vEl.className = 'street-counts-v';
+        vEl.textContent = v;
+        const kEl = document.createElement('span');
+        kEl.className = 'street-counts-k';
+        kEl.textContent = k;
+        row.appendChild(vEl);
+        row.appendChild(kEl);
+        col.appendChild(row);
+      }
+      return col;
+    }
+
+    counts.appendChild(
+      makeCol('Direct', [
+        [String(d.children_file_count ?? 0), 'files'],
+        [String(d.children_dir_count ?? 0), 'dirs'],
+      ]),
+    );
+    counts.appendChild(
+      makeCol('Descendants', [
+        [String(d.descendants_file_count ?? 0), 'files'],
+        [String(d.descendants_dir_count ?? 0), 'dirs'],
+        [formatBytes(d.descendants_size ?? 0), 'size'],
+      ]),
+    );
+    body.appendChild(counts);
+
+    // By extension
+    const stats = aggregateExtensions(d);
+    if (stats.length > 0) {
+      const h = document.createElement('div');
+      h.className = 'street-ext-h';
+      h.textContent = 'By extension';
+      body.appendChild(h);
+      const list = document.createElement('div');
+      list.className = 'street-ext-list';
+      const huePalette = BUILDING_PALETTE.get().HUE_EXT_MAP || {};
+      const asphaltColor = ASPHALT.get().COLOR;
+      for (const s of stats) {
+        const row = document.createElement('div');
+        row.className = 'street-ext-row';
+        const badgeExt = s.ext === '(none)' ? null : s.ext;
+        row.appendChild(makeExtensionBadge(badgeExt, false, huePalette, asphaltColor));
+        const label = document.createElement('span');
+        label.className = 'street-ext-label';
+        label.textContent = s.ext;
+        row.appendChild(label);
+        const count = document.createElement('span');
+        count.className = 'street-ext-count';
+        count.textContent = `${s.count} file${s.count === 1 ? '' : 's'}`;
+        row.appendChild(count);
+        const sep = document.createElement('span');
+        sep.className = 'street-ext-sep';
+        sep.setAttribute('aria-hidden', 'true');
+        sep.textContent = '·';
+        row.appendChild(sep);
+        const size = document.createElement('span');
+        size.className = 'street-ext-size';
+        size.textContent = formatBytes(s.size);
+        row.appendChild(size);
+        list.appendChild(row);
+      }
+      body.appendChild(list);
+    }
+  }
+
+  function setDirectory(d: DirNode | null): void {
+    if (!d) {
+      _renderEmpty();
+      return;
+    }
+    _renderDir(d);
+  }
+
+  setDirectory(null);
+
+  return {
+    pane,
+    api: { setDirectory },
+  };
+}

--- a/app/src/views/panes/streetPane.ts
+++ b/app/src/views/panes/streetPane.ts
@@ -1,7 +1,7 @@
 // views/panes/streetPane.ts — right-sidebar pane shown when a directory
-// (road) is selected in the city. Shows the dir path, direct + descendant
-// children counts + total size, and a sorted breakdown of every file
-// extension in the descendant subtree.
+// (road) is selected in the city. Shows direct + descendant child
+// counts and a sorted breakdown of every file extension in the
+// descendant subtree.
 //
 // API matches commitPane's shape (build once, push selection via
 // setDirectory) so the coordinator can swap panes in the right sidebar
@@ -102,11 +102,13 @@ export function buildStreetPane(opts: BuildStreetPaneOpts = {}) {
   function _renderDir(d: DirNode): void {
     _activeDir = d;
     headerApi.setFocusEnabled(true);
-    const leaf = (d.path && d.path !== '.' ? d.path.split('/').filter(Boolean).pop() : null) || d.name || 'Road';
+    const leaf =
+      (d.path && d.path !== '.' ? d.path.split('/').filter(Boolean).pop() : null) ||
+      d.name ||
+      'Road';
     headerApi.setTitle(leaf);
     body.replaceChildren();
 
-    // Path row
     // Counts block
     const counts = document.createElement('div');
     counts.className = 'street-counts';
@@ -140,13 +142,13 @@ export function buildStreetPane(opts: BuildStreetPaneOpts = {}) {
       makeCol('Direct', [
         [String(d.children_file_count ?? 0), 'files'],
         [String(d.children_dir_count ?? 0), 'dirs'],
-      ]),
+      ])
     );
     counts.appendChild(
       makeCol('Descendants', [
         [String(d.descendants_file_count ?? 0), 'files'],
         [String(d.descendants_dir_count ?? 0), 'dirs'],
-      ]),
+      ])
     );
     body.appendChild(counts);
 

--- a/app/src/views/panes/streetPane.ts
+++ b/app/src/views/panes/streetPane.ts
@@ -107,15 +107,6 @@ export function buildStreetPane(opts: BuildStreetPaneOpts = {}) {
     body.replaceChildren();
 
     // Path row
-    const pathRow = document.createElement('div');
-    pathRow.className = 'street-path';
-    pathRow.appendChild(makeLucideIcon('folder'));
-    const pathText = document.createElement('span');
-    pathText.className = 'street-path-text';
-    pathText.textContent = d.path || d.name || '';
-    pathRow.appendChild(pathText);
-    body.appendChild(pathRow);
-
     // Counts block
     const counts = document.createElement('div');
     counts.className = 'street-counts';
@@ -155,7 +146,6 @@ export function buildStreetPane(opts: BuildStreetPaneOpts = {}) {
       makeCol('Descendants', [
         [String(d.descendants_file_count ?? 0), 'files'],
         [String(d.descendants_dir_count ?? 0), 'dirs'],
-        [formatBytes(d.descendants_size ?? 0), 'size'],
       ]),
     );
     body.appendChild(counts);

--- a/app/src/views/shell/appHeader.ts
+++ b/app/src/views/shell/appHeader.ts
@@ -140,9 +140,7 @@ export function initAppHeader(opts: InitAppHeaderOpts = {}) {
       focusBtn.type = 'button';
       focusBtn.className = 'btn-icon btn-icon--no-drag';
       const tooltip =
-        sel.kind === 'commit'
-          ? 'Focus camera on commit (F)'
-          : 'Focus camera on selection (F)';
+        sel.kind === 'commit' ? 'Focus camera on commit (F)' : 'Focus camera on selection (F)';
       focusBtn.title = tooltip;
       focusBtn.setAttribute('aria-label', tooltip);
       focusBtn.appendChild(makeLucideIcon('focus'));
@@ -184,8 +182,8 @@ export function initAppHeader(opts: InitAppHeaderOpts = {}) {
         isFileSel ? (sel.extension ?? null) : null,
         !isFileSel,
         huePalette,
-        asphaltColor,
-      ),
+        asphaltColor
+      )
     );
 
     const crumbs = document.createElement('div');

--- a/app/src/views/shell/appHeader.ts
+++ b/app/src/views/shell/appHeader.ts
@@ -15,12 +15,19 @@ import { fitSegments } from '../widgets/pathTruncate.js';
 // How long the "Copied!" badge lingers after the copy button is clicked.
 const COPY_FEEDBACK_DURATION_MS = 1500;
 
-interface HeaderSelection {
-  path: string;
-  fullPath?: string;
-  extension?: string;
-  isDir?: boolean;
-}
+export type HeaderSelection =
+  | {
+      kind: 'file' | 'dir';
+      path: string;
+      fullPath?: string;
+      extension?: string;
+      isDir?: boolean;
+    }
+  | {
+      kind: 'commit';
+      sha: string;
+      author: string;
+    };
 
 interface InitAppHeaderOpts {
   /** project name shown in the project button on the left */
@@ -123,49 +130,69 @@ export function initAppHeader(opts: InitAppHeaderOpts = {}) {
   function setSelection(sel: HeaderSelection | null): void {
     lastSelection = sel;
     titleEl!.replaceChildren();
-    const hasSel = !!(sel?.path && sel.path !== rootPath);
-
-    if (!hasSel) {
-      // Empty title — project button on the left carries the project identity.
+    if (!sel) {
       return;
     }
 
-    // Focus button — fires F-key equivalent (focus camera on selection).
-    // Sits LEFT of the extension badge so the order reads
-    // [focus] [ext tag] [path] [copy].
+    // Focus button — shared across all kinds.
     if (onFocus) {
       const focusBtn = document.createElement('button');
       focusBtn.type = 'button';
       focusBtn.className = 'btn-icon btn-icon--no-drag';
-      focusBtn.title = 'Focus camera on selection (F)';
-      focusBtn.setAttribute('aria-label', 'Focus camera on selection');
+      const tooltip =
+        sel.kind === 'commit'
+          ? 'Focus camera on commit (F)'
+          : 'Focus camera on selection (F)';
+      focusBtn.title = tooltip;
+      focusBtn.setAttribute('aria-label', tooltip);
       focusBtn.appendChild(makeLucideIcon('focus'));
       focusBtn.addEventListener('click', () => onFocus());
       titleEl!.appendChild(focusBtn);
     }
 
+    if (sel.kind === 'commit') {
+      // "Commit <short-sha> · <author>" with copy-full-sha button.
+      const label = document.createTextNode('Commit ');
+      titleEl!.appendChild(label);
+      const shaEl = document.createElement('span');
+      shaEl.className = 'app-header-commit-sha';
+      shaEl.textContent = sel.sha.slice(0, 7);
+      titleEl!.appendChild(shaEl);
+      const authorEl = document.createElement('span');
+      authorEl.className = 'app-header-commit-author';
+      authorEl.textContent = ` · ${sel.author || '(unknown)'}`;
+      titleEl!.appendChild(authorEl);
+      titleEl!.appendChild(_makeCopyButton(sel.sha));
+      _crumbsEl = null;
+      _segEls = [];
+      _sepEls = [];
+      return;
+    }
+
+    // file | dir branch — unchanged from previous implementation.
+    const hasSel = !!(sel.path && sel.path !== rootPath);
+    if (!hasSel) return;
+
     // Chip mirrors the leaf: file-ext when a file is selected, dir badge
     // for any directory selection. Palette + asphalt are read fresh from
     // the stores so the badge follows live config edits.
-    const isFileSel = sel && !sel.isDir;
+    const isFileSel = !sel.isDir;
     const huePalette = BUILDING_PALETTE.get().HUE_EXT_MAP || {};
     const asphaltColor = ASPHALT.get().COLOR;
     titleEl!.appendChild(
       makeExtensionBadge(
-        isFileSel ? (sel!.extension ?? null) : null,
+        isFileSel ? (sel.extension ?? null) : null,
         !isFileSel,
         huePalette,
-        asphaltColor
-      )
+        asphaltColor,
+      ),
     );
 
     const crumbs = document.createElement('div');
     crumbs.className = 'app-header-crumbs';
-    crumbs.title = sel ? `${_rootLabel}/${sel.path}` : _rootLabel;
+    crumbs.title = `${_rootLabel}/${sel.path}`;
 
-    // Path segments — the root is in the project button, so we start
-    // directly with the selection's path segments.
-    const segs = sel!.path.split('/').filter(Boolean);
+    const segs = sel.path.split('/').filter(Boolean);
     const segmentEls: HTMLElement[] = [];
     const separatorEls: HTMLElement[] = [];
     let acc = '';
@@ -184,11 +211,8 @@ export function initAppHeader(opts: InitAppHeaderOpts = {}) {
       crumbs.appendChild(segEl);
     }
     titleEl!.appendChild(crumbs);
+    titleEl!.appendChild(_makeCopyButton(sel.fullPath || sel.path));
 
-    // Copy button copies the absolute filesystem path.
-    titleEl!.appendChild(_makeCopyButton(sel!.fullPath || sel!.path));
-
-    // Cache refs for ResizeObserver and run initial fit.
     _crumbsEl = crumbs;
     _segEls = segmentEls;
     _sepEls = separatorEls;

--- a/app/src/views/shell/paneHeader.ts
+++ b/app/src/views/shell/paneHeader.ts
@@ -52,6 +52,12 @@ export function buildPaneHeader(opts: BuildPaneHeaderOpts) {
     focusBtn.setAttribute('aria-label', tooltip);
     focusBtn.appendChild(makeLucideIcon('focus'));
     focusBtn.addEventListener('click', () => {
+      // Drop focus from the button so subsequent F/Escape keystrokes
+      // fall through to the document-level keydown handler that drives
+      // canvas selection/focus. Without this the button stays focused
+      // after a click, but :focus traps Enter/Space and steals the next
+      // keyboard interaction from the canvas.
+      focusBtn.blur();
       opts.onFocus!();
     });
     // Prepend so the button is the leftmost element. setPrefixEl (called

--- a/app/src/views/widgets/badge.ts
+++ b/app/src/views/widgets/badge.ts
@@ -51,7 +51,7 @@ export function makeExtensionBadge(
     return chip;
   }
   chip.textContent = (extension || '').replace(/^\./, '').slice(0, 4) || 'file';
-  const hue = getHue(extension ?? null, huePalette);
+  const hue = getHue(extension ?? '', huePalette);
   chip.style.setProperty('--badge-hue', String(hue));
   chip.style.color = _pickContrastingText(
     _hslToRgb(hue, FILE_BADGE_SATURATION, FILE_BADGE_LIGHTNESS)

--- a/app/tests/scene/effects/buildingFader.test.ts
+++ b/app/tests/scene/effects/buildingFader.test.ts
@@ -156,13 +156,22 @@ describe('buildingFader 5-tier cascade', () => {
     expect(readFor('src/b.ts')!.opacity).toBeCloseTo(1.0);
   });
 
-  it('selected file → self DEFAULT, sibling L1, one-deeper L2, deeper L3, outside L4', () => {
+  it('selected file → symmetric LCA distance: same dir L1, 1 hop L2, 2 hops L3, 3+ hops L4', () => {
+    // dirTarget = src/foo. Distances from src/foo:
+    //   src/foo/a.ts   = 0 (self, but rendered as Default)
+    //   src/foo/b.ts   = 0 → L1
+    //   src/foo/bar/c.ts = 1 down → L2
+    //   src/foo/bar/baz/d.ts = 2 down → L3
+    //   src/lib/e.ts   = 1 up + 1 down → L3
+    //   README.md      = 2 up → L3
+    //   far/deep/x.ts  = 2 up + 2 down = 4 → L4
     const a = makeFile('src/foo/a.ts');
     const b = makeFile('src/foo/b.ts');
     const c = makeFile('src/foo/bar/c.ts');
     const d = makeFile('src/foo/bar/baz/d.ts');
     const e = makeFile('src/lib/e.ts');
     const r = makeFile('README.md');
+    const far = makeFile('other/deep/x.ts');
     const selBuilding = makeBuilding(a);
     const streetByDir = new Map([['src/foo', { dir: makeDir('src/foo') }]]);
 
@@ -174,6 +183,7 @@ describe('buildingFader 5-tier cascade', () => {
         makeBuilding(d),
         makeBuilding(e),
         makeBuilding(r),
+        makeBuilding(far),
       ],
       selection: {
         kind: NodeKind.File,
@@ -188,17 +198,20 @@ describe('buildingFader 5-tier cascade', () => {
     expect(readFor('src/foo/b.ts')!.opacity).toBeCloseTo(0.8);
     expect(readFor('src/foo/bar/c.ts')!.opacity).toBeCloseTo(0.6);
     expect(readFor('src/foo/bar/baz/d.ts')!.opacity).toBeCloseTo(0.4);
-    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.2);
-    expect(readFor('README.md')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('README.md')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('other/deep/x.ts')!.opacity).toBeCloseTo(0.2);
   });
 
-  it('selected dir → direct files L1, one-deeper L2, deeper L3, outside L4', () => {
+  it('selected dir → symmetric distance: direct files L1, 1 hop L2, 2 hops L3', () => {
+    // dirTarget = src/foo. Same distance math as the file-selection case.
     const a = makeFile('src/foo/a.ts');
     const b = makeFile('src/foo/b.ts');
     const c = makeFile('src/foo/bar/c.ts');
     const d = makeFile('src/foo/bar/baz/d.ts');
     const e = makeFile('src/lib/e.ts');
     const r = makeFile('README.md');
+    const far = makeFile('other/deep/x.ts');
     const dir = makeDir('src/foo');
 
     const { readFor } = makeFader({
@@ -209,6 +222,7 @@ describe('buildingFader 5-tier cascade', () => {
         makeBuilding(d),
         makeBuilding(e),
         makeBuilding(r),
+        makeBuilding(far),
       ],
       selection: {
         kind: NodeKind.Directory,
@@ -222,15 +236,17 @@ describe('buildingFader 5-tier cascade', () => {
     expect(readFor('src/foo/b.ts')!.opacity).toBeCloseTo(0.8);
     expect(readFor('src/foo/bar/c.ts')!.opacity).toBeCloseTo(0.6);
     expect(readFor('src/foo/bar/baz/d.ts')!.opacity).toBeCloseTo(0.4);
-    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.2);
-    expect(readFor('README.md')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('README.md')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('other/deep/x.ts')!.opacity).toBeCloseTo(0.2);
   });
 
-  it('hovered file → hover-self DEFAULT, sibling L1, deeper L2, outside L4', () => {
+  it('hovered file → hover-self DEFAULT, sibling L1, 1 hop L2, 2 hops L3, 3+ hops L4', () => {
     const a = makeFile('src/foo/a.ts');
     const b = makeFile('src/foo/b.ts');
     const c = makeFile('src/foo/bar/c.ts');
     const e = makeFile('src/lib/e.ts');
+    const far = makeFile('other/deep/x.ts');
     const hovBuilding = makeBuilding(a);
     const streetByDir = new Map([['src/foo', { dir: makeDir('src/foo') }]]);
 
@@ -240,6 +256,7 @@ describe('buildingFader 5-tier cascade', () => {
         makeBuilding(b),
         makeBuilding(c),
         makeBuilding(e),
+        makeBuilding(far),
       ],
       hover: {
         kind: NodeKind.File,
@@ -253,10 +270,16 @@ describe('buildingFader 5-tier cascade', () => {
     expect(readFor('src/foo/a.ts')!.opacity).toBeCloseTo(1.0);
     expect(readFor('src/foo/b.ts')!.opacity).toBeCloseTo(0.8);
     expect(readFor('src/foo/bar/c.ts')!.opacity).toBeCloseTo(0.6);
-    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('other/deep/x.ts')!.opacity).toBeCloseTo(0.2);
   });
 
-  it('root selection → root-level files L1, top-level sub-dir files L2, deeper L3, no L4 reachable', () => {
+  it('root selection → distance is depth from root', () => {
+    // dirTarget = root. dp=[], so distance equals depth of each file's parent.
+    //   README.md (parent='.')         distance 0 → L1
+    //   src/x.ts (parent='src')        distance 1 → L2
+    //   src/foo/y.ts                   distance 2 → L3
+    //   src/foo/bar/z.ts               distance 3 → L4
     const r = makeFile('README.md');
     const x = makeFile('src/x.ts');
     const y = makeFile('src/foo/y.ts');
@@ -276,10 +299,15 @@ describe('buildingFader 5-tier cascade', () => {
     expect(readFor('README.md')!.opacity).toBeCloseTo(0.8);
     expect(readFor('src/x.ts')!.opacity).toBeCloseTo(0.6);
     expect(readFor('src/foo/y.ts')!.opacity).toBeCloseTo(0.4);
-    expect(readFor('src/foo/bar/z.ts')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('src/foo/bar/z.ts')!.opacity).toBeCloseTo(0.2);
   });
 
-  it('prefix-precision: "src-utils" is NOT inside "src" subtree', () => {
+  it('prefix-precision: "src-utils" is NOT confused with a child of "src"', () => {
+    // dirTarget = src. src/a.ts shares dir → L1 (distance 0).
+    // src-utils/x.ts: parent='src-utils', LCA with 'src' = root, so
+    // distance = 1 (up) + 1 (down) = 2 → L3, NOT L2. Without the
+    // segment-aware split, a naive prefix check would treat 'src-utils'
+    // as a child of 'src' and place it at L2.
     const a = makeFile('src/a.ts');
     const lookAlike = makeFile('src-utils/x.ts');
     const dir = makeDir('src');
@@ -295,7 +323,7 @@ describe('buildingFader 5-tier cascade', () => {
     });
 
     expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.8);
-    expect(readFor('src-utils/x.ts')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('src-utils/x.ts')!.opacity).toBeCloseTo(0.4); // L3, not L2
   });
 
   it('selected file honors DEFAULT config (no hardcoded constants)', () => {

--- a/app/tests/scene/effects/buildingFader.test.ts
+++ b/app/tests/scene/effects/buildingFader.test.ts
@@ -73,7 +73,7 @@ function makeFader(opts: {
 }) {
   const iFadeAttr = new THREE.InstancedBufferAttribute(
     new Float32Array(opts.buildings.length * 3),
-    3,
+    3
   );
   const detailMesh = {
     geometry: { getAttribute: (_: string) => iFadeAttr },

--- a/app/tests/scene/effects/buildingFader.test.ts
+++ b/app/tests/scene/effects/buildingFader.test.ts
@@ -1,7 +1,7 @@
-// buildingFader.test.ts — verifies the in-subtree cascade: every building
-// under the selected/hovered directory's subtree gets the NEAR tier;
-// everything outside gets FAR. Selected and hovered buildings themselves
-// keep their dedicated "brightest" tiers.
+// buildingFader.test.ts — verifies the 5-tier depth-based cascade.
+// Default tier covers selected, hovered, and idle buildings; the four
+// numbered levels cover same-dir (L1), one-deeper (L2), deeper (L3),
+// and outside-subtree (L4).
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as THREE from 'three';
@@ -112,6 +112,9 @@ function makeFader(opts: {
   return { fader, readFor };
 }
 
+/** Set distinctive opacity values per tier so each assertion pins down
+ *  exactly one tier without ambiguity. Detail mode is the same so
+ *  silhouette isn't a confounder; outline disabled across the board. */
 function setKnownFade() {
   BUILDING_FADE.set({
     ..._originalFade,
@@ -119,18 +122,26 @@ function setKnownFade() {
     DEFAULT_BODY_OPACITY: 1.0,
     DEFAULT_OUTLINE: false,
     DEFAULT_OUTLINE_OPACITY: 0.0,
-    NEAR_DETAIL: FadeDetail.Full,
-    NEAR_BODY_OPACITY: 0.7,
-    NEAR_OUTLINE: false,
-    NEAR_OUTLINE_OPACITY: 0.0,
-    FAR_DETAIL: FadeDetail.Silhouette,
-    FAR_BODY_OPACITY: 0.2,
-    FAR_OUTLINE: false,
-    FAR_OUTLINE_OPACITY: 0.0,
+    LEVEL1_DETAIL: FadeDetail.Full,
+    LEVEL1_BODY_OPACITY: 0.8,
+    LEVEL1_OUTLINE: false,
+    LEVEL1_OUTLINE_OPACITY: 0.0,
+    LEVEL2_DETAIL: FadeDetail.Full,
+    LEVEL2_BODY_OPACITY: 0.6,
+    LEVEL2_OUTLINE: false,
+    LEVEL2_OUTLINE_OPACITY: 0.0,
+    LEVEL3_DETAIL: FadeDetail.Full,
+    LEVEL3_BODY_OPACITY: 0.4,
+    LEVEL3_OUTLINE: false,
+    LEVEL3_OUTLINE_OPACITY: 0.0,
+    LEVEL4_DETAIL: FadeDetail.Full,
+    LEVEL4_BODY_OPACITY: 0.2,
+    LEVEL4_OUTLINE: false,
+    LEVEL4_OUTLINE_OPACITY: 0.0,
   });
 }
 
-describe('buildingFader subtree cascade', () => {
+describe('buildingFader 5-tier cascade', () => {
   beforeEach(setKnownFade);
 
   it('no target → every building gets DEFAULT (1.0 opacity)', () => {
@@ -145,15 +156,25 @@ describe('buildingFader subtree cascade', () => {
     expect(readFor('src/b.ts')!.opacity).toBeCloseTo(1.0);
   });
 
-  it('selected building → siblings NEAR, cousins FAR, selected itself Full', () => {
-    const a = makeFile('src/a.ts');
-    const b = makeFile('src/b.ts');
-    const c = makeFile('lib/c.ts');
+  it('selected file → self DEFAULT, sibling L1, one-deeper L2, deeper L3, outside L4', () => {
+    const a = makeFile('src/foo/a.ts');
+    const b = makeFile('src/foo/b.ts');
+    const c = makeFile('src/foo/bar/c.ts');
+    const d = makeFile('src/foo/bar/baz/d.ts');
+    const e = makeFile('src/lib/e.ts');
+    const r = makeFile('README.md');
     const selBuilding = makeBuilding(a);
-    const streetByDir = new Map([['src', { dir: makeDir('src') }]]);
+    const streetByDir = new Map([['src/foo', { dir: makeDir('src/foo') }]]);
 
     const { readFor } = makeFader({
-      buildings: [selBuilding, makeBuilding(b), makeBuilding(c)],
+      buildings: [
+        selBuilding,
+        makeBuilding(b),
+        makeBuilding(c),
+        makeBuilding(d),
+        makeBuilding(e),
+        makeBuilding(r),
+      ],
       selection: {
         kind: NodeKind.File,
         mesh: new THREE.Object3D() as unknown as THREE.Mesh,
@@ -163,38 +184,32 @@ describe('buildingFader subtree cascade', () => {
       streetByDir,
     });
 
-    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(1.0);
-    expect(readFor('src/b.ts')!.opacity).toBeCloseTo(0.7);
-    expect(readFor('lib/c.ts')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('src/foo/a.ts')!.opacity).toBeCloseTo(1.0);
+    expect(readFor('src/foo/b.ts')!.opacity).toBeCloseTo(0.8);
+    expect(readFor('src/foo/bar/c.ts')!.opacity).toBeCloseTo(0.6);
+    expect(readFor('src/foo/bar/baz/d.ts')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('README.md')!.opacity).toBeCloseTo(0.2);
   });
 
-  it('selected building → descendants of the parent dir also NEAR', () => {
-    const a = makeFile('src/a.ts');
-    const nested = makeFile('src/sub/nested.ts');
-    const selBuilding = makeBuilding(a);
-    const streetByDir = new Map([['src', { dir: makeDir('src') }]]);
+  it('selected dir → direct files L1, one-deeper L2, deeper L3, outside L4', () => {
+    const a = makeFile('src/foo/a.ts');
+    const b = makeFile('src/foo/b.ts');
+    const c = makeFile('src/foo/bar/c.ts');
+    const d = makeFile('src/foo/bar/baz/d.ts');
+    const e = makeFile('src/lib/e.ts');
+    const r = makeFile('README.md');
+    const dir = makeDir('src/foo');
 
     const { readFor } = makeFader({
-      buildings: [selBuilding, makeBuilding(nested)],
-      selection: {
-        kind: NodeKind.File,
-        mesh: new THREE.Object3D() as unknown as THREE.Mesh,
-        data: selBuilding,
-        file: a,
-      } as unknown as PickTarget,
-      streetByDir,
-    });
-    expect(readFor('src/sub/nested.ts')!.opacity).toBeCloseTo(0.7);
-  });
-
-  it('selected dir → direct children + nested grandchildren NEAR, others FAR', () => {
-    const a = makeFile('src/a.ts');
-    const nested = makeFile('src/sub/n.ts');
-    const other = makeFile('lib/x.ts');
-    const dir = makeDir('src');
-
-    const { readFor } = makeFader({
-      buildings: [makeBuilding(a), makeBuilding(nested), makeBuilding(other)],
+      buildings: [
+        makeBuilding(a),
+        makeBuilding(b),
+        makeBuilding(c),
+        makeBuilding(d),
+        makeBuilding(e),
+        makeBuilding(r),
+      ],
       selection: {
         kind: NodeKind.Directory,
         sidewalk: new THREE.Object3D() as unknown as THREE.Mesh,
@@ -203,20 +218,29 @@ describe('buildingFader subtree cascade', () => {
       } as unknown as PickTarget,
     });
 
-    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.7);
-    expect(readFor('src/sub/n.ts')!.opacity).toBeCloseTo(0.7);
-    expect(readFor('lib/x.ts')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('src/foo/a.ts')!.opacity).toBeCloseTo(0.8);
+    expect(readFor('src/foo/b.ts')!.opacity).toBeCloseTo(0.8);
+    expect(readFor('src/foo/bar/c.ts')!.opacity).toBeCloseTo(0.6);
+    expect(readFor('src/foo/bar/baz/d.ts')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('README.md')!.opacity).toBeCloseTo(0.2);
   });
 
-  it('hovered building → siblings NEAR, hovered itself DEFAULT', () => {
-    const a = makeFile('src/a.ts');
-    const b = makeFile('src/b.ts');
-    const c = makeFile('lib/c.ts');
+  it('hovered file → hover-self DEFAULT, sibling L1, deeper L2, outside L4', () => {
+    const a = makeFile('src/foo/a.ts');
+    const b = makeFile('src/foo/b.ts');
+    const c = makeFile('src/foo/bar/c.ts');
+    const e = makeFile('src/lib/e.ts');
     const hovBuilding = makeBuilding(a);
-    const streetByDir = new Map([['src', { dir: makeDir('src') }]]);
+    const streetByDir = new Map([['src/foo', { dir: makeDir('src/foo') }]]);
 
     const { readFor } = makeFader({
-      buildings: [hovBuilding, makeBuilding(b), makeBuilding(c)],
+      buildings: [
+        hovBuilding,
+        makeBuilding(b),
+        makeBuilding(c),
+        makeBuilding(e),
+      ],
       hover: {
         kind: NodeKind.File,
         mesh: new THREE.Object3D() as unknown as THREE.Mesh,
@@ -226,19 +250,21 @@ describe('buildingFader subtree cascade', () => {
       streetByDir,
     });
 
-    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(1.0);
-    expect(readFor('src/b.ts')!.opacity).toBeCloseTo(0.7);
-    expect(readFor('lib/c.ts')!.opacity).toBeCloseTo(0.2);
+    expect(readFor('src/foo/a.ts')!.opacity).toBeCloseTo(1.0);
+    expect(readFor('src/foo/b.ts')!.opacity).toBeCloseTo(0.8);
+    expect(readFor('src/foo/bar/c.ts')!.opacity).toBeCloseTo(0.6);
+    expect(readFor('src/lib/e.ts')!.opacity).toBeCloseTo(0.2);
   });
 
-  it('root selection (dir.path = ".") → every building NEAR', () => {
-    const a = makeFile('src/a.ts');
-    const b = makeFile('lib/b.ts');
-    const c = makeFile('README.md');
+  it('root selection → root-level files L1, top-level sub-dir files L2, deeper L3, no L4 reachable', () => {
+    const r = makeFile('README.md');
+    const x = makeFile('src/x.ts');
+    const y = makeFile('src/foo/y.ts');
+    const z = makeFile('src/foo/bar/z.ts');
     const rootDir = makeDir('.');
 
     const { readFor } = makeFader({
-      buildings: [makeBuilding(a), makeBuilding(b), makeBuilding(c)],
+      buildings: [makeBuilding(r), makeBuilding(x), makeBuilding(y), makeBuilding(z)],
       selection: {
         kind: NodeKind.Directory,
         sidewalk: new THREE.Object3D() as unknown as THREE.Mesh,
@@ -247,19 +273,19 @@ describe('buildingFader subtree cascade', () => {
       } as unknown as PickTarget,
     });
 
-    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.7);
-    expect(readFor('lib/b.ts')!.opacity).toBeCloseTo(0.7);
-    expect(readFor('README.md')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('README.md')!.opacity).toBeCloseTo(0.8);
+    expect(readFor('src/x.ts')!.opacity).toBeCloseTo(0.6);
+    expect(readFor('src/foo/y.ts')!.opacity).toBeCloseTo(0.4);
+    expect(readFor('src/foo/bar/z.ts')!.opacity).toBeCloseTo(0.4);
   });
 
-  it('prefix-precision: "src-utils" is NOT a descendant of "src"', () => {
-    const inside = makeFile('src/a.ts');
-    const sibling = makeFile('src/b.ts');
+  it('prefix-precision: "src-utils" is NOT inside "src" subtree', () => {
+    const a = makeFile('src/a.ts');
     const lookAlike = makeFile('src-utils/x.ts');
     const dir = makeDir('src');
 
     const { readFor } = makeFader({
-      buildings: [makeBuilding(inside), makeBuilding(sibling), makeBuilding(lookAlike)],
+      buildings: [makeBuilding(a), makeBuilding(lookAlike)],
       selection: {
         kind: NodeKind.Directory,
         sidewalk: new THREE.Object3D() as unknown as THREE.Mesh,
@@ -268,8 +294,28 @@ describe('buildingFader subtree cascade', () => {
       } as unknown as PickTarget,
     });
 
-    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.7);
-    expect(readFor('src/b.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.8);
     expect(readFor('src-utils/x.ts')!.opacity).toBeCloseTo(0.2);
+  });
+
+  it('selected file honors DEFAULT config (no hardcoded constants)', () => {
+    BUILDING_FADE.setKey('DEFAULT_BODY_OPACITY', 0.5);
+
+    const a = makeFile('src/a.ts');
+    const selBuilding = makeBuilding(a);
+    const streetByDir = new Map([['src', { dir: makeDir('src') }]]);
+
+    const { readFor } = makeFader({
+      buildings: [selBuilding],
+      selection: {
+        kind: NodeKind.File,
+        mesh: new THREE.Object3D() as unknown as THREE.Mesh,
+        data: selBuilding,
+        file: a,
+      } as unknown as PickTarget,
+      streetByDir,
+    });
+
+    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.5);
   });
 });

--- a/app/tests/scene/effects/buildingFader.test.ts
+++ b/app/tests/scene/effects/buildingFader.test.ts
@@ -1,0 +1,275 @@
+// buildingFader.test.ts — verifies the in-subtree cascade: every building
+// under the selected/hovered directory's subtree gets the NEAR tier;
+// everything outside gets FAR. Selected and hovered buildings themselves
+// keep their dedicated "brightest" tiers.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as THREE from 'three';
+import { atom } from 'nanostores';
+import { createBuildingFader } from '@/scene/effects/buildingFader.js';
+import { BUILDING_FADE } from '@/config/index.js';
+import { FadeDetail, NodeKind } from '@/types';
+import type { Building, DirNode, FileNode, PickTarget, Street } from '@/types';
+
+const _originalFade = BUILDING_FADE.get();
+
+afterEach(() => {
+  BUILDING_FADE.set(_originalFade);
+});
+
+function makeFile(path: string): FileNode {
+  return {
+    name: path.split('/').pop()!,
+    type: NodeKind.File,
+    path,
+    fullPath: `/repo/${path}`,
+    extension: '.ts',
+    size: 1,
+    lines: 1,
+    binary: false,
+    created: null,
+    modified: null,
+    git: null,
+  } as unknown as FileNode;
+}
+
+function makeDir(path: string): DirNode {
+  return {
+    name: path === '.' ? 'root' : path.split('/').pop()!,
+    type: NodeKind.Directory,
+    path,
+    fullPath: `/repo/${path}`,
+    children: [],
+    children_file_count: 0,
+    children_dir_count: 0,
+    descendants_file_count: 0,
+    descendants_dir_count: 0,
+    descendants_size: 0,
+  } as unknown as DirNode;
+}
+
+function makeBuilding(file: FileNode): Building {
+  return {
+    x: 0,
+    y: 0,
+    w: 10,
+    d: 10,
+    h: 20,
+    file,
+  } as unknown as Building;
+}
+
+interface FadeReading {
+  opacity: number;
+  silhouette: number;
+  outlineOpacity: number;
+}
+
+function makeFader(opts: {
+  buildings: Building[];
+  selection?: PickTarget | null;
+  hover?: PickTarget | null;
+  streetByDir?: Map<string, { dir: DirNode } & Partial<Street>>;
+}) {
+  const iFadeAttr = new THREE.InstancedBufferAttribute(
+    new Float32Array(opts.buildings.length * 3),
+    3,
+  );
+  const detailMesh = {
+    geometry: { getAttribute: (_: string) => iFadeAttr },
+  } as unknown as THREE.InstancedMesh;
+
+  const cell = { detailMesh, buildings: opts.buildings };
+  const cells = new Map([[0, cell]]);
+
+  const streetByDir = opts.streetByDir ?? new Map();
+
+  const world = {
+    getCells: () => cells,
+    getStreetByDir: (path: string) => streetByDir.get(path) ?? null,
+    getAdPanels: () => null,
+    onChange: () => () => {},
+  } as unknown as Parameters<typeof createBuildingFader>[0]['world'];
+
+  const picker = {
+    selection: atom<PickTarget | null>(opts.selection ?? null),
+    hover: atom<PickTarget | null>(opts.hover ?? null),
+  } as unknown as Parameters<typeof createBuildingFader>[0]['picker'];
+
+  const fader = createBuildingFader({ world, picker });
+
+  function readFor(path: string): FadeReading | null {
+    const slot = opts.buildings.findIndex((b) => b.file?.path === path);
+    if (slot < 0) return null;
+    const i = slot * 3;
+    return {
+      opacity: iFadeAttr.array[i] as number,
+      silhouette: iFadeAttr.array[i + 1] as number,
+      outlineOpacity: iFadeAttr.array[i + 2] as number,
+    };
+  }
+
+  return { fader, readFor };
+}
+
+function setKnownFade() {
+  BUILDING_FADE.set({
+    ..._originalFade,
+    DEFAULT_DETAIL: FadeDetail.Full,
+    DEFAULT_BODY_OPACITY: 1.0,
+    DEFAULT_OUTLINE: false,
+    DEFAULT_OUTLINE_OPACITY: 0.0,
+    NEAR_DETAIL: FadeDetail.Full,
+    NEAR_BODY_OPACITY: 0.7,
+    NEAR_OUTLINE: false,
+    NEAR_OUTLINE_OPACITY: 0.0,
+    FAR_DETAIL: FadeDetail.Silhouette,
+    FAR_BODY_OPACITY: 0.2,
+    FAR_OUTLINE: false,
+    FAR_OUTLINE_OPACITY: 0.0,
+  });
+}
+
+describe('buildingFader subtree cascade', () => {
+  beforeEach(setKnownFade);
+
+  it('no target → every building gets DEFAULT (1.0 opacity)', () => {
+    const a = makeFile('src/a.ts');
+    const b = makeFile('src/b.ts');
+    const { readFor } = makeFader({
+      buildings: [makeBuilding(a), makeBuilding(b)],
+      selection: null,
+      hover: null,
+    });
+    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(1.0);
+    expect(readFor('src/b.ts')!.opacity).toBeCloseTo(1.0);
+  });
+
+  it('selected building → siblings NEAR, cousins FAR, selected itself Full', () => {
+    const a = makeFile('src/a.ts');
+    const b = makeFile('src/b.ts');
+    const c = makeFile('lib/c.ts');
+    const selBuilding = makeBuilding(a);
+    const streetByDir = new Map([['src', { dir: makeDir('src') }]]);
+
+    const { readFor } = makeFader({
+      buildings: [selBuilding, makeBuilding(b), makeBuilding(c)],
+      selection: {
+        kind: NodeKind.File,
+        mesh: new THREE.Object3D() as unknown as THREE.Mesh,
+        data: selBuilding,
+        file: a,
+      } as unknown as PickTarget,
+      streetByDir,
+    });
+
+    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(1.0);
+    expect(readFor('src/b.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('lib/c.ts')!.opacity).toBeCloseTo(0.2);
+  });
+
+  it('selected building → descendants of the parent dir also NEAR', () => {
+    const a = makeFile('src/a.ts');
+    const nested = makeFile('src/sub/nested.ts');
+    const selBuilding = makeBuilding(a);
+    const streetByDir = new Map([['src', { dir: makeDir('src') }]]);
+
+    const { readFor } = makeFader({
+      buildings: [selBuilding, makeBuilding(nested)],
+      selection: {
+        kind: NodeKind.File,
+        mesh: new THREE.Object3D() as unknown as THREE.Mesh,
+        data: selBuilding,
+        file: a,
+      } as unknown as PickTarget,
+      streetByDir,
+    });
+    expect(readFor('src/sub/nested.ts')!.opacity).toBeCloseTo(0.7);
+  });
+
+  it('selected dir → direct children + nested grandchildren NEAR, others FAR', () => {
+    const a = makeFile('src/a.ts');
+    const nested = makeFile('src/sub/n.ts');
+    const other = makeFile('lib/x.ts');
+    const dir = makeDir('src');
+
+    const { readFor } = makeFader({
+      buildings: [makeBuilding(a), makeBuilding(nested), makeBuilding(other)],
+      selection: {
+        kind: NodeKind.Directory,
+        sidewalk: new THREE.Object3D() as unknown as THREE.Mesh,
+        street: { dir } as Street,
+        dir,
+      } as unknown as PickTarget,
+    });
+
+    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('src/sub/n.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('lib/x.ts')!.opacity).toBeCloseTo(0.2);
+  });
+
+  it('hovered building → siblings NEAR, hovered itself DEFAULT', () => {
+    const a = makeFile('src/a.ts');
+    const b = makeFile('src/b.ts');
+    const c = makeFile('lib/c.ts');
+    const hovBuilding = makeBuilding(a);
+    const streetByDir = new Map([['src', { dir: makeDir('src') }]]);
+
+    const { readFor } = makeFader({
+      buildings: [hovBuilding, makeBuilding(b), makeBuilding(c)],
+      hover: {
+        kind: NodeKind.File,
+        mesh: new THREE.Object3D() as unknown as THREE.Mesh,
+        data: hovBuilding,
+        file: a,
+      } as unknown as PickTarget,
+      streetByDir,
+    });
+
+    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(1.0);
+    expect(readFor('src/b.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('lib/c.ts')!.opacity).toBeCloseTo(0.2);
+  });
+
+  it('root selection (dir.path = ".") → every building NEAR', () => {
+    const a = makeFile('src/a.ts');
+    const b = makeFile('lib/b.ts');
+    const c = makeFile('README.md');
+    const rootDir = makeDir('.');
+
+    const { readFor } = makeFader({
+      buildings: [makeBuilding(a), makeBuilding(b), makeBuilding(c)],
+      selection: {
+        kind: NodeKind.Directory,
+        sidewalk: new THREE.Object3D() as unknown as THREE.Mesh,
+        street: { dir: rootDir } as Street,
+        dir: rootDir,
+      } as unknown as PickTarget,
+    });
+
+    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('lib/b.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('README.md')!.opacity).toBeCloseTo(0.7);
+  });
+
+  it('prefix-precision: "src-utils" is NOT a descendant of "src"', () => {
+    const inside = makeFile('src/a.ts');
+    const sibling = makeFile('src/b.ts');
+    const lookAlike = makeFile('src-utils/x.ts');
+    const dir = makeDir('src');
+
+    const { readFor } = makeFader({
+      buildings: [makeBuilding(inside), makeBuilding(sibling), makeBuilding(lookAlike)],
+      selection: {
+        kind: NodeKind.Directory,
+        sidewalk: new THREE.Object3D() as unknown as THREE.Mesh,
+        street: { dir } as Street,
+        dir,
+      } as unknown as PickTarget,
+    });
+
+    expect(readFor('src/a.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('src/b.ts')!.opacity).toBeCloseTo(0.7);
+    expect(readFor('src-utils/x.ts')!.opacity).toBeCloseTo(0.2);
+  });
+});

--- a/app/tests/scene/system/cameraRig.test.ts
+++ b/app/tests/scene/system/cameraRig.test.ts
@@ -1,0 +1,195 @@
+// cameraRig.test.ts — verifies that all four focus actions land the camera
+// at ~80° elevation centered on the expected target.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as THREE from 'three';
+import { createCameraRig } from '@/scene/system/cameraRig.js';
+import { BuildingOrient, NodeKind, StreetAxis } from '@/types';
+import type { Building, Street } from '@/types';
+
+function makeStubWorld(overrides: Partial<ReturnType<typeof _baseWorld>> = {}) {
+  return { ..._baseWorld(), ...overrides };
+}
+
+function _baseWorld() {
+  const bbox = new THREE.Box3(
+    new THREE.Vector3(-500, 0, -500),
+    new THREE.Vector3(500, 200, 500),
+  );
+  return {
+    getBbox: () => bbox,
+    getGemWorldPos: () => new THREE.Vector3(0, 0, 0),
+    getRootStreet: () => ({
+      x: 0,
+      y: 0,
+      width: 40,
+      length: 1000,
+      orientation: StreetAxis.X,
+      dir: null,
+    }) as unknown as Street,
+    onChange: () => () => {},
+    getBuildingPickables: () => [] as THREE.Object3D[],
+    getMaxBuildingHeight: () => 200,
+    getTreeBoundsBySha: (_sha: string) => null as { x: number; y: number; z: number; height: number; radius: number } | null,
+    getGemDims: () => ({ width: 40, height: 40, depth: 40 }),
+  };
+}
+
+function makeBuilding(): Building {
+  return {
+    x: 100,
+    y: 200,
+    w: 30,
+    d: 30,
+    h: 120,
+    orient: BuildingOrient.South,
+    cellId: 1,
+    slotId: 0,
+    file: { name: 'a', type: NodeKind.File, path: 'a', size: 0, lines: 0, extension: '.ts' },
+  } as unknown as Building;
+}
+
+function makeStreet(): Street {
+  return {
+    x: 200,
+    y: 50,
+    width: 20,
+    length: 600,
+    orientation: StreetAxis.X,
+    dir: { name: 'src', path: 'src', type: NodeKind.Directory },
+  } as unknown as Street;
+}
+
+function makeCanvas(): HTMLCanvasElement {
+  const c = document.createElement('canvas');
+  Object.defineProperty(c, 'clientWidth', { value: 1280 });
+  Object.defineProperty(c, 'clientHeight', { value: 720 });
+  return c;
+}
+
+function elevationDeg(camPos: THREE.Vector3, target: THREE.Vector3): number {
+  const v = camPos.clone().sub(target);
+  const horiz = Math.sqrt(v.x * v.x + v.z * v.z);
+  return Math.atan2(v.y, horiz) * (180 / Math.PI);
+}
+
+describe('cameraRig top-down focus', () => {
+  beforeEach(() => {
+    // jsdom canvas doesn't support WebGL — OrbitControls only needs the
+    // DOM canvas, no WebGL context.
+  });
+
+  it('focusBuilding lands the camera at ~80° elevation centered on the building', () => {
+    const canvas = makeCanvas();
+    const world = makeStubWorld();
+    const rig = createCameraRig({ canvas, world: world as any });
+    rig.update(16);
+
+    const b = makeBuilding();
+    rig.focusBuilding(new THREE.Object3D(), b);
+    return new Promise<void>((resolve) => {
+      let frames = 0;
+      function tick() {
+        if (frames++ < 60) {
+          requestAnimationFrame(tick);
+          return;
+        }
+        const target = rig.controls.target;
+        expect(target.x).toBeCloseTo(b.x, 1);
+        expect(target.y).toBeCloseTo(b.h / 2, 1);
+        expect(target.z).toBeCloseTo(b.y, 1);
+        const elev = elevationDeg(rig.camera.position, target);
+        expect(elev).toBeGreaterThan(75);
+        expect(elev).toBeLessThan(85);
+        resolve();
+      }
+      requestAnimationFrame(tick);
+    });
+  });
+
+  it('focusStreet lands the camera at ~80° elevation centered on the street', () => {
+    const canvas = makeCanvas();
+    const rig = createCameraRig({ canvas, world: makeStubWorld() as any });
+    rig.update(16);
+    const s = makeStreet();
+    rig.focusStreet(s, null);
+    return new Promise<void>((resolve) => {
+      let frames = 0;
+      function tick() {
+        if (frames++ < 60) { requestAnimationFrame(tick); return; }
+        const target = rig.controls.target;
+        expect(target.x).toBeCloseTo(s.x, 1);
+        expect(target.y).toBeCloseTo(0, 1);
+        expect(target.z).toBeCloseTo(s.y, 1);
+        const elev = elevationDeg(rig.camera.position, target);
+        expect(elev).toBeGreaterThan(75);
+        expect(elev).toBeLessThan(85);
+        resolve();
+      }
+      requestAnimationFrame(tick);
+    });
+  });
+
+  it('focusGem lands the camera at ~80° elevation on the gem position', () => {
+    const canvas = makeCanvas();
+    const rig = createCameraRig({ canvas, world: makeStubWorld() as any });
+    rig.update(16);
+    rig.focusGem();
+    return new Promise<void>((resolve) => {
+      let frames = 0;
+      function tick() {
+        if (frames++ < 60) { requestAnimationFrame(tick); return; }
+        const target = rig.controls.target;
+        expect(target.x).toBeCloseTo(0, 1);
+        expect(target.z).toBeCloseTo(0, 1);
+        const elev = elevationDeg(rig.camera.position, target);
+        expect(elev).toBeGreaterThan(75);
+        expect(elev).toBeLessThan(85);
+        resolve();
+      }
+      requestAnimationFrame(tick);
+    });
+  });
+
+  it('focusTree lands the camera at ~80° elevation centered on the tree', () => {
+    const canvas = makeCanvas();
+    const world = makeStubWorld({
+      getTreeBoundsBySha: (sha: string) =>
+        sha === 'abc' ? { x: 250, y: 0, z: -180, height: 100, radius: 30 } : null,
+    });
+    const rig = createCameraRig({ canvas, world: world as any });
+    rig.update(16);
+    rig.focusTree('abc');
+    return new Promise<void>((resolve) => {
+      let frames = 0;
+      function tick() {
+        if (frames++ < 60) { requestAnimationFrame(tick); return; }
+        const target = rig.controls.target;
+        expect(target.x).toBeCloseTo(250, 1);
+        expect(target.y).toBeCloseTo(50, 1);
+        expect(target.z).toBeCloseTo(-180, 1);
+        const elev = elevationDeg(rig.camera.position, target);
+        expect(elev).toBeGreaterThan(75);
+        expect(elev).toBeLessThan(85);
+        resolve();
+      }
+      requestAnimationFrame(tick);
+    });
+  });
+
+  it('focusTree is a no-op when getTreeBoundsBySha returns null', () => {
+    const canvas = makeCanvas();
+    const rig = createCameraRig({ canvas, world: makeStubWorld() as any });
+    rig.update(16);
+    const beforePos = rig.camera.position.clone();
+    rig.focusTree('missing-sha');
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(rig.camera.position.x).toBeCloseTo(beforePos.x, 1);
+        expect(rig.camera.position.y).toBeCloseTo(beforePos.y, 1);
+        expect(rig.camera.position.z).toBeCloseTo(beforePos.z, 1);
+        resolve();
+      }, 50);
+    });
+  });
+});

--- a/app/tests/scene/system/cameraRig.test.ts
+++ b/app/tests/scene/system/cameraRig.test.ts
@@ -31,7 +31,6 @@ function _baseWorld() {
     getBuildingPickables: () => [] as THREE.Object3D[],
     getMaxBuildingHeight: () => 200,
     getTreeBoundsBySha: (_sha: string) => null as { x: number; y: number; z: number; height: number; radius: number } | null,
-    getGemDims: () => ({ width: 40, height: 40, depth: 40 }),
   };
 }
 
@@ -121,27 +120,6 @@ describe('cameraRig top-down focus', () => {
         expect(target.x).toBeCloseTo(s.x, 1);
         expect(target.y).toBeCloseTo(0, 1);
         expect(target.z).toBeCloseTo(s.y, 1);
-        const elev = elevationDeg(rig.camera.position, target);
-        expect(elev).toBeGreaterThan(75);
-        expect(elev).toBeLessThan(85);
-        resolve();
-      }
-      requestAnimationFrame(tick);
-    });
-  });
-
-  it('focusGem lands the camera at ~80° elevation on the gem position', () => {
-    const canvas = makeCanvas();
-    const rig = createCameraRig({ canvas, world: makeStubWorld() as any });
-    rig.update(16);
-    rig.focusGem();
-    return new Promise<void>((resolve) => {
-      let frames = 0;
-      function tick() {
-        if (frames++ < 60) { requestAnimationFrame(tick); return; }
-        const target = rig.controls.target;
-        expect(target.x).toBeCloseTo(0, 1);
-        expect(target.z).toBeCloseTo(0, 1);
         const elev = elevationDeg(rig.camera.position, target);
         expect(elev).toBeGreaterThan(75);
         expect(elev).toBeLessThan(85);

--- a/app/tests/scene/system/cameraRig.test.ts
+++ b/app/tests/scene/system/cameraRig.test.ts
@@ -12,25 +12,24 @@ function makeStubWorld(overrides: Partial<ReturnType<typeof _baseWorld>> = {}) {
 }
 
 function _baseWorld() {
-  const bbox = new THREE.Box3(
-    new THREE.Vector3(-500, 0, -500),
-    new THREE.Vector3(500, 200, 500),
-  );
+  const bbox = new THREE.Box3(new THREE.Vector3(-500, 0, -500), new THREE.Vector3(500, 200, 500));
   return {
     getBbox: () => bbox,
     getGemWorldPos: () => new THREE.Vector3(0, 0, 0),
-    getRootStreet: () => ({
-      x: 0,
-      y: 0,
-      width: 40,
-      length: 1000,
-      orientation: StreetAxis.X,
-      dir: null,
-    }) as unknown as Street,
+    getRootStreet: () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 40,
+        length: 1000,
+        orientation: StreetAxis.X,
+        dir: null,
+      }) as unknown as Street,
     onChange: () => () => {},
     getBuildingPickables: () => [] as THREE.Object3D[],
     getMaxBuildingHeight: () => 200,
-    getTreeBoundsBySha: (_sha: string) => null as { x: number; y: number; z: number; height: number; radius: number } | null,
+    getTreeBoundsBySha: (_sha: string) =>
+      null as { x: number; y: number; z: number; height: number; radius: number } | null,
   };
 }
 
@@ -115,7 +114,10 @@ describe('cameraRig top-down focus', () => {
     return new Promise<void>((resolve) => {
       let frames = 0;
       function tick() {
-        if (frames++ < 60) { requestAnimationFrame(tick); return; }
+        if (frames++ < 60) {
+          requestAnimationFrame(tick);
+          return;
+        }
         const target = rig.controls.target;
         expect(target.x).toBeCloseTo(s.x, 1);
         expect(target.y).toBeCloseTo(0, 1);
@@ -141,7 +143,10 @@ describe('cameraRig top-down focus', () => {
     return new Promise<void>((resolve) => {
       let frames = 0;
       function tick() {
-        if (frames++ < 60) { requestAnimationFrame(tick); return; }
+        if (frames++ < 60) {
+          requestAnimationFrame(tick);
+          return;
+        }
         const target = rig.controls.target;
         expect(target.x).toBeCloseTo(250, 1);
         expect(target.y).toBeCloseTo(50, 1);

--- a/app/tests/scene/trees/treeRendererCommitLookup.test.ts
+++ b/app/tests/scene/trees/treeRendererCommitLookup.test.ts
@@ -293,6 +293,37 @@ describe('Trees commit lookups', () => {
     expect(sNew.z * 10).toBeLessThan(sOld.z);
   });
 
+  it('getTreeBoundsBySha returns position + dims for a known sha', () => {
+    resetStores();
+    const commits = [commit(0), commit(1), commit(2)];
+    const placements = [placement(5, 0), placement(11, 1), placement(17, 2)];
+    const trees = createTreeRenderer(placements, commits);
+
+    const bounds = trees.getTreeBoundsBySha(commits[1].sha);
+    expect(bounds).not.toBeNull();
+    // Placement seed=11 lands the tree at (110, 110) in XZ.
+    expect(bounds!.x).toBeCloseTo(110, 3);
+    expect(bounds!.z).toBeCloseTo(110, 3);
+    expect(bounds!.y).toBe(0);
+    expect(bounds!.height).toBeGreaterThan(0);
+    expect(bounds!.radius).toBeGreaterThan(0);
+  });
+
+  it('getTreeBoundsBySha returns null for an unknown sha', () => {
+    resetStores();
+    const commits = [commit(0), commit(1)];
+    const placements = [placement(3, 0), placement(7, 1)];
+    const trees = createTreeRenderer(placements, commits);
+    expect(trees.getTreeBoundsBySha('f'.repeat(40))).toBeNull();
+  });
+
+  it('getTreeBoundsBySha returns null when commits is null', () => {
+    resetStores();
+    const placements = [placement(3, 0)];
+    const trees = createTreeRenderer(placements, null);
+    expect(trees.getTreeBoundsBySha('a'.repeat(40))).toBeNull();
+  });
+
   it('degenerate height range (min == max) does not produce NaN canopy matrices', () => {
     // When TREE_MIN_HEIGHT == TREE_MAX_HEIGHT, the heightRatio computation
     // would divide by zero without a clamp. Verify the renderer constructs

--- a/app/tests/views/panes/commitPane.test.ts
+++ b/app/tests/views/panes/commitPane.test.ts
@@ -411,8 +411,11 @@ describe('buildCommitPane', () => {
     const onFocus = vi.fn();
     const { pane, api } = buildCommitPane({ onFocus });
     api.setCommit(COMMIT, { remoteUrl: null });
-    const focusBtn = pane.querySelector('.pane-header .btn-icon[aria-label="Focus the camera on this commit (F)"]') as HTMLButtonElement | null
-      ?? pane.querySelector('.pane-header .btn-icon') as HTMLButtonElement | null;
+    const focusBtn =
+      (pane.querySelector(
+        '.pane-header .btn-icon[aria-label="Focus the camera on this commit (F)"]'
+      ) as HTMLButtonElement | null) ??
+      (pane.querySelector('.pane-header .btn-icon') as HTMLButtonElement | null);
     expect(focusBtn).not.toBeNull();
     focusBtn!.click();
     expect(onFocus).toHaveBeenCalledTimes(1);

--- a/app/tests/views/panes/commitPane.test.ts
+++ b/app/tests/views/panes/commitPane.test.ts
@@ -407,6 +407,27 @@ describe('buildCommitPane', () => {
     expect(err.textContent).toMatch(/failed/i);
   });
 
+  it('passes onFocus through to the pane header and fires with the current commit', () => {
+    const onFocus = vi.fn();
+    const { pane, api } = buildCommitPane({ onFocus });
+    api.setCommit(COMMIT, { remoteUrl: null });
+    const focusBtn = pane.querySelector('.pane-header .btn-icon[aria-label="Focus the camera on this commit (F)"]') as HTMLButtonElement | null
+      ?? pane.querySelector('.pane-header .btn-icon') as HTMLButtonElement | null;
+    expect(focusBtn).not.toBeNull();
+    focusBtn!.click();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(onFocus).toHaveBeenCalledWith(COMMIT);
+  });
+
+  it('focus button is disabled in the empty state', () => {
+    const onFocus = vi.fn();
+    const { pane, api } = buildCommitPane({ onFocus });
+    api.setCommit(null);
+    const focusBtn = pane.querySelector('.pane-header button') as HTMLButtonElement | null;
+    expect(focusBtn).not.toBeNull();
+    expect(focusBtn!.disabled).toBe(true);
+  });
+
   it('drops a late fetch result when the pane has moved to a different commit', async () => {
     // Fetch for the first commit hangs, then resolves AFTER the second
     // commit's render has replaced the body. The late result must

--- a/app/tests/views/panes/streetPane.test.ts
+++ b/app/tests/views/panes/streetPane.test.ts
@@ -95,8 +95,9 @@ describe('buildStreetPane', () => {
     const { pane, api } = buildStreetPane({ onFocus });
     const d = dir('lib', [f('x.ts', '.ts', 100)]);
     api.setDirectory(d);
-    const btn = pane.querySelector('.pane-header button[aria-label*="Focus"]') as HTMLButtonElement
-      ?? pane.querySelector('.pane-header button') as HTMLButtonElement;
+    const btn =
+      (pane.querySelector('.pane-header button[aria-label*="Focus"]') as HTMLButtonElement) ??
+      (pane.querySelector('.pane-header button') as HTMLButtonElement);
     btn!.click();
     expect(onFocus).toHaveBeenCalledTimes(1);
     expect(onFocus).toHaveBeenCalledWith(d);

--- a/app/tests/views/panes/streetPane.test.ts
+++ b/app/tests/views/panes/streetPane.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { buildStreetPane } from '@/views/panes/streetPane.js';
+import { NodeKind } from '@/types';
+import type { DirNode, FileNode } from '@/types';
+
+function resetDom() {
+  document.body.innerHTML = '';
+}
+
+function f(name: string, ext: string, size: number, lines = 0): FileNode {
+  return {
+    name,
+    type: NodeKind.File,
+    path: `src/${name}`,
+    fullPath: `/tmp/src/${name}`,
+    extension: ext,
+    size,
+    lines,
+    binary: false,
+    created: null,
+    modified: null,
+    git: null,
+  } as unknown as FileNode;
+}
+
+function dir(name: string, children: (FileNode | DirNode)[] = []): DirNode {
+  return {
+    name,
+    type: NodeKind.Directory,
+    path: name === '.' ? '.' : name,
+    fullPath: `/tmp/${name}`,
+    children,
+    children_file_count: children.filter((c) => c.type === NodeKind.File).length,
+    children_dir_count: children.filter((c) => c.type === NodeKind.Directory).length,
+    descendants_file_count: 0,
+    descendants_dir_count: 0,
+    descendants_size: 0,
+  } as unknown as DirNode;
+}
+
+describe('buildStreetPane', () => {
+  beforeEach(resetDom);
+
+  it('returns a .pane wrapper containing a pane header with title "Road"', () => {
+    const { pane } = buildStreetPane({});
+    expect(pane.classList.contains('pane')).toBe(true);
+    expect(pane.querySelector('.pane-header')).not.toBeNull();
+  });
+
+  it('renders an empty state when no directory is set', () => {
+    const { pane } = buildStreetPane({});
+    expect(pane.querySelector('.empty-state')).not.toBeNull();
+  });
+
+  it('setDirectory(d) renders direct + descendant counts and the path', () => {
+    const { pane, api } = buildStreetPane({});
+    const d = dir('src', [f('a.ts', '.ts', 100), f('b.md', '.md', 50)]);
+    d.descendants_file_count = 4;
+    d.descendants_dir_count = 1;
+    d.descendants_size = 1234;
+    d.children = [
+      f('a.ts', '.ts', 100),
+      f('b.md', '.md', 50),
+      dir('sub', [f('c.ts', '.ts', 80), f('d.json', '.json', 30)]),
+    ];
+
+    api.setDirectory(d);
+
+    const body = pane.querySelector('.pane-body, .street-body') as HTMLElement;
+    expect(body.textContent).toContain('src');
+    // Direct counts
+    expect(body.textContent).toMatch(/2.*files/i);
+    expect(body.textContent).toMatch(/1.*dirs?/i);
+    // Descendant counts
+    expect(body.textContent).toMatch(/4.*files/i);
+    expect(body.textContent).toContain('1.2 KB'); // 1234 bytes ≈ 1.2 KB
+  });
+
+  it('lists every extension in the descendant subtree sorted by count desc', () => {
+    const { pane, api } = buildStreetPane({});
+    const d = dir('src', [
+      f('a.ts', '.ts', 100),
+      f('b.ts', '.ts', 100),
+      f('c.ts', '.ts', 100),
+      f('readme.md', '.md', 50),
+      f('config.json', '.json', 30),
+    ]);
+    api.setDirectory(d);
+    const extRows = Array.from(pane.querySelectorAll('.street-ext-row')) as HTMLElement[];
+    expect(extRows.length).toBeGreaterThanOrEqual(3);
+    // First row is the most common extension (.ts with 3 files).
+    expect(extRows[0].textContent).toContain('.ts');
+    expect(extRows[0].textContent).toContain('3');
+  });
+
+  it('onFocus callback fires with the active directory when focus button clicked', () => {
+    const onFocus = vi.fn();
+    const { pane, api } = buildStreetPane({ onFocus });
+    const d = dir('lib', [f('x.ts', '.ts', 100)]);
+    api.setDirectory(d);
+    const btn = pane.querySelector('.pane-header button[aria-label*="Focus"]') as HTMLButtonElement
+      ?? pane.querySelector('.pane-header button') as HTMLButtonElement;
+    btn!.click();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(onFocus).toHaveBeenCalledWith(d);
+  });
+
+  it('setDirectory(null) returns to the empty state', () => {
+    const { pane, api } = buildStreetPane({});
+    api.setDirectory(dir('src', [f('a.ts', '.ts', 100)]));
+    api.setDirectory(null);
+    expect(pane.querySelector('.empty-state')).not.toBeNull();
+    expect(pane.querySelector('.street-ext-row')).toBeNull();
+  });
+});

--- a/app/tests/views/panes/streetPane.test.ts
+++ b/app/tests/views/panes/streetPane.test.ts
@@ -52,12 +52,11 @@ describe('buildStreetPane', () => {
     expect(pane.querySelector('.empty-state')).not.toBeNull();
   });
 
-  it('setDirectory(d) renders direct + descendant counts and the path', () => {
+  it('setDirectory(d) renders direct + descendant counts', () => {
     const { pane, api } = buildStreetPane({});
     const d = dir('src', [f('a.ts', '.ts', 100), f('b.md', '.md', 50)]);
     d.descendants_file_count = 4;
     d.descendants_dir_count = 1;
-    d.descendants_size = 1234;
     d.children = [
       f('a.ts', '.ts', 100),
       f('b.md', '.md', 50),
@@ -67,13 +66,11 @@ describe('buildStreetPane', () => {
     api.setDirectory(d);
 
     const body = pane.querySelector('.pane-body, .street-body') as HTMLElement;
-    expect(body.textContent).toContain('src');
     // Direct counts
     expect(body.textContent).toMatch(/2.*files/i);
     expect(body.textContent).toMatch(/1.*dirs?/i);
     // Descendant counts
     expect(body.textContent).toMatch(/4.*files/i);
-    expect(body.textContent).toContain('1.2 KB'); // 1234 bytes ≈ 1.2 KB
   });
 
   it('lists every extension in the descendant subtree sorted by count desc', () => {

--- a/app/tests/views/shell/appHeader.test.ts
+++ b/app/tests/views/shell/appHeader.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { initAppHeader } from '@/views/shell/appHeader.js';
+
+function resetDom() {
+  document.body.innerHTML = `
+    <header id="app-header-row">
+      <div id="app-title"></div>
+    </header>
+  `;
+}
+
+describe('initAppHeader commit selection', () => {
+  beforeEach(resetDom);
+
+  it('renders Commit <short-sha> · <author> with focus + copy buttons', () => {
+    const onFocus = vi.fn();
+    const header = initAppHeader({ rootLabel: 'demo', onFocus });
+    header.setSelection({
+      kind: 'commit',
+      sha: 'a1b2c3d4567890abcdef1234567890abcdef1234',
+      author: 'Alice Author',
+    });
+    const title = document.getElementById('app-title')!;
+    expect(title.textContent).toContain('Commit');
+    expect(title.textContent).toContain('a1b2c3d');
+    expect(title.textContent).toContain('Alice Author');
+    const focusBtn = title.querySelector('button[aria-label*="Focus" i]') as HTMLButtonElement;
+    expect(focusBtn).not.toBeNull();
+    focusBtn.click();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the title when null is passed', () => {
+    const header = initAppHeader({ rootLabel: 'demo' });
+    header.setSelection({
+      kind: 'commit',
+      sha: 'a1b2c3d4567890abcdef1234567890abcdef1234',
+      author: 'Alice',
+    });
+    header.setSelection(null);
+    expect(document.getElementById('app-title')!.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- **Unified top-down focus framing.** F-key, dblclick, and pane focus buttons all snap the camera to a single near-overhead pose (~80° elevation, bounding-sphere fit) for buildings, roads, and trees. One shared `_focusTopDown(center, fitW, fitD, fitH, ratio)` helper replaces the door-facing sightline raycaster and the per-target altitude math.
- **Tree (commit) focus support.** New `rig.focusTree(sha)` backed by a new `world.getTreeBoundsBySha(sha)` accessor. F-key and dblclick on a commit-tree now reach it.
- **Right sidebar for road selections.** New `streetPane` opens when a directory is selected, showing direct + descendant child counts and a sorted by-extension breakdown. Header gets a Focus button (frames the road top-down) and a Close button. Live-update polls refresh the pane via `world.onChange`. Heavy DOM mutation is deferred with `setTimeout(0)` so it doesn't run inside the pointer event that triggered selection.
- **Commit pane focus button.** Mirrors the file-preview pane's pattern. Coordinator wires it to `rig.focusTree(c.sha)`.
- **Sitewide header commit branch.** `HeaderSelection` becomes a discriminated union (`file | dir | commit`). Commit selection renders `[focus] Commit <short-sha> · <author> [copy-sha]`.
- **5-tier selection-fade cascade (bidirectional).** Tier is now the symmetric directory-tree distance to the dirTarget (hops up to LCA plus hops back down). Default covers selected/hovered/idle; L1 = same dir; L2 = 1 hop in either direction; L3 = 2 hops; L4 = 3+. Going UP the tree (parent's other branches) is weighted the same as going DOWN. Selected buildings now read `DEFAULT_*` from config (previously hardcoded) so the Default knob actually drives the selected look. Config keys renamed: `NEAR_*` → `LEVEL1_*`, `FAR_*` → `LEVEL2_*`; new `LEVEL3_*` and `LEVEL4_*` added. All five tiers configurable under the existing \"Selection fade\" Controls subgroup.
- **Stability fixes along the way:**
  - `_applyDisplayLabel` now runs before the second `applyManifest` on cold-load (the tree pane and 3D label briefly showed the cache hash instead of the friendly repo name).
  - `makeExtensionBadge` passes `''` not `null` to `getHue` for files with no extension (was crashing the streetPane mid-render whenever a README/Makefile-style file was in the subtree).
  - Canvas resize wrapped in rAF defensively.

## Test plan

- [x] Unit tests: 1944 / 1944 passing, build clean, typecheck clean, prettier clean.
- [ ] F on a building, road, and tree all snap to the new top-down pose.
- [ ] Dblclick on a road / tree focuses; dblclick on the gem still resets.
- [ ] Select a road → streetPane opens with correct counts + by-extension list.
- [ ] Select a tree → sitewide header shows \`Commit <sha> · <author>\` with a working copy button.
- [ ] Open Controls → Selection fade → all 5 tier subgroups present and dialing each updates the city.
- [ ] Canvas hover / click still works after multiple road selections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)