### PR TITLE
Linux-scale rendering: scan UTF-8 decode + orbit-ring lazy pool

### DIFF
--- a/api/scan.py
+++ b/api/scan.py
@@ -257,6 +257,13 @@ def _collect_git_dates_windowed(
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
+            # Old commits (e.g. torvalds/linux) carry Latin-1 author/subject
+            # bytes that aren't valid UTF-8. Default strict decoding raises
+            # mid-stream, exits this loop, and the finally below then
+            # deadlocks on proc.wait() because git still has output to
+            # write. Replace decode errors so the walk completes.
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
         )
     except FileNotFoundError:
@@ -274,8 +281,10 @@ def _collect_git_dates_windowed(
     heartbeat_every = 25_000
     assert proc.stdout is not None
     # try/finally so an exception escaping the parse loop (MemoryError,
-    # KeyboardInterrupt, decode error) doesn't leave the git subprocess
-    # running as a zombie.
+    # KeyboardInterrupt, etc.) doesn't leave the git subprocess running
+    # as a zombie. Must kill before wait — if git is mid-write with a
+    # full stdout pipe (we stopped reading), wait() alone deadlocks
+    # because git can't exit until the pipe drains.
     try:
         for line in proc.stdout:
             line = line.rstrip("\n")
@@ -332,6 +341,8 @@ def _collect_git_dates_windowed(
                 "subject": current_subject,
             })
     finally:
+        if proc.poll() is None:
+            proc.kill()
         proc.wait()
     _log(
         f"  done — {commits:,} commits in window, "

--- a/api/tests/test_scan.py
+++ b/api/tests/test_scan.py
@@ -680,6 +680,140 @@ class GitMetadataParallelTests(_CacheRedirectMixin, unittest.TestCase):
                 f"clean merge files count should be >= 1; got {commits[-1]['files']}")
 
 
+class GitLogRobustnessTests(_CacheRedirectMixin, unittest.TestCase):
+    """The git-log streamer must survive two failure modes seen on real
+    repos like torvalds/linux:
+
+      A. Commit metadata that isn't valid UTF-8 (old Linux-kernel commits
+         have raw Latin-1 bytes in author names — e.g. byte 0xe9 for 'é').
+         Strict UTF-8 decoding raises UnicodeDecodeError mid-stream.
+      B. Any exception escaping the parse loop must not deadlock the
+         finally cleanup. ``proc.wait()`` on a child whose stdout pipe
+         is full (we stopped reading) blocks forever — git can't exit
+         until the pipe drains, and python won't drain because it's
+         in wait(). Cleanup must kill the child before waiting.
+    """
+
+    def test_non_utf8_author_bytes_do_not_crash(self):
+        """Failure mode A: a commit with non-UTF-8 author metadata must
+        parse without raising. Bytes are replaced, not crashed-on."""
+        from api.scan import _collect_git_metadata
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            _init_repo(td_path)
+            (td_path / "f.txt").write_text("x\n")
+            subprocess.run(["git", "-C", td, "add", "-A"], check=True)
+            # Build the commit object by hand so a raw 0xe9 byte
+            # (Latin-1 'é', invalid standalone UTF-8) survives into the
+            # author line. Passing it via GIT_AUTHOR_NAME doesn't work —
+            # git silently re-encodes env strings to valid UTF-8.
+            tree_sha = subprocess.run(
+                ["git", "-C", td, "write-tree"],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+            commit_body = (
+                f"tree {tree_sha}\n".encode("ascii")
+                + b"author Fran\xe9ois <f@example.com> 1577836800 +0000\n"
+                + b"committer Fran\xe9ois <f@example.com> 1577836800 +0000\n"
+                + b"\nmsg\n"
+            )
+            sha = subprocess.run(
+                ["git", "-C", td, "hash-object", "-t", "commit",
+                 "-w", "--stdin"],
+                input=commit_body, capture_output=True, check=True,
+            ).stdout.decode().strip()
+            subprocess.run(
+                ["git", "-C", td, "update-ref", "HEAD", sha], check=True,
+            )
+
+            # Run in a thread with a deadline so a regression that
+            # deadlocks the finally clause fails loudly instead of
+            # hanging the pytest worker forever.
+            import threading
+            result: dict[str, object] = {}
+            def go() -> None:
+                try:
+                    _c, _m, _t, commits = _collect_git_metadata(
+                        td_path, use_cache=False,
+                    )
+                    result["commits"] = commits
+                except BaseException as e:  # pragma: no cover - defensive
+                    result["error"] = e
+            t = threading.Thread(target=go, daemon=True)
+            t.start()
+            t.join(timeout=30)
+            self.assertFalse(
+                t.is_alive(),
+                "scan deadlocked on non-UTF-8 metadata (likely "
+                "finally: proc.wait() with a full stdout pipe)",
+            )
+            self.assertNotIn(
+                "error", result,
+                f"scan raised on non-UTF-8 metadata: {result.get('error')!r}",
+            )
+            commits = result["commits"]
+            assert isinstance(commits, list)
+            self.assertEqual(len(commits), 1)
+            author = commits[0]["author"]
+            self.assertIn("Fran", author)
+            self.assertIn("ois", author)
+
+    def test_parse_loop_exception_kills_subprocess_before_waiting(self):
+        """Failure mode B: when the parse loop raises, cleanup must
+        ``proc.kill()`` before ``proc.wait()``. Otherwise wait() blocks
+        forever on any git child that still has buffered output."""
+        from unittest.mock import patch
+        from api.scan import _collect_git_dates_windowed
+
+        class _FakeStdout:
+            """Yields one valid line, then raises — mimics the moment
+            TextIOWrapper hits an invalid byte mid-stream."""
+            def __init__(self) -> None:
+                self._emitted = False
+            def __iter__(self): return self
+            def __next__(self) -> str:
+                if not self._emitted:
+                    self._emitted = True
+                    return (
+                        "COMMIT:2020-01-01T00:00:00+00:00\t"
+                        + "a" * 40
+                        + "\tAuthor\tsubj\n"
+                    )
+                raise UnicodeDecodeError(
+                    "utf-8", b"\xe9", 0, 1, "simulated mid-stream failure",
+                )
+
+        class _FakeProc:
+            """``wait()`` asserts ``kill()`` ran first — the real bug is
+            that wait() on an unread-pipe child deadlocks, and the only
+            way to avoid that is to kill the child first."""
+            def __init__(self) -> None:
+                self.stdout = _FakeStdout()
+                self.killed = False
+                self.waited = False
+                self.returncode: int | None = None
+            def poll(self) -> int | None:
+                return self.returncode
+            def kill(self) -> None:
+                self.killed = True
+                self.returncode = -9
+            def wait(self, timeout: float | None = None) -> int:
+                if not self.killed:
+                    raise AssertionError(
+                        "proc.wait() called without proc.kill() first — "
+                        "this deadlocks on real git when stdout pipe is full"
+                    )
+                self.waited = True
+                return self.returncode or 0
+
+        fake = _FakeProc()
+        with patch("api.scan.subprocess.Popen", return_value=fake):
+            with self.assertRaises(UnicodeDecodeError):
+                _collect_git_dates_windowed(Path("/tmp/does-not-matter"))
+        self.assertTrue(fake.killed, "cleanup must call proc.kill()")
+        self.assertTrue(fake.waited, "cleanup must call proc.wait() after kill")
+
+
 class GitHistoryCacheTests(_CacheRedirectMixin, unittest.TestCase):
     """When HEAD hasn't moved, _collect_git_metadata should hit the
     persistent cache and skip the two `git log` walks entirely."""

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -244,6 +244,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -292,6 +293,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -302,31 +304,6 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -965,6 +942,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1043,6 +1021,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1234,6 +1213,7 @@
       "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.7",
@@ -1378,6 +1358,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1532,6 +1513,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^7.0.0",
         "prebuild-install": "^7.1.3"
@@ -1724,6 +1706,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2251,6 +2234,7 @@
       "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.5",
         "@asamuzakjp/dom-selector": "^7.0.6",
@@ -2927,6 +2911,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3495,6 +3480,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3567,6 +3553,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3645,6 +3632,7 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",

--- a/app/src/config/components/fireflies.ts
+++ b/app/src/config/components/fireflies.ts
@@ -5,8 +5,9 @@
 // modulation (additive output color × (1 + pulseAmp * sin(...))).
 // v4 adds emission (HDR bloom), flicker (high-frequency brightness noise),
 // and per-author commit-count scaling (always on; tune spread via SCALE_MIN/MAX).
-// v5 adds orbit-ring controls (ORBIT_RING_ENABLED, ORBIT_RING_COLOR,
-// ORBIT_RING_OPACITY) and decouples orbit radius from per-author scale.
+// v5 adds orbit-ring controls (ORBIT_RING_ENABLED, ORBIT_RING_HOVER_COLOR,
+// ORBIT_RING_SELECTED_COLOR, ORBIT_RING_THICKNESS) for the lazy ring pool;
+// rings render only for the hovered/selected commit, no rest-state color.
 // v6 adds hover/selected highlight colors for orbit rings.
 
 import { map } from 'nanostores';
@@ -34,10 +35,6 @@ export interface FirefliesConfig {
   SCALE_MAX: number;
   /** Show / hide the subtle orbit ring around each tree. */
   ORBIT_RING_ENABLED: boolean;
-  /** Orbit ring color, hex string (e.g. '#ffffff'). */
-  ORBIT_RING_COLOR: string;
-  /** Orbit ring opacity, 0..1. */
-  ORBIT_RING_OPACITY: number;
   /** Tube radius of the orbit ring in world units (constant across rings). */
   ORBIT_RING_THICKNESS: number;
   /** Orbit ring color when the corresponding tree is hovered, hex string. */
@@ -58,8 +55,6 @@ export const FIREFLIES = map<FirefliesConfig>({
   SCALE_MIN: 0.5,
   SCALE_MAX: 2.5,
   ORBIT_RING_ENABLED: true,
-  ORBIT_RING_COLOR: '#808080',
-  ORBIT_RING_OPACITY: 0.05,
   ORBIT_RING_THICKNESS: 0.15,
   ORBIT_RING_HOVER_COLOR: '#c8c8c8',
   ORBIT_RING_SELECTED_COLOR: '#ffd700',

--- a/app/src/config/components/fireflies.ts
+++ b/app/src/config/components/fireflies.ts
@@ -5,10 +5,12 @@
 // modulation (additive output color × (1 + pulseAmp * sin(...))).
 // v4 adds emission (HDR bloom), flicker (high-frequency brightness noise),
 // and per-author commit-count scaling (always on; tune spread via SCALE_MIN/MAX).
-// v5 adds orbit-ring controls (ORBIT_RING_ENABLED, ORBIT_RING_HOVER_COLOR,
-// ORBIT_RING_SELECTED_COLOR, ORBIT_RING_THICKNESS) for the lazy ring pool;
-// rings render only for the hovered/selected commit, no rest-state color.
+// v5 adds orbit-ring controls (ORBIT_RING_ENABLED, ORBIT_RING_COLOR,
+// ORBIT_RING_OPACITY) and decouples orbit radius from per-author scale.
 // v6 adds hover/selected highlight colors for orbit rings.
+// v7 replaces the merged-mesh ring with a lazy 2-slot pool — rings
+// render only for the hovered/selected commit, so ORBIT_RING_COLOR
+// and ORBIT_RING_OPACITY (the rest-state color/alpha) were dropped.
 
 import { map } from 'nanostores';
 

--- a/app/src/scene/components/fireflies/orbitRings.ts
+++ b/app/src/scene/components/fireflies/orbitRings.ts
@@ -140,8 +140,7 @@ export function createOrbitRings(orbs: FireflyPlacement[]): OrbitRings {
 
   /** The hover mesh should be visible iff hover is set AND distinct from selected. */
   function reconcileHoverMesh(): void {
-    const shouldShow =
-      hover.commitIndex !== null && hover.commitIndex !== selected.commitIndex;
+    const shouldShow = hover.commitIndex !== null && hover.commitIndex !== selected.commitIndex;
 
     if (!shouldShow) {
       disposeSlotMesh(hover);

--- a/app/src/scene/components/fireflies/orbitRings.ts
+++ b/app/src/scene/components/fireflies/orbitRings.ts
@@ -1,15 +1,15 @@
-// scene/fireflies/orbitRings.ts — subtle ring around each tree at the
-// height + tilt of its firefly orbit.
+// scene/fireflies/orbitRings.ts — selection/hover ring around the tree
+// for the currently hovered + currently selected commits.
 //
-// All rings are merged into ONE BufferGeometry / ONE Mesh (one draw call)
-// with a per-vertex RGBA color attribute. Hover and select states write
-// directly into the colour buffer for the affected ring's vertex range —
-// no material swap, no extra draw calls.
+// New shape: two slots (hover + selected). Each slot owns one Mesh
+// built lazily when its commitIndex is non-null AND visible per the
+// reconciliation rule. Materials are allocated once per slot; only
+// geometry is rebuilt on commit-change.
 //
-//   setHoveredCommit(idx):  update the colour attribute for the hovered ring.
-//   setSelectedCommit(idx): update the colour attribute for the selected ring.
-//   refresh():  rewrite all vertex ranges with the current config colours.
-//   dispose():  clean up the merged geometry + material.
+//   setHoveredCommit(idx):  update hover.commitIndex, reconcile.
+//   setSelectedCommit(idx): update selected slot (and reconcile hover).
+//   refresh():  reapply config colors to active slot materials.
+//   dispose():  drop both slot geometries + materials.
 
 import * as THREE from 'three';
 import { FIREFLIES } from '@/config/components/fireflies.js';
@@ -32,7 +32,6 @@ class TiltedCirclePath extends THREE.Curve<THREE.Vector3> {
     const a = t * Math.PI * 2;
     const x = this.radius * Math.cos(a);
     const zRaw = this.radius * Math.sin(a);
-    // Per-orb tilt around X (matches firefly vertex shader).
     const ct = Math.cos(this.tilt);
     const st = Math.sin(this.tilt);
     const y = -st * zRaw;
@@ -41,23 +40,40 @@ class TiltedCirclePath extends THREE.Curve<THREE.Vector3> {
   }
 }
 
-interface RingRange {
-  /** First vertex index in the merged colour array. */
-  vertexStart: number;
-  /** Number of vertices for this ring. */
-  vertexCount: number;
-}
-
 export interface OrbitRings {
   group: THREE.Group;
   /** Highlight the ring for the given commitIndex as hovered. Pass null to clear. */
   setHoveredCommit(commitIndex: number | null): void;
   /** Highlight the ring for the given commitIndex as selected. Pass null to clear. */
   setSelectedCommit(commitIndex: number | null): void;
+  /**
+   * Reapply current config colors to active slot materials. Note:
+   * ORBIT_RING_THICKNESS is baked into geometry, so a thickness change
+   * only takes effect on the next slot rebuild (i.e. next hover/select
+   * change), not on this refresh() call.
+   */
   refresh(): void;
   /** No-op for tube-based rings; kept for interface symmetry. */
   onResize(width: number, height: number): void;
   dispose(): void;
+}
+
+interface Slot {
+  /** Logical state: what commit this slot tracks (independent of visibility). */
+  commitIndex: number | null;
+  /** The currently-rendered mesh, or null if the slot has no visible ring. */
+  mesh: THREE.Mesh | null;
+  /** Pre-allocated material for this slot. Color is updated on refresh(). */
+  material: THREE.MeshBasicMaterial;
+}
+
+function buildTubeGeometry(orb: FireflyPlacement, thickness: number): THREE.TubeGeometry {
+  const path = new TiltedCirclePath(
+    new THREE.Vector3(orb.treeX, orb.height, orb.treeZ),
+    orb.orbitRadius,
+    orb.orbitTilt
+  );
+  return new THREE.TubeGeometry(path, TUBULAR_SEGMENTS, thickness, RADIAL_SEGMENTS, true);
 }
 
 export function createOrbitRings(orbs: FireflyPlacement[]): OrbitRings {
@@ -77,195 +93,111 @@ export function createOrbitRings(orbs: FireflyPlacement[]): OrbitRings {
     };
   }
 
-  // Build each per-orb TubeGeometry, then merge their position/normal/index
-  // attributes into a single BufferGeometry. Track per-ring vertex ranges.
-  const rangeByCommit = new Map<number, RingRange>();
-  const positionArrays: Float32Array[] = [];
-  const normalArrays: Float32Array[] = [];
-  const indexArrays: Uint32Array[] = [];
-  let totalVerts = 0;
-  let totalIndices = 0;
-  const perGeometries: THREE.TubeGeometry[] = [];
-
-  for (let i = 0; i < orbs.length; i++) {
-    const o = orbs[i];
-    const path = new TiltedCirclePath(
-      new THREE.Vector3(o.treeX, o.height, o.treeZ),
-      o.orbitRadius,
-      o.orbitTilt
-    );
-    const tube = new THREE.TubeGeometry(
-      path,
-      TUBULAR_SEGMENTS,
-      cfg.ORBIT_RING_THICKNESS,
-      RADIAL_SEGMENTS,
-      true // closed
-    );
-    perGeometries.push(tube);
-
-    const posAttr = tube.getAttribute('position');
-    const nrmAttr = tube.getAttribute('normal');
-    const idxAttr = tube.getIndex();
-    if (!posAttr || !nrmAttr || !idxAttr) continue;
-    const vertCount = posAttr.count;
-    const indCount = idxAttr.count;
-
-    const posCopy = new Float32Array(posAttr.array as ArrayLike<number>).slice();
-    const nrmCopy = new Float32Array(nrmAttr.array as ArrayLike<number>).slice();
-    const idxCopy = new Uint32Array(indCount);
-    const srcIdx = idxAttr.array as ArrayLike<number>;
-    for (let k = 0; k < indCount; k++) idxCopy[k] = (srcIdx[k] as number) + totalVerts;
-
-    positionArrays.push(posCopy);
-    normalArrays.push(nrmCopy);
-    indexArrays.push(idxCopy);
-
-    rangeByCommit.set(o.commitIndex, { vertexStart: totalVerts, vertexCount: vertCount });
-    totalVerts += vertCount;
-    totalIndices += indCount;
+  // Build the placement lookup once. Pure pointer work — no geometry.
+  const placementByCommit = new Map<number, FireflyPlacement>();
+  for (const orb of orbs) {
+    placementByCommit.set(orb.commitIndex, orb);
   }
 
-  // Allocate combined buffers.
-  const combinedPos = new Float32Array(totalVerts * 3);
-  const combinedNrm = new Float32Array(totalVerts * 3);
-  const combinedIdx = new Uint32Array(totalIndices);
-  const combinedColor = new Float32Array(totalVerts * 4);
-  let vOffset = 0;
-  let iOffset = 0;
-  for (let i = 0; i < positionArrays.length; i++) {
-    combinedPos.set(positionArrays[i], vOffset * 3);
-    combinedNrm.set(normalArrays[i], vOffset * 3);
-    combinedIdx.set(indexArrays[i], iOffset);
-    vOffset += positionArrays[i].length / 3;
-    iOffset += indexArrays[i].length;
+  function makeSlotMaterial(color: string): THREE.MeshBasicMaterial {
+    return new THREE.MeshBasicMaterial({
+      color,
+      // Match the firefly orbs' transparent pass; depthWrite: false keeps
+      // the ring from punching depth into the trees behind it.
+      transparent: true,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      toneMapped: false,
+    });
   }
 
-  // Fill the colour attribute with the default RGBA for every vertex.
-  const defaultColor = new THREE.Color(cfg.ORBIT_RING_COLOR);
-  for (let v = 0; v < totalVerts; v++) {
-    combinedColor[v * 4 + 0] = defaultColor.r;
-    combinedColor[v * 4 + 1] = defaultColor.g;
-    combinedColor[v * 4 + 2] = defaultColor.b;
-    combinedColor[v * 4 + 3] = cfg.ORBIT_RING_OPACITY;
-  }
+  const hover: Slot = {
+    commitIndex: null,
+    mesh: null,
+    material: makeSlotMaterial(cfg.ORBIT_RING_HOVER_COLOR),
+  };
+  const selected: Slot = {
+    commitIndex: null,
+    mesh: null,
+    material: makeSlotMaterial(cfg.ORBIT_RING_SELECTED_COLOR),
+  };
 
-  const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute('position', new THREE.BufferAttribute(combinedPos, 3));
-  geometry.setAttribute('normal', new THREE.BufferAttribute(combinedNrm, 3));
-  const colorAttr = new THREE.BufferAttribute(combinedColor, 4);
-  colorAttr.setUsage(THREE.DynamicDrawUsage);
-  geometry.setAttribute('color', colorAttr);
-  geometry.setIndex(new THREE.BufferAttribute(combinedIdx, 1));
-
-  // Free intermediate per-tube geometries — their data is now in combined arrays.
-  for (const g of perGeometries) g.dispose();
-
-  const material = new THREE.MeshBasicMaterial({
-    vertexColors: true,
-    transparent: true,
-    depthWrite: false,
-    side: THREE.DoubleSide,
-    toneMapped: false,
-    // Per-vertex alpha is carried in the colour attribute (itemSize 4).
-    // The material opacity is fixed at 1 so the alpha channel from the
-    // colour buffer is used directly by the renderer.
-    opacity: 1.0,
-  });
-
-  const mesh = new THREE.Mesh(geometry, material);
-  mesh.frustumCulled = false;
-  mesh.name = 'firefly-orbit-rings-merged';
-  group.add(mesh);
-
-  // Track hover / selected commit indices for refresh() and state transitions.
-  let currentHoveredCommit: number | null = null;
-  let currentSelectedCommit: number | null = null;
-
-  function writeRangeRGBA(range: RingRange, r: number, g: number, b: number, a: number): void {
-    for (let v = 0; v < range.vertexCount; v++) {
-      const i = (range.vertexStart + v) * 4;
-      combinedColor[i + 0] = r;
-      combinedColor[i + 1] = g;
-      combinedColor[i + 2] = b;
-      combinedColor[i + 3] = a;
+  function disposeSlotMesh(slot: Slot): void {
+    if (slot.mesh) {
+      group.remove(slot.mesh);
+      slot.mesh.geometry.dispose();
+      slot.mesh = null;
     }
-    colorAttr.needsUpdate = true;
   }
 
-  function applyDefaultTo(range: RingRange): void {
-    const c = new THREE.Color(FIREFLIES.get().ORBIT_RING_COLOR);
-    writeRangeRGBA(range, c.r, c.g, c.b, FIREFLIES.get().ORBIT_RING_OPACITY);
+  function buildSlotMesh(slot: Slot, orb: FireflyPlacement): void {
+    const geom = buildTubeGeometry(orb, FIREFLIES.get().ORBIT_RING_THICKNESS);
+    const mesh = new THREE.Mesh(geom, slot.material);
+    mesh.frustumCulled = false;
+    slot.mesh = mesh;
+    group.add(mesh);
   }
 
-  function applyHoverTo(range: RingRange): void {
-    const c = new THREE.Color(FIREFLIES.get().ORBIT_RING_HOVER_COLOR);
-    writeRangeRGBA(range, c.r, c.g, c.b, 1.0);
+  /** The hover mesh should be visible iff hover is set AND distinct from selected. */
+  function reconcileHoverMesh(): void {
+    const shouldShow =
+      hover.commitIndex !== null && hover.commitIndex !== selected.commitIndex;
+
+    if (!shouldShow) {
+      disposeSlotMesh(hover);
+      return;
+    }
+
+    // hover.commitIndex is non-null per shouldShow.
+    const orb = placementByCommit.get(hover.commitIndex);
+    if (!orb) {
+      disposeSlotMesh(hover);
+      return;
+    }
+    disposeSlotMesh(hover);
+    buildSlotMesh(hover, orb);
   }
 
-  function applySelectedTo(range: RingRange): void {
-    const c = new THREE.Color(FIREFLIES.get().ORBIT_RING_SELECTED_COLOR);
-    writeRangeRGBA(range, c.r, c.g, c.b, 1.0);
+  function setSelectedSlot(idx: number | null): void {
+    if (selected.commitIndex === idx) return;
+    selected.commitIndex = idx;
+    disposeSlotMesh(selected);
+    if (idx === null) return;
+    const orb = placementByCommit.get(idx);
+    if (!orb) return;
+    buildSlotMesh(selected, orb);
   }
 
   return {
     group,
 
     setHoveredCommit(commitIndex: number | null) {
-      // Restore previous hover (if not selected).
-      if (currentHoveredCommit !== null && currentHoveredCommit !== commitIndex) {
-        const prevRange = rangeByCommit.get(currentHoveredCommit);
-        if (prevRange && currentHoveredCommit !== currentSelectedCommit) {
-          applyDefaultTo(prevRange);
-        }
-      }
-      currentHoveredCommit = commitIndex;
-      if (commitIndex !== null && commitIndex !== currentSelectedCommit) {
-        const range = rangeByCommit.get(commitIndex);
-        if (range) applyHoverTo(range);
-      }
+      if (hover.commitIndex === commitIndex) return;
+      hover.commitIndex = commitIndex;
+      reconcileHoverMesh();
     },
 
     setSelectedCommit(commitIndex: number | null) {
-      if (currentSelectedCommit !== null && currentSelectedCommit !== commitIndex) {
-        const prevRange = rangeByCommit.get(currentSelectedCommit);
-        if (prevRange) {
-          if (currentSelectedCommit === currentHoveredCommit) {
-            applyHoverTo(prevRange);
-          } else {
-            applyDefaultTo(prevRange);
-          }
-        }
-      }
-      currentSelectedCommit = commitIndex;
-      if (commitIndex !== null) {
-        const range = rangeByCommit.get(commitIndex);
-        if (range) applySelectedTo(range);
-      }
+      setSelectedSlot(commitIndex);
+      reconcileHoverMesh();
     },
 
     refresh() {
       const next = FIREFLIES.get();
       group.visible = next.ORBIT_RING_ENABLED;
-      // Rewrite ALL ranges with the current default colour/opacity, then
-      // re-apply hover + selected so they keep their highlight colours.
-      for (const [commit, range] of rangeByCommit.entries()) {
-        if (commit === currentSelectedCommit) {
-          applySelectedTo(range);
-        } else if (commit === currentHoveredCommit) {
-          applyHoverTo(range);
-        } else {
-          applyDefaultTo(range);
-        }
-      }
+      hover.material.color.set(next.ORBIT_RING_HOVER_COLOR);
+      selected.material.color.set(next.ORBIT_RING_SELECTED_COLOR);
+      hover.material.needsUpdate = true;
+      selected.material.needsUpdate = true;
     },
 
-    onResize() {
-      // Tube-based rings have no screen-space uniforms; no-op.
-    },
+    onResize() {},
 
     dispose() {
-      geometry.dispose();
-      material.dispose();
+      disposeSlotMesh(hover);
+      disposeSlotMesh(selected);
+      hover.material.dispose();
+      selected.material.dispose();
       group.clear();
     },
   };

--- a/app/src/store/configCommitReactions.ts
+++ b/app/src/store/configCommitReactions.ts
@@ -328,9 +328,9 @@ export function attachCommitReactions({ world, applyTheme }: CommitReactionsOpts
   // (drops the merged mesh entirely), so toggling it also needs a full rebuild.
   // ORBIT_RING_THICKNESS bakes into TubeGeometry tube radius — refresh()
   // only rewrites RGBA, so thickness changes require regenerating geometry.
-  // The remaining keys (animation, brightness, ORBIT_RING_COLOR,
-  // ORBIT_RING_OPACITY) fall through to the materialOnlyStores subscription
-  // above and are hot-applied via fireflies.refresh() → rings.refresh().
+  // The remaining keys (animation, brightness) fall through to the
+  // materialOnlyStores subscription above and are hot-applied via
+  // fireflies.refresh() → rings.refresh().
   unsubs.push(
     listenKeys(
       FIREFLIES,

--- a/app/src/store/configCommitReactions.ts
+++ b/app/src/store/configCommitReactions.ts
@@ -324,10 +324,11 @@ export function attachCommitReactions({ world, applyTheme }: CommitReactionsOpts
   );
   // FIREFLIES structural keys: ENABLED gates orb creation at createFireflies()
   // call time; SCALE_MIN/MAX bake into per-instance data;
-  // ORBIT_RING_ENABLED takes the empty-stub path in createOrbitRings when false
-  // (drops the merged mesh entirely), so toggling it also needs a full rebuild.
+  // ORBIT_RING_ENABLED takes the no-op interface path in createOrbitRings
+  // when false, so toggling it also needs a full rebuild.
   // ORBIT_RING_THICKNESS bakes into TubeGeometry tube radius — refresh()
-  // only rewrites RGBA, so thickness changes require regenerating geometry.
+  // only updates material colors, so thickness changes require regenerating
+  // the geometry on the next hover/select swap.
   // The remaining keys (animation, brightness) fall through to the
   // materialOnlyStores subscription above and are hot-applied via
   // fireflies.refresh() → rings.refresh().

--- a/app/src/views/panes/controlsPane.ts
+++ b/app/src/views/panes/controlsPane.ts
@@ -611,12 +611,6 @@ function _buildFirefliesSection(): HTMLElement {
       _toggle('Show orbit ring', FIREFLIES, 'ORBIT_RING_ENABLED', {
         tip: "Draws a subtle ring around each tree showing the firefly's orbital path.",
       }),
-      _color('Ring color', FIREFLIES, 'ORBIT_RING_COLOR', {
-        tip: 'Hex color of the orbit ring.',
-      }),
-      _slider('Ring opacity', FIREFLIES, 'ORBIT_RING_OPACITY', 0, 1, 0.05, {
-        tip: '0 = invisible, 1 = fully opaque.',
-      }),
       _slider('Ring thickness', FIREFLIES, 'ORBIT_RING_THICKNESS', 0.02, 0.5, 0.01, {
         tip: 'Tube radius of the orbit ring in world units. Rebuilds geometry on change.',
       }),

--- a/app/tests/scene/fireflies/fireflies.test.ts
+++ b/app/tests/scene/fireflies/fireflies.test.ts
@@ -11,36 +11,32 @@ const COMMITS: CommitEntry[] = [
 
 const PLACEMENTS: TreePlacement[] = [{ x: 0, y: 0, commitIndex: 0, seed: 0 } as TreePlacement];
 
-/** Read the RGBA of vertex 0 from the merged ring mesh's colour attribute. */
-function getRingVertex0RGBA(ringGroup: THREE.Object3D): {
-  r: number;
-  g: number;
-  b: number;
-  a: number;
-} {
-  const ringMesh = ringGroup.children[0] as THREE.Mesh;
-  const colorAttr = ringMesh.geometry.getAttribute('color') as THREE.BufferAttribute;
-  return {
-    r: colorAttr.getX(0),
-    g: colorAttr.getY(0),
-    b: colorAttr.getZ(0),
-    a: colorAttr.getW(0),
-  };
+function ringMeshes(f: ReturnType<typeof createFireflies>): THREE.Mesh[] {
+  const ringGroup = f.group.children.find((c) => c.name === 'firefly-orbit-rings');
+  if (!ringGroup) return [];
+  return ringGroup.children.filter(
+    (c): c is THREE.Mesh => (c as THREE.Mesh).isMesh === true
+  );
+}
+
+function meshColor(mesh: THREE.Mesh): THREE.Color {
+  return (mesh.material as THREE.MeshBasicMaterial).color;
 }
 
 describe('createFireflies', () => {
-  it('returns a group containing one InstancedMesh (orbs) and one Mesh (rings) when commits is non-empty', () => {
+  it('returns a group containing one InstancedMesh (orbs) and an empty ring group when commits is non-empty', () => {
     const f = createFireflies(PLACEMENTS, COMMITS);
     expect(f.group).toBeInstanceOf(THREE.Group);
     // The parent group has two child Groups (rings + renderer).
-    // Rings group contains exactly ONE merged Mesh; renderer group contains one InstancedMesh.
+    // The ring group is lazy: it starts empty and only spawns meshes on
+    // hover/select. The renderer group contains one InstancedMesh.
     const allDescendants = f.group.children.flatMap((c) => c.children);
     const instancedMeshes = allDescendants.filter((c) => c instanceof THREE.InstancedMesh);
     const tubeMeshes = allDescendants.filter(
       (c) => c instanceof THREE.Mesh && !(c instanceof THREE.InstancedMesh)
     );
     expect(instancedMeshes.length).toBe(1);
-    expect(tubeMeshes.length).toBe(1);
+    expect(tubeMeshes.length).toBe(0);
     f.dispose();
   });
 
@@ -111,31 +107,6 @@ describe('createFireflies', () => {
     }
   });
 
-  it('refresh() updates the ring vertex colour + opacity', () => {
-    const orig = {
-      color: FIREFLIES.get().ORBIT_RING_COLOR,
-      opacity: FIREFLIES.get().ORBIT_RING_OPACITY,
-    };
-    FIREFLIES.setKey('ORBIT_RING_COLOR', '#00ff00');
-    FIREFLIES.setKey('ORBIT_RING_OPACITY', 0.5);
-    try {
-      const f = createFireflies(PLACEMENTS, COMMITS);
-      f.refresh();
-      const ringGroup = f.group.children.find((c) => c.name === 'firefly-orbit-rings');
-      expect(ringGroup).toBeDefined();
-      const { r, g, b, a } = getRingVertex0RGBA(ringGroup!);
-      const expected = new THREE.Color('#00ff00');
-      expect(r).toBeCloseTo(expected.r, 4);
-      expect(g).toBeCloseTo(expected.g, 4);
-      expect(b).toBeCloseTo(expected.b, 4);
-      expect(a).toBeCloseTo(0.5, 4);
-      f.dispose();
-    } finally {
-      FIREFLIES.setKey('ORBIT_RING_COLOR', orig.color);
-      FIREFLIES.setKey('ORBIT_RING_OPACITY', orig.opacity);
-    }
-  });
-
   it('orbit ring is absent when ORBIT_RING_ENABLED is false', () => {
     const orig = FIREFLIES.get().ORBIT_RING_ENABLED;
     FIREFLIES.setKey('ORBIT_RING_ENABLED', false);
@@ -151,59 +122,47 @@ describe('createFireflies', () => {
     }
   });
 
-  it('setHoveredCommit writes the hover colour into the vertex buffer', () => {
+  it('setHoveredCommit shows one ring mesh with the hover color', () => {
     const f = createFireflies(PLACEMENTS, COMMITS);
     f.setHoveredCommit(COMMITS[0].sha);
-    const ringGroup = f.group.children.find((c) => c.name === 'firefly-orbit-rings');
-    const { r, g, b, a } = getRingVertex0RGBA(ringGroup!);
+    const ms = ringMeshes(f);
+    expect(ms.length).toBe(1);
     const expected = new THREE.Color(FIREFLIES.get().ORBIT_RING_HOVER_COLOR);
-    expect(r).toBeCloseTo(expected.r, 4);
-    expect(g).toBeCloseTo(expected.g, 4);
-    expect(b).toBeCloseTo(expected.b, 4);
-    expect(a).toBe(1.0);
+    const got = meshColor(ms[0]);
+    expect(got.r).toBeCloseTo(expected.r, 4);
+    expect(got.g).toBeCloseTo(expected.g, 4);
+    expect(got.b).toBeCloseTo(expected.b, 4);
     f.dispose();
   });
 
-  it('setSelectedCommit beats setHoveredCommit when both target the same ring', () => {
+  it('selected and hovered on the same commit shows only the selected mesh', () => {
     const f = createFireflies(PLACEMENTS, COMMITS);
     f.setHoveredCommit(COMMITS[0].sha);
     f.setSelectedCommit(COMMITS[0].sha);
-    const ringGroup = f.group.children.find((c) => c.name === 'firefly-orbit-rings');
-    const { r, g, b, a } = getRingVertex0RGBA(ringGroup!);
+    const ms = ringMeshes(f);
+    expect(ms.length).toBe(1);
     const expected = new THREE.Color(FIREFLIES.get().ORBIT_RING_SELECTED_COLOR);
-    expect(r).toBeCloseTo(expected.r, 4);
-    expect(g).toBeCloseTo(expected.g, 4);
-    expect(b).toBeCloseTo(expected.b, 4);
-    expect(a).toBe(1.0);
+    expect(meshColor(ms[0]).r).toBeCloseTo(expected.r, 4);
     f.dispose();
   });
 
-  it('clearing selection restores hover colour when still hovered', () => {
+  it('deselecting while still hovered restores the hover ring', () => {
     const f = createFireflies(PLACEMENTS, COMMITS);
     f.setHoveredCommit(COMMITS[0].sha);
     f.setSelectedCommit(COMMITS[0].sha);
     f.setSelectedCommit(null);
-    const ringGroup = f.group.children.find((c) => c.name === 'firefly-orbit-rings');
-    const { r, g, b, a } = getRingVertex0RGBA(ringGroup!);
+    const ms = ringMeshes(f);
+    expect(ms.length).toBe(1);
     const expected = new THREE.Color(FIREFLIES.get().ORBIT_RING_HOVER_COLOR);
-    expect(r).toBeCloseTo(expected.r, 4);
-    expect(g).toBeCloseTo(expected.g, 4);
-    expect(b).toBeCloseTo(expected.b, 4);
-    expect(a).toBe(1.0);
+    expect(meshColor(ms[0]).r).toBeCloseTo(expected.r, 4);
     f.dispose();
   });
 
-  it('clearing hover restores default colour when not selected', () => {
+  it('clearing hover with no selection leaves the ring group empty', () => {
     const f = createFireflies(PLACEMENTS, COMMITS);
     f.setHoveredCommit(COMMITS[0].sha);
     f.setHoveredCommit(null);
-    const ringGroup = f.group.children.find((c) => c.name === 'firefly-orbit-rings');
-    const { r, g, b, a } = getRingVertex0RGBA(ringGroup!);
-    const expected = new THREE.Color(FIREFLIES.get().ORBIT_RING_COLOR);
-    expect(r).toBeCloseTo(expected.r, 4);
-    expect(g).toBeCloseTo(expected.g, 4);
-    expect(b).toBeCloseTo(expected.b, 4);
-    expect(a).toBeCloseTo(FIREFLIES.get().ORBIT_RING_OPACITY, 4);
+    expect(ringMeshes(f).length).toBe(0);
     f.dispose();
   });
 });

--- a/app/tests/scene/fireflies/fireflies.test.ts
+++ b/app/tests/scene/fireflies/fireflies.test.ts
@@ -14,9 +14,7 @@ const PLACEMENTS: TreePlacement[] = [{ x: 0, y: 0, commitIndex: 0, seed: 0 } as 
 function ringMeshes(f: ReturnType<typeof createFireflies>): THREE.Mesh[] {
   const ringGroup = f.group.children.find((c) => c.name === 'firefly-orbit-rings');
   if (!ringGroup) return [];
-  return ringGroup.children.filter(
-    (c): c is THREE.Mesh => (c as THREE.Mesh).isMesh === true
-  );
+  return ringGroup.children.filter((c): c is THREE.Mesh => (c as THREE.Mesh).isMesh === true);
 }
 
 function meshColor(mesh: THREE.Mesh): THREE.Color {

--- a/app/tests/scene/fireflies/orbitRings.test.ts
+++ b/app/tests/scene/fireflies/orbitRings.test.ts
@@ -29,16 +29,10 @@ function makePlacement(commitIndex: number): FireflyPlacement {
   };
 }
 
-const PLACEMENTS: FireflyPlacement[] = [
-  makePlacement(0),
-  makePlacement(1),
-  makePlacement(2),
-];
+const PLACEMENTS: FireflyPlacement[] = [makePlacement(0), makePlacement(1), makePlacement(2)];
 
 function meshesIn(rings: ReturnType<typeof createOrbitRings>): THREE.Mesh[] {
-  return rings.group.children.filter(
-    (c): c is THREE.Mesh => (c as THREE.Mesh).isMesh === true
-  );
+  return rings.group.children.filter((c): c is THREE.Mesh => (c as THREE.Mesh).isMesh === true);
 }
 
 function colorOf(mesh: THREE.Mesh): THREE.Color {
@@ -195,9 +189,7 @@ describe('createOrbitRings — lazy pool', () => {
     //      would fail here regardless of timing noise.
     //   2. Performance: a single hover after a 100k-placement factory
     //      must still feel instant.
-    const big: FireflyPlacement[] = Array.from({ length: 100_000 }, (_, i) =>
-      makePlacement(i)
-    );
+    const big: FireflyPlacement[] = Array.from({ length: 100_000 }, (_, i) => makePlacement(i));
     const rings = createOrbitRings(big);
     expect(meshesIn(rings).length).toBe(0);
 

--- a/app/tests/scene/fireflies/orbitRings.test.ts
+++ b/app/tests/scene/fireflies/orbitRings.test.ts
@@ -1,0 +1,212 @@
+// app/tests/scene/fireflies/orbitRings.test.ts
+//
+// Unit tests for the lazy 2-slot orbit-ring pool. The pool is exercised
+// in isolation (not through createFireflies) so failures point at the
+// pool itself, not the surrounding renderer wiring.
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { createOrbitRings } from '@/scene/components/fireflies/orbitRings.js';
+import type { FireflyPlacement } from '@/scene/components/fireflies/firefliesPlacement.js';
+import { FIREFLIES } from '@/config/components/fireflies.js';
+
+const RING_GROUP_NAME = 'firefly-orbit-rings';
+
+function makePlacement(commitIndex: number): FireflyPlacement {
+  return {
+    treeX: commitIndex * 10,
+    treeZ: 0,
+    height: 5,
+    orbitRadius: 2,
+    orbitStartAngle: 0,
+    orbitTilt: 0.2,
+    phase: 0,
+    pulsePhase: 0,
+    colorHex: '#ffffff',
+    rgb: [1, 1, 1],
+    scale: 1,
+    commitIndex,
+  };
+}
+
+const PLACEMENTS: FireflyPlacement[] = [
+  makePlacement(0),
+  makePlacement(1),
+  makePlacement(2),
+];
+
+function meshesIn(rings: ReturnType<typeof createOrbitRings>): THREE.Mesh[] {
+  return rings.group.children.filter(
+    (c): c is THREE.Mesh => (c as THREE.Mesh).isMesh === true
+  );
+}
+
+function colorOf(mesh: THREE.Mesh): THREE.Color {
+  const mat = mesh.material as THREE.MeshBasicMaterial;
+  return mat.color;
+}
+
+describe('createOrbitRings — lazy pool', () => {
+  it('returns an empty group at construction (no upfront geometry)', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    expect(rings.group.name).toBe(RING_GROUP_NAME);
+    expect(meshesIn(rings).length).toBe(0);
+    rings.dispose();
+  });
+
+  it('returns the no-op interface when placements is empty', () => {
+    const rings = createOrbitRings([]);
+    expect(() => rings.setHoveredCommit(0)).not.toThrow();
+    expect(() => rings.setSelectedCommit(0)).not.toThrow();
+    expect(meshesIn(rings).length).toBe(0);
+    rings.dispose();
+  });
+
+  it('setHoveredCommit(idx) builds exactly one mesh in the group', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(0);
+    const ms = meshesIn(rings);
+    expect(ms.length).toBe(1);
+    const geom = ms[0].geometry as THREE.BufferGeometry;
+    const posAttr = geom.getAttribute('position');
+    expect(posAttr).toBeDefined();
+    expect(posAttr.count).toBeGreaterThan(0);
+    rings.dispose();
+  });
+
+  it('setHoveredCommit with the same idx twice is a no-op (geometry identity preserved)', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(1);
+    const geomBefore = meshesIn(rings)[0].geometry;
+    rings.setHoveredCommit(1);
+    const geomAfter = meshesIn(rings)[0].geometry;
+    expect(geomAfter).toBe(geomBefore);
+    rings.dispose();
+  });
+
+  it('setHoveredCommit(a) then (b) disposes the old geometry and builds a new one', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(0);
+    const oldGeom = meshesIn(rings)[0].geometry as THREE.BufferGeometry;
+    let disposed = false;
+    oldGeom.addEventListener('dispose', () => {
+      disposed = true;
+    });
+    rings.setHoveredCommit(2);
+    const newGeom = meshesIn(rings)[0].geometry as THREE.BufferGeometry;
+    expect(disposed).toBe(true);
+    expect(newGeom).not.toBe(oldGeom);
+    rings.dispose();
+  });
+
+  it('setHoveredCommit(null) disposes the hover slot mesh', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(0);
+    expect(meshesIn(rings).length).toBe(1);
+    rings.setHoveredCommit(null);
+    expect(meshesIn(rings).length).toBe(0);
+    rings.dispose();
+  });
+
+  it('setSelectedCommit(idx) builds a mesh with the selected color', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setSelectedCommit(0);
+    const ms = meshesIn(rings);
+    expect(ms.length).toBe(1);
+    const expected = new THREE.Color(FIREFLIES.get().ORBIT_RING_SELECTED_COLOR);
+    const got = colorOf(ms[0]);
+    expect(got.r).toBeCloseTo(expected.r, 4);
+    expect(got.g).toBeCloseTo(expected.g, 4);
+    expect(got.b).toBeCloseTo(expected.b, 4);
+    rings.dispose();
+  });
+
+  it('hover + selected on the same commit shows only the selected mesh', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(0);
+    rings.setSelectedCommit(0);
+    const ms = meshesIn(rings);
+    expect(ms.length).toBe(1);
+    const expected = new THREE.Color(FIREFLIES.get().ORBIT_RING_SELECTED_COLOR);
+    expect(colorOf(ms[0]).r).toBeCloseTo(expected.r, 4);
+    rings.dispose();
+  });
+
+  it('hover + selected on different commits shows two meshes with distinct colors', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(0);
+    rings.setSelectedCommit(1);
+    const ms = meshesIn(rings);
+    expect(ms.length).toBe(2);
+    const hoverColor = new THREE.Color(FIREFLIES.get().ORBIT_RING_HOVER_COLOR);
+    const selColor = new THREE.Color(FIREFLIES.get().ORBIT_RING_SELECTED_COLOR);
+    const colors = ms.map((m) => colorOf(m).getHexString());
+    expect(colors).toContain(hoverColor.getHexString());
+    expect(colors).toContain(selColor.getHexString());
+    rings.dispose();
+  });
+
+  it('deselecting while still hovered restores the hover ring', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(0);
+    rings.setSelectedCommit(0);
+    // After selecting the hovered commit, only the selected mesh is visible.
+    expect(meshesIn(rings).length).toBe(1);
+    rings.setSelectedCommit(null);
+    // Selection cleared; the hover state is still on commit 0, so the
+    // hover slot's mesh comes back.
+    const ms = meshesIn(rings);
+    expect(ms.length).toBe(1);
+    const expected = new THREE.Color(FIREFLIES.get().ORBIT_RING_HOVER_COLOR);
+    expect(colorOf(ms[0]).r).toBeCloseTo(expected.r, 4);
+    rings.dispose();
+  });
+
+  it('refresh() updates the active slot materials when hover/selected colors change', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(0);
+    const orig = FIREFLIES.get().ORBIT_RING_HOVER_COLOR;
+    FIREFLIES.setKey('ORBIT_RING_HOVER_COLOR', '#00ff00');
+    try {
+      rings.refresh();
+      const expected = new THREE.Color('#00ff00');
+      expect(colorOf(meshesIn(rings)[0]).r).toBeCloseTo(expected.r, 4);
+      expect(colorOf(meshesIn(rings)[0]).g).toBeCloseTo(expected.g, 4);
+      expect(colorOf(meshesIn(rings)[0]).b).toBeCloseTo(expected.b, 4);
+    } finally {
+      FIREFLIES.setKey('ORBIT_RING_HOVER_COLOR', orig);
+    }
+    rings.dispose();
+  });
+
+  it('dispose() clears the group and is idempotent', () => {
+    const rings = createOrbitRings(PLACEMENTS);
+    rings.setHoveredCommit(0);
+    rings.setSelectedCommit(1);
+    rings.dispose();
+    expect(meshesIn(rings).length).toBe(0);
+    expect(() => rings.dispose()).not.toThrow();
+  });
+
+  it('factory does zero upfront geometry; setHoveredCommit stays fast at 100k placements', () => {
+    // Two assertions cover the spec invariants:
+    //   1. Structural: the factory must not build any ring meshes upfront.
+    //      A regression that loops over placements and builds geometry
+    //      would fail here regardless of timing noise.
+    //   2. Performance: a single hover after a 100k-placement factory
+    //      must still feel instant.
+    const big: FireflyPlacement[] = Array.from({ length: 100_000 }, (_, i) =>
+      makePlacement(i)
+    );
+    const rings = createOrbitRings(big);
+    expect(meshesIn(rings).length).toBe(0);
+
+    const t0 = performance.now();
+    rings.setHoveredCommit(50_000);
+    const elapsed = performance.now() - t0;
+    expect(meshesIn(rings).length).toBe(1);
+    expect(elapsed).toBeLessThan(200);
+
+    rings.dispose();
+  });
+});

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ default:
 # under key 'vite'), uses a worktree-derived compose project name (so containers
 # + volumes don't collide), and prints a subdomain URL so browser storage is
 # isolated per worktree. Auto-re-picks if the saved port becomes occupied.
-dev mount='': install-hooks
+dev mount='': install-hooks setup
     @PORT=$(python3 bin/pick-port.py vite) ; \
      SLUG=$(basename $(pwd) | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]' '-' | sed 's/-*$//') ; \
      COMPOSE_ARGS="-f docker-compose.dev.yml" ; \


### PR DESCRIPTION
## Summary

Two independent fixes bundled so torvalds/linux renders end-to-end. Without either, the load hangs.

**1. `api/scan.py` — UTF-8 + cleanup deadlock** ([fix(scan)](../../commit/2d79bd2))
Linux kernel commits carry raw Latin-1 author bytes (e.g. `0xe9` for `é`). `subprocess.Popen` was opened with `text=True` and no `errors=`, so the strict UTF-8 decoder raised mid-stream. The exception escaped the parse loop into a `finally: proc.wait()` — and git was blocked on `pipe_write` with a full stdout pipe Python had stopped draining. Both processes hung indefinitely.

Fix: `errors="replace"` on `Popen` so non-load-bearing bytes in author names / subjects sanitize cleanly, and `proc.kill()` before `proc.wait()` in the finally so any future parse-loop exception can't reproduce the deadlock pattern.

**2. `orbitRings.ts` — lazy 2-slot pool replaces 100k-tube upfront merge** ([refactor(rings)](../../commit/fda003f))
With the scan unblocked, "Adding decorations" then froze the browser. `createOrbitRings` was building one `TubeGeometry` per firefly (~100k on linux) and merging them into one 57M-vertex mesh, synchronously on the main thread. The merge existed only so per-vertex color writes could highlight one ring at a time.

Rings are a selection/hover affordance only — they don't need to exist at rest. New shape: two slots (hover + selected), each owning at most one mesh, built lazily on first hover/select. Reconciliation rule keeps the hover mesh hidden under selection but retains the hover commitIndex, so deselecting while still hovered restores the hover ring (preserves prior UX). Same external `OrbitRings` interface; consumers unchanged.

Downstream cleanup: `ORBIT_RING_COLOR` and `ORBIT_RING_OPACITY` were dead after the refactor — dropped from config, controls pane, and a stale comment.

## Commits (top-to-bottom)

- `docs(fireflies)`: align comments with the lazy-ring-pool reality
- `fix(scan)`: non-UTF-8 git log bytes no longer deadlock the scan
- `style(rings)`: prettier format the lazy-pool refactor files
- `chore(fireflies)`: drop rest-state ring color config
- `refactor(rings)`: lazy 2-slot pool replaces upfront 100k-tube merge

Scan fix is at the top of the stack but logically came first (it's what made the rings freeze observable). All commits are independent and self-contained.

## Test Plan

- [x] `just test-api` clean (225 passed)
- [x] `just test-app` clean (1956 passed)
- [x] `just lint` clean (eslint + prettier + tsc all green)
- [x] Manual: small repo — hover shows hover ring, click selects, click-elsewhere deselects → hover ring restored
- [x] Manual: torvalds/linux loads end-to-end, "Adding decorations" completes without "Page Unresponsive" warning
- [ ] CI green

## Coverage

- New regression tests in `api/tests/test_scan.py`:
  - Non-UTF-8 author bytes round-trip through `_collect_git_metadata` without raising (real commit object via `git hash-object`, wrapped in a 30s threaded deadline so a deadlock fails loudly).
  - Mock `Popen` whose `wait()` asserts `kill()` ran first — pins the cleanup contract.
- New unit test file `app/tests/scene/fireflies/orbitRings.test.ts` (13 tests) — slot state, geometry lifecycle, hover/selected reconciliation, dispose idempotency, and a structural perf-regression assertion (`group.children.length === 0` after factory at 100k placements).
- `app/tests/scene/fireflies/fireflies.test.ts` updated to the new contract (per-vertex-color tests rewritten as mesh-existence/material-color tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)