### PR TITLE
Project opening UX, metadata polish, README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# CodeCity
+# codecity
 
-CodeCity visualizes a codebase as an isometric 3D city. Point it at a git repository and it walks the tree, collects file metadata + git history, then opens the city in your browser. Directories become streets, files become buildings; shape and color encode size, line count, language, and how recently the code changed.
+Visualize any codebase as an isometric 3D city. Point it at a git repo and it walks the tree, collects file + git metadata, and renders a city in your browser. Directories become streets, files become buildings.
 
 ## Quick start
 
-Requires: Docker.
+You need Docker.
 
 ```sh
 docker run --rm --init --pull=always \
@@ -13,21 +13,88 @@ docker run --rm --init --pull=always \
     ghcr.io/thalida/codecity
 ```
 
-Then open <http://localhost:8080/> and paste a git URL into the source picker. CodeCity clones it into its cache and renders the city.
+Open <http://localhost:8080/> and paste a git URL into the source picker.
 
-Out of the box, CodeCity works with **git URLs only**. To render a local repo, see [Advanced: rendering local directories](#advanced-rendering-local-directories) below.
+`--pull=always` keeps you on the latest image; drop it to pin to your cached copy. Wipe the cache with `docker volume rm codecity-cache`. Port in use? `-p 8081:8080`.
 
-> Tip: any `*.localhost` subdomain works (e.g. <http://codecity.localhost:8080/>). Use a unique subdomain per project to keep your source-picker recents (browser localStorage) isolated.
+Use a unique `*.localhost` subdomain per project (e.g. <http://myproj.localhost:8080/>) to keep source-picker recents isolated in localStorage.
 
-Cache lives in the Docker volume `codecity-cache`. To wipe: `docker volume rm codecity-cache`. Port conflict? Use a different host port: `-p 8081:8080`.
+## What gets rendered
 
-The `--pull=always` flag makes Docker check for a newer image on every run, so you always get the latest CodeCity. To pin to your cached version (offline, or to avoid the network hit), drop the flag and pull explicitly when you want updates: `docker pull ghcr.io/thalida/codecity:latest`.
+### Buildings — one per file
 
-## Advanced: rendering local directories
+- **Height** — line count (sqrt-interp across the floor range).
+- **Width & depth** — byte size (log-interp, square footprint).
+- **Hue** — file extension.
+- **Saturation** — created date (older → desaturated).
+- **Lightness** — last-modified (recent → bright).
+- **Facade** — windows, door, roof border, floor slabs.
+- **Windows** — lit-pane density and glow track recency. Newer files glow brighter.
+- **Aging** — older files get grime streaks and a slight lean.
+- **Media files** (images, video) render an ad-panel face on the front above the door.
 
-To render a local git repo, mount it into the container at the same absolute path. The source picker will show the host path and resolve correctly inside the container.
+### Streets — one per directory
 
-**Recommended — mount your code/repos directory only:**
+- **Width tier** — descendant count (step function).
+- **Length** — packed siblings + spacing.
+- Sidewalk + asphalt slabs with the directory name painted on the asphalt.
+
+### Trees — one per commit
+
+- **Placement** — scattered across the world floor. Oldest commit closest to the gem, newest at the edges.
+- **Height** — commit age (older = taller).
+- **Canopy width + facet detail** — files changed in that commit.
+- **Color** — commits-per-day (solo-day vs busy-day color blend).
+- Age desaturation (optional) fades the oldest commits toward gray.
+
+### Fireflies — one orb per commit
+
+Orbit their tree.
+
+- **Color** — per author. Each committer gets their own hue.
+- **Scale** — that author's total commit count.
+- **Motion** — orbit + bob + brightness pulse + flicker.
+
+### Gem — the "you are here" beacon
+
+Floats above the root street's origin cap. Size scales with the root street's width. Rotates, bobs, and cycles its glow color.
+
+## Scanning
+
+codecity scans only **git-tracked** files (`git ls-files`). Gitignored and untracked paths are hidden automatically. Per-file git history (created + most-recent-modify dates) and per-commit metadata (file count, author, date) feed the visuals above.
+
+Some directories and files are always skipped, even when tracked. Full list in `api/scan.py` (`ALWAYS_SKIP`). Highlights:
+
+- VCS: `.git`, `.hg`, `.svn`
+- JS: `node_modules`, lockfiles (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, …)
+- Python: `.venv`, `venv`, `__pycache__`, `poetry.lock`, `uv.lock`, `Pipfile.lock`
+- Framework caches: `.next`, `.nuxt`, `.svelte-kit`
+- Test / coverage: `.pytest_cache`, `.mypy_cache`, `.tox`, `.coverage`, `htmlcov`
+- IDE / OS: `.idea`, `.vscode`, `.DS_Store`
+
+### `.codecityignore`
+
+Drop a `.codecityignore` file at the scan root for per-project ignores. One pattern per line.
+
+```gitignore
+# Skip anywhere named "fixtures"
+fixtures
+
+# Skip a specific path (relative to scan root)
+tests/fixtures/large-repo
+
+# Un-ignore a default skip (! prefix overrides ALWAYS_SKIP)
+!package-lock.json
+```
+
+- No `/` → matches a name anywhere in the tree.
+- Has `/` → anchored to the scan root.
+- `!` prefix un-ignores. `!.git` is silently rejected; the object database is never walked.
+- `#` lines are comments.
+
+## Local directories
+
+To render a local git repo, mount it into the container at the same absolute path:
 
 ```sh
 docker run --rm --init --pull=always \
@@ -37,116 +104,58 @@ docker run --rm --init --pull=always \
     ghcr.io/thalida/codecity
 ```
 
-Replace `$HOME/Documents/Repos` with wherever you keep code. Use multiple `-v` flags to mount multiple directories.
+Use multiple `-v` flags for multiple directories. codecity only renders git working trees — `git init` first if you want to render a non-git directory.
 
-**Full `$HOME` mount — browse anywhere under your home:**
+## Controls
 
-```sh
-docker run --rm --init --pull=always \
-    -v "$HOME:$HOME:ro" \
-    -v codecity-cache:/cache \
-    -p 8080:8080 \
-    ghcr.io/thalida/codecity
-```
+Click the gear in the left sidebar to open the Controls pane. Tweaks stage as drafts; click Save to apply.
 
-> On macOS, Docker Desktop will show a one-time warning about sharing your home directory. Click OK (or "Don't show again"). Trade-off: the container can read everything under `$HOME`. Bind-mount performance on a huge home dir can be slow.
+What you can tune:
 
-### Local-directory requirements
+- **Live updates** — off by default. Turn on to re-render the city when files change on disk; poll interval is configurable (1–60 s).
+- **Buildings** — floor and width ranges, per-extension hue map, palette ranges, facade detail, aging, and the selection-fade cascade that dims unrelated buildings when one is selected.
+- **Streets** — width tiers, spacing, colors, label typography.
+- **Trees** — density falloff, height/width ranges, color encoding, age desaturation, facet detail.
+- **Fireflies** — visibility, scale range, motion, orbit ring.
+- **Scene** — sky color and stars.
+- **Gem** — sizing and materials.
+- **File preview** — syntax highlight theme.
 
-CodeCity only renders **git working trees**. Any local path you mount must be inside a git repo (the path itself, or any of its parents, must contain `.git/`). Non-git directories — and bare repos (no working tree) — are rejected with a clear error. If you want to visualize a non-git directory, `git init` it first; or use a git URL to clone into CodeCity's cache.
-
-### Mount syntax caveats
-
-- The trailing `:ro` flag in `-v <src>:<dst>:ro` can be silently dropped if your path contains characters Docker parses ambiguously. If you see unexpected writes or want stricter syntax, use the long form: `--mount type=bind,source=<src>,target=<dst>,readonly`.
-- Git worktrees (created with `git worktree add`) have a `.git` *file* pointing at the parent repo's `.git/worktrees/<name>/`. To render a worktree, mount the parent repo too (or mount its `.git` dir alongside) so the in-container git can resolve the link.
-
-## How it works
-
-- **Scan** — Python walks the tree on every `/api/manifest` request, gathering stat + git metadata in memory.
-- **Serve** — The container's Python HTTP server (port 8080) computes a fresh manifest per request and streams individual files at `/api/file?path=…` for the in-app preview.
-- **Render** — Your browser loads the bundled three.js renderer from the same server. Nothing leaves your machine.
-
-## Building visual encoding
-
-Each file becomes a building. Visual properties map directly to data:
-
-| Property   | Source                | Meaning                                                            |
-| ---------- | --------------------- | ------------------------------------------------------------------ |
-| Height     | Line count            | Taller = more lines of code                                        |
-| Width      | File size (bytes)     | Wider = larger file on disk                                        |
-| Depth      | Blend of height/width | `lerp(width, height, 0.5)`                                         |
-| Hue        | File extension        | Language family (blue = JS/TS, orange = Python, green = CSS, etc.) |
-| Saturation | File age (created)    | Vivid = newer file, faded = older file                             |
-| Lightness  | Last modified date    | Bright = recently changed, dim = long untouched                    |
-
-Tweak any of these from the in-app Controls pane (left sidebar → gear icon). Changes apply when you click Save.
-
-## Live updates and config commits
-
-The city re-renders **in place** in two situations:
-
-- **Filesystem changes** — when **Updates → Live updates** is on (default), the frontend polls `/api/manifest` on a user-tunable interval (clamped to 1–60 s); when the tree's mtime/size signature changes, new buildings grow in and shifted siblings slide to make room.
-- **Config tweaks** — every slider, color, and toggle in the Controls pane writes to a draft layer. Clicking **Save** flushes the drafts into the live config and recomputes the affected meshes (rebuild) or refreshes their materials (no-rebuild). Discard reverts the pending drafts.
+Plus a keyboard + mouse cheat sheet.
 
 ## Requirements
 
 - Docker (Docker Desktop on macOS/Windows; engine + WSL on Windows; docker on Linux)
-- A modern browser (Chrome, Safari, Firefox, Edge — anything with WebGL2 support)
+- A modern browser with WebGL2 (Chrome, Safari, Firefox, Edge)
 
 ## Development
 
-Requires: Docker, just (optional but recommended), python3 (for the worktree-aware `just dev` port helper).
+You need Docker, just, and python3.
 
 ```sh
 git clone https://github.com/thalida/codecity.git
 cd codecity
-just install-hooks                # one-time: enable pre-push quality gate (lint + prettier + tests)
-just dev                          # http://<worktree-slug>.localhost:<port>/  (Vite HMR + Python API)
-just test                         # pytest + vitest in containers (230 + 1940 tests)
-just build                        # build the local image
-just run                          # run the local image like an end user
+just install-hooks   # pre-push: lint + prettier + tests
+just dev             # http://<worktree-slug>.localhost:<port>/
+just test            # pytest + vitest in containers
+just build           # build the local image
+just run             # run the local image like an end user
 ```
 
-Both `just dev` and `just run` accept an optional path arg to mount a local git repo for visualization: `just dev ~/Documents/Repos/myproj`. Without an arg, codecity is git-URL-only (matches the production `docker run` quickstart).
+`just dev` and `just run` accept a path arg to mount a local repo: `just dev ~/Documents/Repos/myproj`. Without an arg, codecity is git-URL-only.
 
-The pre-push hook runs pytest, vitest, eslint, prettier --check, and typecheck before any `git push` to origin. Bypass with `git push --no-verify` if you need to push WIP. Docker must be running (used for pytest + vitest).
-
-### Multiple worktrees
-
-`just dev` is worktree-aware. Each worktree:
-
-- Gets a unique compose project name (derived from the worktree dir name), so containers and named volumes don't collide.
-- Picks a free host port for Vite on first run, persists to `.local/worktree-ports.json` (gitignored, per-worktree) so the URL is stable across restarts.
-- Opens at `http://<worktree-slug>.localhost:<port>/` — the subdomain isolates browser storage per worktree.
-- Has its own isolated cache volume (compose-scoped; cold cache per worktree by design).
-
-You can run `just dev` in multiple worktrees simultaneously — each gets a different port automatically and they don't interfere.
-
-### Layout
-
-```text
-codecity/
-  api/                 # Python HTTP server (scan, cache, clone, serve)
-  app/                 # Vite frontend (TypeScript + three.js)
-  Dockerfile           # multi-stage build (node:24-bookworm-slim → python:3.13-slim)
-  docker-compose.dev.yml      # contributor dev mode (HMR + auto-reload)
-  docker-compose.test.yml     # contributor test runners
-  pyproject.toml + uv.lock    # python deps + hatch-vcs versioning
-  justfile             # build / dev / test / shell / clean
-```
+The pre-push hook runs pytest, vitest, eslint, prettier, and typecheck before pushing to origin. Bypass with `git push --no-verify` if needed. Docker must be running.
 
 ## Release
-
-Cut a release from `main`:
 
 ```sh
 git tag v0.2.0
 git push --tags
 ```
 
-GitHub Actions builds a multi-arch image (linux/amd64 + linux/arm64), pushes to `ghcr.io/thalida/codecity` with all tag aliases (`v0.2.0`, `v0.2`, `v0`, `latest`, `sha-…`), signs with cosign keyless via OIDC, smoke-tests the published image via `/api/health`, and creates a GitHub Release.
+GitHub Actions builds a multi-arch image (linux/amd64 + linux/arm64), pushes to `ghcr.io/thalida/codecity` with all tag aliases, signs with cosign keyless via OIDC, smoke-tests via `/api/health`, and creates a GitHub Release.
 
-To verify image signatures:
+Verify image signatures:
 
 ```sh
 cosign verify \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use a unique `*.localhost` subdomain per project (e.g. <http://myproj.localhost:
 - **Height** — line count (sqrt-interp across the floor range).
 - **Width & depth** — byte size (log-interp, square footprint).
 - **Hue** — file extension.
-- **Saturation** — created date (older → desaturated).
+- **Saturation** — last-modified (recent → vivid).
 - **Lightness** — last-modified (recent → bright).
 - **Facade** — windows, door, roof border, floor slabs.
 - **Windows** — lit-pane density and glow track recency. Newer files glow brighter.
@@ -57,7 +57,7 @@ Orbit their tree.
 
 ### Gem — the "you are here" beacon
 
-Floats above the root street's origin cap. Size scales with the root street's width. Rotates, bobs, and cycles its glow color.
+Floats above the root street's origin-end cap. Size scales with the root street's width. Rotates, bobs, and cycles its glow color.
 
 ## Scanning
 
@@ -66,10 +66,11 @@ codecity scans only **git-tracked** files (`git ls-files`). Gitignored and untra
 Some directories and files are always skipped, even when tracked. Full list in `api/scan.py` (`ALWAYS_SKIP`). Highlights:
 
 - VCS: `.git`, `.hg`, `.svn`
-- JS: `node_modules`, lockfiles (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, …)
-- Python: `.venv`, `venv`, `__pycache__`, `poetry.lock`, `uv.lock`, `Pipfile.lock`
+- JS: `node_modules`, lockfiles (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `bun.lockb`, …)
+- Python: `.venv`, `venv`, `env`, `__pycache__`, `poetry.lock`, `uv.lock`, `Pipfile.lock`
+- Rust: `target`, `.cargo`, `Cargo.lock`
 - Framework caches: `.next`, `.nuxt`, `.svelte-kit`
-- Test / coverage: `.pytest_cache`, `.mypy_cache`, `.tox`, `.coverage`, `htmlcov`
+- Test / coverage: `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.tox`, `.coverage`, `htmlcov`
 - IDE / OS: `.idea`, `.vscode`, `.DS_Store`
 
 ### `.codecityignore`
@@ -89,7 +90,7 @@ tests/fixtures/large-repo
 
 - No `/` → matches a name anywhere in the tree.
 - Has `/` → anchored to the scan root.
-- `!` prefix un-ignores. `!.git` is silently rejected; the object database is never walked.
+- `!` prefix un-ignores either form (`!name` or `!path/to/thing`). `!.git` is silently rejected; the object database is never walked.
 - `#` lines are comments.
 
 ## Local directories

--- a/api/clone.py
+++ b/api/clone.py
@@ -226,8 +226,16 @@ def _run_git_streaming(
     # a payload through when the stage changes (so the client sees the
     # transition from 'counting' → 'receiving' → 'resolving' even if
     # the throttle window hasn't elapsed).
+    #
+    # We also track the LAST SEEN payload (regardless of whether it was
+    # emitted). On stage change and at end-of-stream we flush the most
+    # recent seen value if it wasn't emitted — otherwise the terminal
+    # percent of each stage (typically 100%) gets silently dropped when
+    # it arrives within 250ms of the previous emit, freezing the UI at
+    # whatever value happened to pass the throttle.
     last_progress_at = [0.0]
-    last_progress_payload: list[tuple[str, int] | None] = [None]
+    last_emitted_payload: list[tuple[str, int] | None] = [None]
+    last_seen_payload: list[tuple[str, int] | None] = [None]
     proc_done = threading.Event()
 
     def _maybe_emit_progress(line: str) -> None:
@@ -237,13 +245,32 @@ def _run_git_streaming(
         if parsed is None:
             return
         now = time.monotonic()
-        prev = last_progress_payload[0]
+        prev = last_emitted_payload[0]
         same_stage = prev is not None and prev[0] == parsed[0]
+        # Stage change: flush the previous stage's terminal value first
+        # so the UI sees e.g. "resolving 100%" before "receiving 1%".
+        if not same_stage and prev is not None:
+            last_seen = last_seen_payload[0]
+            if last_seen is not None and last_seen != prev:
+                on_progress(last_seen)
+                last_emitted_payload[0] = last_seen
+        last_seen_payload[0] = parsed
         if same_stage and now - last_progress_at[0] < CLONE_PROGRESS_THROTTLE_S:
             return
         on_progress(parsed)
         last_progress_at[0] = now
-        last_progress_payload[0] = parsed
+        last_emitted_payload[0] = parsed
+
+    def _flush_progress() -> None:
+        """Emit the most recently seen payload if it wasn't emitted.
+        Called at end-of-stream so the terminal value (e.g. 100%) reaches
+        the UI even when the throttle suppressed it."""
+        if on_progress is None:
+            return
+        last_seen = last_seen_payload[0]
+        if last_seen is not None and last_seen != last_emitted_payload[0]:
+            on_progress(last_seen)
+            last_emitted_payload[0] = last_seen
 
     def _drain_stderr() -> None:
         assert proc.stderr is not None
@@ -275,6 +302,7 @@ def _run_git_streaming(
                 _log(line)
                 last_output_at[0] = time.monotonic()
                 _maybe_emit_progress(line)
+        _flush_progress()
 
     def _drain_stdout() -> None:
         assert proc.stdout is not None

--- a/api/clone.py
+++ b/api/clone.py
@@ -25,6 +25,7 @@ import sys
 import threading
 import time
 from pathlib import Path
+from typing import Callable
 
 from api.types import (
     BranchNotFoundError,
@@ -52,6 +53,32 @@ CACHE_ROOT = (
     Path(os.environ.get("CODECITY_CACHE_ROOT") or Path.home() / ".cache" / "codecity")
     / "clones"
 )
+
+
+# Progress events arrive from git stderr as fast as one per few-percent
+# step. Throttle the user-facing callback so the NDJSON stream isn't
+# flooded with redundant payloads (the server forwards every callback
+# fire as one event). 250ms is short enough to feel live, long enough
+# to coalesce the ~1% steps git emits for big clones.
+CLONE_PROGRESS_THROTTLE_S = 0.25
+
+
+_CLONE_PROGRESS_RE = re.compile(
+    r"^(Receiving|Resolving|Counting) (?:objects|deltas):\s*(\d+)%"
+)
+
+
+def _parse_clone_progress_line(line: str) -> tuple[str, int] | None:
+    """Parse one line of ``git clone --progress`` stderr output.
+
+    Returns ``(stage, percent)`` for matchable progress lines, else None.
+    Stage is lowercase: ``'receiving' | 'resolving' | 'counting'``."""
+    m = _CLONE_PROGRESS_RE.match(line.strip())
+    if m is None:
+        return None
+    stage = m.group(1).lower()
+    percent = int(m.group(2))
+    return stage, percent
 
 
 _BRANCH_NOT_FOUND_PATTERNS = (
@@ -150,6 +177,7 @@ def _run_git_streaming(
     *args: str,
     cwd: Path | None = None,
     progress_dir: Path | None = None,
+    on_progress: Callable[[tuple[str, int]], None] | None = None,
 ) -> str:
     """Run git and forward stderr to ``_log`` line-by-line as it arrives.
 
@@ -192,7 +220,30 @@ def _run_git_streaming(
     # Wall-clock of the last stderr line we forwarded. The watchdog
     # treats anything older than _STALL_HEARTBEAT_SECS as a stall.
     last_output_at = [time.monotonic()]
+    # Throttle state for on_progress: when the last callback fired and
+    # the last (stage, percent) tuple emitted. We coalesce identical
+    # back-to-back payloads within the throttle window, but ALWAYS let
+    # a payload through when the stage changes (so the client sees the
+    # transition from 'counting' → 'receiving' → 'resolving' even if
+    # the throttle window hasn't elapsed).
+    last_progress_at = [0.0]
+    last_progress_payload: list[tuple[str, int] | None] = [None]
     proc_done = threading.Event()
+
+    def _maybe_emit_progress(line: str) -> None:
+        if on_progress is None:
+            return
+        parsed = _parse_clone_progress_line(line)
+        if parsed is None:
+            return
+        now = time.monotonic()
+        prev = last_progress_payload[0]
+        same_stage = prev is not None and prev[0] == parsed[0]
+        if same_stage and now - last_progress_at[0] < CLONE_PROGRESS_THROTTLE_S:
+            return
+        on_progress(parsed)
+        last_progress_at[0] = now
+        last_progress_payload[0] = parsed
 
     def _drain_stderr() -> None:
         assert proc.stderr is not None
@@ -213,6 +264,7 @@ def _run_git_streaming(
                         captured_stderr.append(line)
                         _log(line)
                         last_output_at[0] = time.monotonic()
+                        _maybe_emit_progress(line)
                     start = i + 1
             if start:
                 del buf[:start]
@@ -222,6 +274,7 @@ def _run_git_streaming(
                 captured_stderr.append(line)
                 _log(line)
                 last_output_at[0] = time.monotonic()
+                _maybe_emit_progress(line)
 
     def _drain_stdout() -> None:
         assert proc.stdout is not None
@@ -297,9 +350,18 @@ def _resolve_default_branch(repo: Path) -> str:
     return out.rsplit("/", 1)[-1] if out else "HEAD"
 
 
-def ensure_clone(url: str, branch: str | None = None) -> Path:
+def ensure_clone(
+    url: str,
+    branch: str | None = None,
+    *,
+    on_progress: Callable[[tuple[str, int]], None] | None = None,
+) -> Path:
     """Clone ``url`` (optionally pinned to ``branch``) into the local cache,
     or fetch+reset if it already exists. Returns the local repo path.
+
+    ``on_progress``, if set, is invoked with ``(stage, percent)`` tuples
+    parsed from ``git --progress`` stderr, throttled to ~250ms.
+    Server-side this becomes one ``cloning`` NDJSON event per call.
 
     Raises one of:
       - BranchNotFoundError — requested branch absent on remote
@@ -315,6 +377,7 @@ def ensure_clone(url: str, branch: str | None = None) -> Path:
             _run_git_streaming(
                 "fetch", "--prune", "--progress", "origin",
                 cwd=target, progress_dir=pack_dir,
+                on_progress=on_progress,
             )
             ref = f"origin/{branch}" if branch else f"origin/{_resolve_default_branch(target)}"
             _log(f"resetting to {ref}")
@@ -344,7 +407,7 @@ def ensure_clone(url: str, branch: str | None = None) -> Path:
         args += ["--branch", branch]
     args += ["--", url, str(target)]
     try:
-        _run_git_streaming(*args, progress_dir=pack_dir)
+        _run_git_streaming(*args, progress_dir=pack_dir, on_progress=on_progress)
         _log("clone complete")
     except CloneError as e:
         # First-clone failure: nuke the partial directory before re-raising,

--- a/api/scan.py
+++ b/api/scan.py
@@ -831,7 +831,7 @@ class _Heartbeat:
     the every-100-files log line above). Server-side this becomes one
     ``scanning`` NDJSON event per call."""
 
-    __slots__ = ("seen", "_on_progress", "_last_emit")
+    __slots__ = ("seen", "_on_progress", "_last_emit", "_last_emitted_count")
 
     def __init__(
         self,
@@ -840,6 +840,7 @@ class _Heartbeat:
         self.seen = 0
         self._on_progress = on_progress
         self._last_emit = 0.0
+        self._last_emitted_count = -1  # -1 = never emitted
 
     def tick(self) -> None:
         self.seen += 1
@@ -852,6 +853,17 @@ class _Heartbeat:
             return
         self._on_progress(self.seen)
         self._last_emit = now
+        self._last_emitted_count = self.seen
+
+    def flush(self) -> None:
+        """Emit the final count if it hasn't been emitted yet. Called
+        when the walk finishes so the UI sees the true file total even
+        if the last few ticks were throttled."""
+        if self._on_progress is None:
+            return
+        if self.seen != self._last_emitted_count:
+            self._on_progress(self.seen)
+            self._last_emitted_count = self.seen
 
 
 class _DirFrame:
@@ -1093,6 +1105,7 @@ def scan_tree(
         sig=sig,
         heartbeat=heartbeat,
     )
+    heartbeat.flush()  # ensure UI sees the true final count, not whatever the throttle last allowed through
     _log(f"walked {heartbeat.seen} files; emitting skeleton")
 
     # Compute tree_signature once after the tree is built. This is

--- a/api/scan.py
+++ b/api/scan.py
@@ -18,10 +18,11 @@ import os
 import subprocess
 import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator
 
 from .cache import (
     cache_load_files,
@@ -812,21 +813,45 @@ def _iter_file_nodes(tree: DirNode) -> Iterator[FileNode]:
             yield from _iter_file_nodes(child)  # type: ignore[arg-type]
 
 
+# Match clone.py: 250ms is short enough to feel live, long enough to
+# coalesce the high-frequency tick() calls during a fast tree walk
+# (where tick() fires once per file — easily thousands/sec on warm
+# fs cache).
+SCAN_PROGRESS_THROTTLE_S = 0.25
+
+
 class _Heartbeat:
     """Per-scan file-count tracker. Was a module-level global; that race-
     bombed under ThreadingHTTPServer because two concurrent /api/manifest
     requests would share + mutate the same counter, garbling progress
-    output and corrupting the running tally."""
+    output and corrupting the running tally.
 
-    __slots__ = ("seen",)
+    If ``on_progress`` is supplied, the heartbeat calls it with the
+    current ``seen`` count at most once per ~250ms (independently of
+    the every-100-files log line above). Server-side this becomes one
+    ``scanning`` NDJSON event per call."""
 
-    def __init__(self) -> None:
+    __slots__ = ("seen", "_on_progress", "_last_emit")
+
+    def __init__(
+        self,
+        on_progress: Callable[[int], None] | None = None,
+    ) -> None:
         self.seen = 0
+        self._on_progress = on_progress
+        self._last_emit = 0.0
 
     def tick(self) -> None:
         self.seen += 1
         if self.seen % 100 == 0:
             _log(f"  walked {self.seen} files so far…")
+        if self._on_progress is None:
+            return
+        now = time.monotonic()
+        if now - self._last_emit < SCAN_PROGRESS_THROTTLE_S:
+            return
+        self._on_progress(self.seen)
+        self._last_emit = now
 
 
 class _DirFrame:
@@ -1017,6 +1042,7 @@ def scan_tree(
     use_cache: bool = True,
     cancel_event: "threading.Event | None" = None,
     git_window: str | None = None,
+    on_scan_progress: Callable[[int], None] | None = None,
 ) -> Iterator["ScanStreamEvent"]:
     """Scan a git working tree and yield manifest events.
 
@@ -1054,7 +1080,7 @@ def scan_tree(
         _load_codecityignore(Path(root_abs))
     )
 
-    heartbeat = _Heartbeat()
+    heartbeat = _Heartbeat(on_progress=on_scan_progress)
     _log("walking tree…")
     sig = hashlib.blake2b(digest_size=16)
     _hash_git_window(sig, git_window)

--- a/api/server.py
+++ b/api/server.py
@@ -602,12 +602,14 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
 
             clone_thread = threading.Thread(target=_run_clone, daemon=True)
             clone_thread.start()
-            while True:
-                ev = clone_q.get()
-                if ev is None:
-                    break
-                yield ev
-            clone_thread.join()
+            try:
+                while True:
+                    ev = clone_q.get()
+                    if ev is None:
+                        break
+                    yield ev
+            finally:
+                clone_thread.join()
 
             err = clone_result["error"]
             if isinstance(err, (BranchNotFoundError, RepoNotFoundError, HostUnreachableError)):
@@ -693,7 +695,7 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
                     on_scan_progress=_on_scan_progress,
                 ):
                     scan_q.put(ev)  # skeleton + final flow through the same queue
-            except BaseException as e:  # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
                 scan_error.append(e)
             finally:
                 scan_q.put(None)  # sentinel

--- a/api/server.py
+++ b/api/server.py
@@ -618,10 +618,10 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
                 return
             if err is not None:
                 # Unexpected exception type — surface as an error event so
-                # the client sees a clean message instead of a truncated
-                # stream, and re-raise so the outer try/except logs it.
+                # the client sees a clean message, then re-raise so the
+                # outer handler logs it server-side.
                 yield {"phase": "error", "error": str(err)}
-                return
+                raise err
             scan_target = clone_result["target"]
         else:
             assert local_target is not None

--- a/api/server.py
+++ b/api/server.py
@@ -28,6 +28,7 @@ import gzip
 import json
 import mimetypes
 import os
+import queue
 import re
 import select
 import socket as _socket
@@ -571,15 +572,57 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
         # response has already begun streaming by the time this runs.
         if kind == "git":
             yield {"phase": "cloning", "display_root": display_root}
-            try:
-                with _State.clone_lock:
-                    scan_target = ensure_clone(raw_src, raw_branch)
-            except (BranchNotFoundError, RepoNotFoundError, HostUnreachableError) as e:
-                yield {"phase": "error", "error": str(e)}
+            # ensure_clone is synchronous, but we want its progress
+            # callbacks to stream out as additional `cloning` events.
+            # Run it on a worker thread that pushes events into a queue;
+            # the generator drains the queue until a sentinel arrives,
+            # then collects the result (or re-raises any exception).
+            clone_q: queue.Queue[dict[str, Any] | None] = queue.Queue()
+            clone_result: dict[str, Any] = {"target": None, "error": None}
+
+            def _on_clone_progress(payload: tuple[str, int]) -> None:
+                stage, percent = payload
+                clone_q.put({
+                    "phase": "cloning",
+                    "display_root": display_root,
+                    "stage": stage,
+                    "percent": percent,
+                })
+
+            def _run_clone() -> None:
+                try:
+                    with _State.clone_lock:
+                        clone_result["target"] = ensure_clone(
+                            raw_src, raw_branch, on_progress=_on_clone_progress
+                        )
+                except Exception as e:  # pylint: disable=broad-except
+                    clone_result["error"] = e
+                finally:
+                    clone_q.put(None)  # sentinel
+
+            clone_thread = threading.Thread(target=_run_clone, daemon=True)
+            clone_thread.start()
+            while True:
+                ev = clone_q.get()
+                if ev is None:
+                    break
+                yield ev
+            clone_thread.join()
+
+            err = clone_result["error"]
+            if isinstance(err, (BranchNotFoundError, RepoNotFoundError, HostUnreachableError)):
+                yield {"phase": "error", "error": str(err)}
                 return
-            except CloneError as e:
-                yield {"phase": "error", "error": str(e)}
+            if isinstance(err, CloneError):
+                yield {"phase": "error", "error": str(err)}
                 return
+            if err is not None:
+                # Unexpected exception type — surface as an error event so
+                # the client sees a clean message instead of a truncated
+                # stream, and re-raise so the outer try/except logs it.
+                yield {"phase": "error", "error": str(err)}
+                return
+            scan_target = clone_result["target"]
         else:
             assert local_target is not None
             scan_target = local_target

--- a/api/server.py
+++ b/api/server.py
@@ -550,9 +550,7 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
 
     def _stamp_display_root(m: "Manifest") -> "Manifest":
         if kind == "git":
-            m["display_root"] = (
-                f"{raw_src}@{raw_branch}" if raw_branch else raw_src
-            )
+            m["display_root"] = display_root
         return m
 
     # Captured by the closure below so we can decide whether to write

--- a/api/server.py
+++ b/api/server.py
@@ -667,30 +667,65 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
             yield {"phase": "final", "manifest": cached}
             return
 
-        # Cache miss — stream live scan.
+        # Cache miss — stream live scan. scan_tree is synchronous and
+        # also yields its own events (skeleton + final); we want the
+        # heartbeat-driven scanning progress events to interleave with
+        # those. Same queue/thread pattern as the cloning phase: the
+        # worker pushes both kinds of events into one queue, the
+        # generator drains and yields in arrival order.
+        scan_q: queue.Queue[dict[str, Any] | None] = queue.Queue()
+        scan_error: list[BaseException] = []
+
+        def _on_scan_progress(files_scanned: int) -> None:
+            scan_q.put({
+                "phase": "scanning",
+                "display_root": display_root,
+                "files_scanned": files_scanned,
+            })
+
+        def _run_scan() -> None:
+            try:
+                for ev in scan_tree(
+                    str(scan_target),
+                    use_cache=use_cache,
+                    cancel_event=cancel_event,
+                    git_window=git_window,
+                    on_scan_progress=_on_scan_progress,
+                ):
+                    scan_q.put(ev)  # skeleton + final flow through the same queue
+            except BaseException as e:  # pylint: disable=broad-except
+                scan_error.append(e)
+            finally:
+                scan_q.put(None)  # sentinel
+
+        scan_thread = threading.Thread(target=_run_scan, daemon=True)
+        scan_thread.start()
         try:
-            for event in scan_tree(
-                str(scan_target),
-                use_cache=use_cache,
-                cancel_event=cancel_event,
-                git_window=git_window,
-            ):
-                m = _stamp_display_root(event["manifest"])
-                if event["phase"] == "final":
-                    state["final_manifest"] = m
-                yield event  # type: ignore[misc]
-        except ScanCancelledError:
-            # Cancellation isn't an error to surface to the client —
-            # they disconnected, so there's nobody to read a message.
-            # Re-raise so the outer try skips the cache write and logs
-            # the disconnect.
-            raise
-        except Exception as e:  # pylint: disable=broad-except
+            while True:
+                ev = scan_q.get()
+                if ev is None:
+                    break
+                if ev.get("phase") in ("skeleton", "final"):
+                    m = _stamp_display_root(ev["manifest"])
+                    if ev["phase"] == "final":
+                        state["final_manifest"] = m
+                yield ev  # type: ignore[misc]
+        finally:
+            scan_thread.join()
+
+        if scan_error:
+            err = scan_error[0]
+            if isinstance(err, ScanCancelledError):
+                # Cancellation isn't an error to surface to the client —
+                # they disconnected, so there's nobody to read a message.
+                # Re-raise so the outer try skips the cache write and logs
+                # the disconnect.
+                raise err
             # Unexpected mid-stream failure (e.g., disk read error
             # during _populate_file_metadata). Emit one final error
             # event so the client sees a clear message instead of a
             # truncated stream / parse error.
-            yield {"phase": "error", "error": f"scan failed: {e}"}
+            yield {"phase": "error", "error": f"scan failed: {err}"}
 
     try:
         _stream_events(handler, _events(), cancel_event)

--- a/api/server.py
+++ b/api/server.py
@@ -559,12 +559,20 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
     # the manifest cache after _stream_events returns.
     state: dict[str, Any] = {"final_manifest": None, "scan_target": None, "sig": None}
 
+    # Display label for the in-flight scan. Hoisted above the first
+    # yield so the cloning/scanning event can carry it — the client
+    # uses this to set "{label} (pending)" before any manifest exists.
+    if kind == "git":
+        display_root = f"{raw_src}@{raw_branch}" if raw_branch else raw_src
+    else:
+        display_root = raw_src
+
     def _events() -> Iterable[dict[str, Any]]:
         # Git sources: emit cloning, run ensure_clone, then continue.
         # Errors during the clone become NDJSON error events because the
         # response has already begun streaming by the time this runs.
         if kind == "git":
-            yield {"phase": "cloning"}
+            yield {"phase": "cloning", "display_root": display_root}
             try:
                 with _State.clone_lock:
                     scan_target = ensure_clone(raw_src, raw_branch)
@@ -585,7 +593,11 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
         with _State.allowed_roots_lock:
             _State.allowed_roots.add(scan_target.resolve())
 
-        yield {"phase": "scanning"}
+        # For git sources this is the second event (after `cloning`);
+        # for local sources it's the first. Either way, display_root
+        # rides along so the client can show the pending label
+        # immediately for local sources too.
+        yield {"phase": "scanning", "display_root": display_root}
 
         # Cheap signature probe — same call the live-poll endpoint uses.
         # git_window MUST flow in here too: it feeds the signature, and

--- a/api/server.py
+++ b/api/server.py
@@ -67,6 +67,7 @@ from api.types import (
     FileTooLargeResponse,
     HealthResponse,
     Manifest,
+    ScanStreamEvent,
     SignatureResponse,
 )
 
@@ -209,7 +210,7 @@ def _send_json(handler: BaseHTTPRequestHandler, status: int, body: JsonBody) -> 
 
 def _stream_events(
     handler: BaseHTTPRequestHandler,
-    events: Iterable[dict[str, Any]],
+    events: Iterable[ScanStreamEvent | dict[str, Any]],
     cancel_event: threading.Event,
 ) -> None:
     """Stream NDJSON events over a chunked HTTP response.
@@ -566,7 +567,7 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
     else:
         display_root = raw_src
 
-    def _events() -> Iterable[dict[str, Any]]:
+    def _events() -> Iterable[ScanStreamEvent | dict[str, Any]]:
         # Git sources: emit cloning, run ensure_clone, then continue.
         # Errors during the clone become NDJSON error events because the
         # response has already begun streaming by the time this runs.
@@ -675,7 +676,7 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
         # those. Same queue/thread pattern as the cloning phase: the
         # worker pushes both kinds of events into one queue, the
         # generator drains and yields in arrival order.
-        scan_q: queue.Queue[dict[str, Any] | None] = queue.Queue()
+        scan_q: queue.Queue[ScanStreamEvent | dict[str, Any] | None] = queue.Queue()
         scan_error: list[BaseException] = []
 
         def _on_scan_progress(files_scanned: int) -> None:
@@ -711,7 +712,7 @@ def _serve_manifest(handler: BaseHTTPRequestHandler, query: str) -> None:
                     m = _stamp_display_root(ev["manifest"])
                     if ev["phase"] == "final":
                         state["final_manifest"] = m
-                yield ev  # type: ignore[misc]
+                yield ev
         finally:
             scan_thread.join()
 

--- a/api/tests/test_clone.py
+++ b/api/tests/test_clone.py
@@ -487,5 +487,71 @@ def test_ensure_clone_emits_throttled_progress_via_callback(tmp_path):
     assert on_progress.call_count <= 7, "throttle should not let every line through unbounded"
 
 
+def test_ensure_clone_emits_terminal_percent_of_each_stage(tmp_path):
+    """Regression: when the throttle suppresses the terminal percent of
+    a stage (e.g. 100%), the user gets stuck at whatever value last
+    passed the throttle. The fix flushes the latest seen payload on
+    stage change AND at end-of-stream. Verify the user always sees
+    100% as the final payload for each stage."""
+    from unittest.mock import MagicMock
+    from api import clone as clone_mod
+
+    # Many rapid progress lines per stage; the throttle will block
+    # most of them. Without the flush fix, "Receiving 100%" gets
+    # silently dropped because it lands within 250ms of the previous
+    # emit, leaving the UI frozen at e.g. 66%.
+    fake_stderr = (
+        b"Cloning into '/tmp/foo'...\n"
+        b"Counting objects:  10%\n"
+        b"Counting objects:  50%\n"
+        b"Counting objects:  75%\n"
+        b"Counting objects: 100%\n"
+        b"Receiving objects:   1%\n"
+        b"Receiving objects:  33%\n"
+        b"Receiving objects:  66%\n"
+        b"Receiving objects:  99%\n"
+        b"Receiving objects: 100%\n"
+        b"Resolving deltas:   1%\n"
+        b"Resolving deltas:  50%\n"
+        b"Resolving deltas:  99%\n"
+        b"Resolving deltas: 100%\n"
+    )
+
+    class FakeProc:
+        returncode = 0
+
+        def __init__(self) -> None:
+            self.stdout = io.BytesIO(b"")
+            self.stderr = io.BytesIO(fake_stderr)
+
+        def wait(self) -> int:
+            return 0
+
+    cache = tmp_path / "cache"
+    on_progress = MagicMock()
+    with mock.patch.object(clone_mod, "CACHE_ROOT", cache):
+        with mock.patch.object(subprocess, "Popen", return_value=FakeProc()):
+            clone_mod.ensure_clone(
+                "https://example.com/foo.git", None, on_progress=on_progress
+            )
+
+    # Collect per-stage the highest percent ever emitted.
+    per_stage_max: dict[str, int] = {}
+    for call in on_progress.call_args_list:
+        stage, percent = call.args[0]
+        per_stage_max[stage] = max(per_stage_max.get(stage, 0), percent)
+
+    # Every stage we sent must have ended with 100% reaching the UI.
+    assert per_stage_max.get("counting") == 100, (
+        f"counting should reach 100%; per-stage max: {per_stage_max}"
+    )
+    assert per_stage_max.get("receiving") == 100, (
+        f"receiving should reach 100%; per-stage max: {per_stage_max}"
+    )
+    assert per_stage_max.get("resolving") == 100, (
+        f"resolving should reach 100%; per-stage max: {per_stage_max}"
+    )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/api/tests/test_clone.py
+++ b/api/tests/test_clone.py
@@ -411,5 +411,81 @@ class StallWatchdogTests(unittest.TestCase):
         self.assertEqual(len(git_lines), 10, f"missing git lines: {captured}")
 
 
+def test_parse_clone_progress_line():
+    """Real git --progress emits lines like:
+        Receiving objects:  45% (123/273), 1.20 MiB | 2.50 MiB/s
+    The parser extracts (stage, percent) when matchable, else None.
+    """
+    from api.clone import _parse_clone_progress_line
+
+    cases = [
+        ("Receiving objects:  45% (123/273), 1.20 MiB | 2.50 MiB/s", ("receiving", 45)),
+        ("Resolving deltas:  100% (50/50), done.", ("resolving", 100)),
+        ("Counting objects:  12%", ("counting", 12)),
+        ("Cloning into '/tmp/foo'...", None),
+        ("", None),
+        ("garbage line", None),
+    ]
+    for line, expected in cases:
+        assert _parse_clone_progress_line(line) == expected, f"failed for: {line!r}"
+
+
+def test_ensure_clone_emits_throttled_progress_via_callback(tmp_path):
+    """ensure_clone should call the on_progress callback for parseable
+    progress lines. Real git on a tiny repo doesn't always emit
+    progress, so we fake the Popen and synthesize the stderr stream.
+    The invariant — callback fires with (stage, percent) tuples for
+    each parseable line — is what matters."""
+    from unittest.mock import MagicMock
+    from api import clone as clone_mod
+
+    # \r is git's in-place rewrite separator for progress lines; the
+    # drain splits on either \r or \n so we use \n here for readability.
+    fake_stderr = (
+        b"Cloning into '/tmp/foo'...\n"
+        b"Counting objects:  10%\n"
+        b"Counting objects:  50%\n"
+        b"Counting objects: 100%\n"
+        b"Receiving objects:   1%\n"
+        b"Receiving objects:  50%\n"
+        b"Receiving objects: 100%\n"
+        b"Resolving deltas: 100%\n"
+    )
+
+    class FakeProc:
+        returncode = 0
+
+        def __init__(self) -> None:
+            self.stdout = io.BytesIO(b"")
+            self.stderr = io.BytesIO(fake_stderr)
+
+        def wait(self) -> int:
+            return 0
+
+    cache = tmp_path / "cache"
+    on_progress = MagicMock()
+    with mock.patch.object(clone_mod, "CACHE_ROOT", cache):
+        with mock.patch.object(subprocess, "Popen", return_value=FakeProc()):
+            clone_mod.ensure_clone(
+                "https://example.com/foo.git", None, on_progress=on_progress
+            )
+
+    assert on_progress.call_count >= 1, (
+        f"callback should fire at least once; calls={on_progress.call_args_list}"
+    )
+    for call in on_progress.call_args_list:
+        args = call.args[0]
+        assert isinstance(args, tuple) and len(args) == 2
+        assert args[0] in {"counting", "receiving", "resolving"}
+        assert 0 <= args[1] <= 100
+    # Verify the throttle: at least one stage-transition payload should
+    # come through (counting → receiving or receiving → resolving), and
+    # total should be capped (we sent 7 progress lines; expect ≤ 7 fires
+    # but ≥ 1, with throttling further reducing within-stage duplicates).
+    seen_stages = {call.args[0][0] for call in on_progress.call_args_list}
+    assert len(seen_stages) >= 1, "expected at least one stage emitted"
+    assert on_progress.call_count <= 7, "throttle should not let every line through unbounded"
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/api/tests/test_scan.py
+++ b/api/tests/test_scan.py
@@ -1244,5 +1244,27 @@ class MediaDimsInScanTests(_CacheRedirectMixin, unittest.TestCase):
             self.assertNotIn("media_height", files[0])
 
 
+def test_heartbeat_calls_progress_callback_throttled():
+    """The heartbeat should fire the callback at most once per ~250ms
+    even if tick() is called rapidly."""
+    import time
+    from unittest.mock import MagicMock
+    from api.scan import _Heartbeat
+
+    cb = MagicMock()
+    hb = _Heartbeat(on_progress=cb)
+
+    for _ in range(1000):
+        hb.tick()
+
+    initial_count = cb.call_count
+    assert initial_count >= 1, "expected at least one callback during the rapid ticks"
+    assert initial_count < 50, f"expected throttling to keep count low, got {initial_count}"
+
+    time.sleep(0.3)
+    hb.tick()
+    assert cb.call_count > initial_count, "expected a new callback after throttle window"
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/api/tests/test_scan.py
+++ b/api/tests/test_scan.py
@@ -1266,5 +1266,54 @@ def test_heartbeat_calls_progress_callback_throttled():
     assert cb.call_count > initial_count, "expected a new callback after throttle window"
 
 
+def test_heartbeat_flush_emits_terminal_count():
+    """flush() must emit the final seen count when the last tick was
+    throttle-suppressed, so the UI never freezes at a stale value."""
+    from unittest.mock import MagicMock
+    from api.scan import _Heartbeat
+
+    cb = MagicMock()
+    hb = _Heartbeat(on_progress=cb)
+
+    # Rapid ticks: throttle blocks all but the first (or first few).
+    for _ in range(1000):
+        hb.tick()
+    ticks_before_flush = cb.call_count
+    last_emitted_count_before_flush = cb.call_args.args[0]
+
+    # The heartbeat's seen count is 1000 but the last emit was much earlier.
+    assert hb.seen == 1000
+    assert last_emitted_count_before_flush < 1000, "throttle should have suppressed late ticks"
+
+    hb.flush()
+    assert cb.call_count == ticks_before_flush + 1, "flush should emit exactly once"
+    assert cb.call_args.args[0] == 1000, "flush must emit the true terminal count"
+
+    # Flushing again with no new ticks is a no-op.
+    hb.flush()
+    assert cb.call_count == ticks_before_flush + 1
+
+
+def test_heartbeat_flush_noop_when_already_emitted():
+    """flush() must not re-emit a count that was already emitted."""
+    import time
+    from unittest.mock import MagicMock
+    from api.scan import _Heartbeat
+
+    cb = MagicMock()
+    hb = _Heartbeat(on_progress=cb)
+
+    hb.tick()
+    assert cb.call_count == 1
+    # Sleep past the throttle window so the next tick emits.
+    time.sleep(0.3)
+    hb.tick()
+    assert cb.call_count == 2
+
+    # No new ticks between the last emit and flush: should be a no-op.
+    hb.flush()
+    assert cb.call_count == 2
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/api/tests/test_server_manifest.py
+++ b/api/tests/test_server_manifest.py
@@ -287,6 +287,34 @@ class DisplayRootTests(unittest.TestCase):
             final = next(e for e in events if e["phase"] == "final")["manifest"]
             self.assertEqual(final.get("display_root"), f"{url}@feature")
 
+    def test_cloning_event_includes_display_root(self) -> None:
+        # The first cloning event must carry display_root so the client
+        # can show "{label} (pending)" before clone/scan even starts.
+        with TemporaryDirectory() as td:
+            remote, _ = self._make_fake_remote(Path(td))
+            url = f"file://{remote}"
+            with mock.patch.object(clone_mod, "CACHE_ROOT", Path(td) / "cache"):
+                status, events = self._http.request_stream(
+                    self.server_port, f"/api/manifest?src={url}",
+                )
+            self.assertEqual(status, 200)
+            self.assertEqual(events[0]["phase"], "cloning")
+            self.assertEqual(events[0].get("display_root"), url)
+
+    def test_scanning_event_includes_display_root(self) -> None:
+        # Local sources skip cloning; their first event is `scanning`,
+        # which must also carry display_root (the raw local path the
+        # caller passed in — the same value the final manifest omits).
+        with TemporaryDirectory() as td:
+            self._init_git_repo(Path(td))
+            (Path(td) / "x.py").write_text("\n")
+            status, events = self._http.request_stream(
+                self.server_port, f"/api/manifest?src={td}",
+            )
+            self.assertEqual(status, 200)
+            self.assertEqual(events[0]["phase"], "scanning")
+            self.assertEqual(events[0].get("display_root"), td)
+
 
 class ClientDisconnectTests(unittest.TestCase):
     """Browsers routinely close the TCP socket mid-response — tab reload,

--- a/api/types.py
+++ b/api/types.py
@@ -189,6 +189,26 @@ class ScanStreamEvent(TypedDict):
     manifest: Manifest
 
 
+class ScanCloningEvent(TypedDict):
+    """First event for git sources — emitted before ensure_clone runs
+    so the client can show a "{label} (pending)" header while the
+    network clone is in flight. `display_root` mirrors what the final
+    manifest will carry (URL, or URL@branch when branch is set)."""
+
+    phase: Literal["cloning"]
+    display_root: NotRequired[str]
+
+
+class ScanScanningEvent(TypedDict):
+    """First event for local sources (and the second event for git
+    sources, after the clone settles). `display_root` carries the
+    raw source string so the client can label the pending project
+    before any manifest exists."""
+
+    phase: Literal["scanning"]
+    display_root: NotRequired[str]
+
+
 class ScanErrorEvent(TypedDict):
     """Emitted only if a scan fails AFTER the response body has started
     streaming. Errors before the first byte use the standard 500-JSON

--- a/api/types.py
+++ b/api/types.py
@@ -193,20 +193,29 @@ class ScanCloningEvent(TypedDict):
     """First event for git sources — emitted before ensure_clone runs
     so the client can show a "{label} (pending)" header while the
     network clone is in flight. `display_root` mirrors what the final
-    manifest will carry (URL, or URL@branch when branch is set)."""
+    manifest will carry (URL, or URL@branch when branch is set).
+
+    Subsequent cloning events carry `stage`/`percent` parsed from
+    `git clone --progress` stderr (throttled to ~250ms in api.clone)."""
 
     phase: Literal["cloning"]
     display_root: NotRequired[str]
+    stage: NotRequired[Literal["receiving", "resolving", "counting"]]
+    percent: NotRequired[int]  # 0..100
 
 
 class ScanScanningEvent(TypedDict):
     """First event for local sources (and the second event for git
     sources, after the clone settles). `display_root` carries the
     raw source string so the client can label the pending project
-    before any manifest exists."""
+    before any manifest exists.
+
+    Subsequent scanning events carry `files_scanned` from the
+    scanner's heartbeat callback (throttled to ~250ms in api.scan)."""
 
     phase: Literal["scanning"]
     display_root: NotRequired[str]
+    files_scanned: NotRequired[int]
 
 
 class ScanErrorEvent(TypedDict):

--- a/app/index.html
+++ b/app/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Visualize any codebase as an isometric 3D city." />
+    <meta name="theme-color" content="#010005" />
+    <meta name="color-scheme" content="dark" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <title>codecity</title>
   </head>
   <body>

--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CodeCity</title>
+    <title>codecity</title>
   </head>
   <body>
     <!-- All divs in the body are empty mount points; their content is

--- a/app/public/favicon.svg
+++ b/app/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5eead4"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <polygon points="16,2 30,16 16,30 2,16" fill="url(#g)" stroke="#ffffff" stroke-width="1.5" stroke-linejoin="round"/>
+  <polygon points="16,2 22,16 16,30 10,16" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.5)" stroke-width="0.5"/>
+</svg>

--- a/app/src/coordinator.ts
+++ b/app/src/coordinator.ts
@@ -24,7 +24,7 @@ import { buildFilePreviewPane, humanLanguageFor } from './views/panes/filePrevie
 import { buildCommitPane } from './views/panes/commitPane.js';
 import { buildStreetPane } from './views/panes/streetPane.js';
 import { sameDayCommitCount } from './views/widgets/commitMetrics.js';
-import { labelFromDisplayRoot } from './views/widgets/displayLabel.js';
+import { labelFromManifest } from './views/widgets/displayLabel.js';
 import { LIVE_UPDATES } from './config/index.js';
 import { REBUILD_STATUS, LAST_REBUILD_ERROR, LAST_UPDATED_AT } from './store/liveStatus.js';
 import { DateSource, NodeKind } from './types';
@@ -135,11 +135,7 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
   // Derive the friendly label for the header breadcrumb and document title.
   // manifest.tree.name is already set to the friendly value by main.ts
   // (_applyDisplayLabel) before applyManifest is called, so no mutation needed here.
-  const _rootLabel = labelFromDisplayRoot(
-    _initManifest?.display_root,
-    _initManifest?.repo?.remote_url,
-    rootNode?.name ?? ''
-  );
+  const _rootLabel = labelFromManifest(_initManifest) ?? rootNode?.name ?? '';
   document.title = _rootLabel ? `${_rootLabel} — codecity` : 'codecity';
   // Read initial branch + source URL from the current page URL so the header
   // can show the branch pill and repo link on first paint.
@@ -409,11 +405,7 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
     // _applyDisplayLabel before every applyManifest, so no mutation needed here.
     // Keep document.title in sync with the now-correct name.
     if (m) {
-      const freshLabel = labelFromDisplayRoot(
-        m.display_root,
-        m.repo?.remote_url,
-        m.tree?.name ?? ''
-      );
+      const freshLabel = labelFromManifest(m) ?? m.tree?.name ?? '';
       document.title = freshLabel ? `${freshLabel} — codecity` : 'codecity';
     }
     LAST_UPDATED_AT.set(Date.now());
@@ -467,7 +459,7 @@ export function createCoordinator({ world, picker, rig, resetView, applyTheme }:
     // project-btn updates after a switch. manifest.tree.name is already
     // the friendly label (main.ts._applyDisplayLabel sets it pre-applyManifest).
     const m = world.getManifest();
-    const label = labelFromDisplayRoot(m?.display_root, m?.repo?.remote_url, m?.tree?.name ?? '');
+    const label = labelFromManifest(m) ?? m?.tree?.name ?? '';
     appHeader.setSourceInfo(label, branch, sourceUrl);
   }
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -136,11 +136,13 @@ if (_canvas) {
         for await (const event of streamManifest(manifestUrl())) {
           if (event.phase === 'error') throw new Error(event.error);
           // First event carrying display_root (cloning for git, scanning
-          // for local) — set the pending document title before the
-          // manifest lands so the tab shows the project name during
-          // clone/scan instead of the static page title.
+          // for local) — set the pending document title AND the overlay
+          // header before the manifest lands, so both the tab and the
+          // loading card show the project name during clone/scan instead
+          // of just the static page title / generic spinner copy.
           if (!_pendingTitleSet && 'display_root' in event && event.display_root) {
             applyPendingTitle(event.display_root);
+            loadingOverlay.setPendingLabel(labelFromUrl(event.display_root));
             _pendingTitleSet = true;
           }
           // Lifecycle markers (cloning/scanning) carry no manifest —
@@ -262,11 +264,13 @@ if (_canvas) {
         for await (const event of streamManifest(url.toString())) {
           if (event.phase === 'error') throw new Error(event.error);
           // First event carrying display_root (cloning for git, scanning
-          // for local) — set the pending document title before the
-          // manifest lands so the tab shows the new project name during
-          // clone/scan after a source-switch.
+          // for local) — set the pending document title AND the overlay
+          // header before the manifest lands, so both the tab and the
+          // loading card show the new project name during clone/scan
+          // after a source-switch.
           if (!_pendingTitleSet && 'display_root' in event && event.display_root) {
             applyPendingTitle(event.display_root);
+            loadingOverlay.setPendingLabel(labelFromUrl(event.display_root));
             _pendingTitleSet = true;
           }
           // Lifecycle markers (cloning/scanning) carry no manifest —

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -150,12 +150,28 @@ if (_canvas) {
           // bearing event (skeleton or final) does the bootstrap below.
           if (event.phase === 'cloning' || event.phase === 'scanning') {
             loadingOverlay.setStep(event.phase);
+            // Subsequent same-phase events carry running progress —
+            // render it as a tail on the active step row. Spec: ~250ms
+            // throttle is server-side; client just paints what arrives.
+            if (event.phase === 'cloning' && event.percent !== undefined) {
+              const stage = event.stage ? ` (${event.stage})` : '';
+              loadingOverlay.setStepTail('cloning', `${event.percent}%${stage}`);
+            } else if (event.phase === 'scanning' && event.files_scanned !== undefined) {
+              loadingOverlay.setStepTail(
+                'scanning',
+                `${event.files_scanned.toLocaleString()} files`
+              );
+            }
             continue;
           }
           const m = event.manifest;
           // Advance the overlay step BEFORE the (synchronous-looking) work
           // begins so the user sees the phase update before the city paints
-          // behind the semi-transparent backdrop.
+          // behind the semi-transparent backdrop. Clear any lingering
+          // tails from the now-completed phases so the step rows look
+          // clean as they collapse into the "done" state.
+          loadingOverlay.setStepTail('cloning', null);
+          loadingOverlay.setStepTail('scanning', null);
           loadingOverlay.setStep(event.phase === 'skeleton' ? 'skeleton' : 'building');
           if (handle === null) {
             // First manifest event — skeleton on cold cache, or final on
@@ -274,14 +290,29 @@ if (_canvas) {
             _pendingTitleSet = true;
           }
           // Lifecycle markers (cloning/scanning) carry no manifest —
-          // advance the overlay step and continue.
+          // advance the overlay step and continue. Progress fields
+          // (percent / files_scanned) render as a tail on the active
+          // step row; main flow is unchanged.
           if (event.phase === 'cloning' || event.phase === 'scanning') {
             loadingOverlay.setStep(event.phase);
+            if (event.phase === 'cloning' && event.percent !== undefined) {
+              const stage = event.stage ? ` (${event.stage})` : '';
+              loadingOverlay.setStepTail('cloning', `${event.percent}%${stage}`);
+            } else if (event.phase === 'scanning' && event.files_scanned !== undefined) {
+              loadingOverlay.setStepTail(
+                'scanning',
+                `${event.files_scanned.toLocaleString()} files`
+              );
+            }
             continue;
           }
           // Skeleton step covers the placeholder paint while the server
           // resolves per-file metadata; building step covers the final
           // tween. Overlay stays up through both — hidden only in finally.
+          // Clear lingering progress tails so the now-done step rows
+          // look clean.
+          loadingOverlay.setStepTail('cloning', null);
+          loadingOverlay.setStepTail('scanning', null);
           loadingOverlay.setStep(event.phase === 'skeleton' ? 'skeleton' : 'building');
           if (event.phase === 'skeleton') {
             // Apply the skeleton so the new city paints behind the overlay

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -27,6 +27,24 @@ import { createLoadingOverlay } from './views/source/loadingOverlay.js';
 import { streamManifest } from './utils/manifestStream.js';
 import { pushRecent } from './views/source/sourceRecents.js';
 import { startRenderLoop, _applyDisplayLabel } from './scene/renderLoop.js';
+import { labelFromUrl } from './views/widgets/displayLabel.js';
+
+/**
+ * Set document.title to "{label} (pending) — codecity" from a server-emitted
+ * `display_root`. Called from the source-applying loop on the FIRST stream
+ * event that carries display_root — before any manifest exists — so the tab
+ * title shows the project being loaded instead of the static page title.
+ *
+ * Once the final manifest lands, coordinator.ts's title-swap (using
+ * labelFromManifest) takes over and the "(pending)" suffix disappears.
+ *
+ * Exported so the corresponding unit test can drive it without booting
+ * the renderer.
+ */
+export function applyPendingTitle(displayRoot: string): void {
+  const label = labelFromUrl(displayRoot);
+  document.title = label ? `${label} (pending) — codecity` : 'codecity';
+}
 
 const EMPTY_MANIFEST: Manifest = {
   root: '',
@@ -114,8 +132,17 @@ if (_canvas) {
         branch: _bootBranch,
       });
       try {
+        let _pendingTitleSet = false;
         for await (const event of streamManifest(manifestUrl())) {
           if (event.phase === 'error') throw new Error(event.error);
+          // First event carrying display_root (cloning for git, scanning
+          // for local) — set the pending document title before the
+          // manifest lands so the tab shows the project name during
+          // clone/scan instead of the static page title.
+          if (!_pendingTitleSet && 'display_root' in event && event.display_root) {
+            applyPendingTitle(event.display_root);
+            _pendingTitleSet = true;
+          }
           // Lifecycle markers (cloning/scanning) carry no manifest —
           // advance the overlay step and continue. The first manifest-
           // bearing event (skeleton or final) does the bootstrap below.
@@ -231,8 +258,17 @@ if (_canvas) {
         }
 
         let manifest: Manifest | null = null;
+        let _pendingTitleSet = false;
         for await (const event of streamManifest(url.toString())) {
           if (event.phase === 'error') throw new Error(event.error);
+          // First event carrying display_root (cloning for git, scanning
+          // for local) — set the pending document title before the
+          // manifest lands so the tab shows the new project name during
+          // clone/scan after a source-switch.
+          if (!_pendingTitleSet && 'display_root' in event && event.display_root) {
+            applyPendingTitle(event.display_root);
+            _pendingTitleSet = true;
+          }
           // Lifecycle markers (cloning/scanning) carry no manifest —
           // advance the overlay step and continue.
           if (event.phase === 'cloning' || event.phase === 'scanning') {

--- a/app/src/scene/renderLoop.ts
+++ b/app/src/scene/renderLoop.ts
@@ -36,7 +36,7 @@ import { createCoordinator } from '../coordinator.js';
 import { showTooltip, hideTooltip } from '../views/widgets/tooltip.js';
 import { createPostFx } from './system/postFx.js';
 import { registerRenderer as registerAdPanelRenderer } from './components/adPanels/adPanelTextureArray.js';
-import { labelFromDisplayRoot } from '../views/widgets/displayLabel.js';
+import { labelFromManifest } from '../views/widgets/displayLabel.js';
 
 // Rewrite manifest.tree.name to the friendly label derived from display_root
 // so that every downstream consumer (root street label, file tree root row,
@@ -45,11 +45,7 @@ import { labelFromDisplayRoot } from '../views/widgets/displayLabel.js';
 // client-side mutation is the single point of policy. Must be called BEFORE
 // applyManifest so the scene is built with the correct name from the start.
 export function _applyDisplayLabel(manifest: Manifest): void {
-  const friendly = labelFromDisplayRoot(
-    manifest.display_root,
-    manifest.repo?.remote_url,
-    manifest.tree?.name ?? ''
-  );
+  const friendly = labelFromManifest(manifest);
   if (manifest.tree && friendly) {
     manifest.tree.name = friendly;
   }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2904,6 +2904,15 @@ canvas {
   color: var(--cc-success-dark);
   font-size: var(--cc-font-sm);
 }
+/* Trailing progress text appended via setStepTail (clone %, scanned file
+ * count). Muted compared to the step label so it reads as secondary info
+ * — present on the active step only in practice, since setStep advances
+ * forward and main.ts wipes the tail on phase transitions. */
+.loading-step-tail {
+  color: var(--cc-text-muted);
+  font-size: var(--cc-font-md);
+  font-variant-numeric: tabular-nums;
+}
 /* Header icon buttons — switch-source (far left) + refresh (far right).
  * Both use the same styling as the old footer reset-view button so they
  * read as the same affordance: fixed 22×22 square, muted blue-grey,

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2852,7 +2852,7 @@ canvas {
  * arrives, the (pending) suffix in document.title goes away; the overlay
  * itself is hidden in main.ts's finally block, so this header is only
  * visible during clone/scan. */
-.loading-overlay__pending-label {
+.loading-pending-label {
   font-size: var(--cc-font-lg);
   font-weight: 600;
   color: var(--cc-text-base);

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2847,6 +2847,17 @@ canvas {
 .text-card-title.is-loading {
   text-align: center;
 }
+/* Server-emitted project label rendered above the spinner from the moment
+ * the first phase event lands — before any manifest exists. Once `final`
+ * arrives, the (pending) suffix in document.title goes away; the overlay
+ * itself is hidden in main.ts's finally block, so this header is only
+ * visible during clone/scan. */
+.loading-overlay__pending-label {
+  font-size: var(--cc-font-lg);
+  font-weight: 600;
+  color: var(--cc-text-base);
+  text-align: center;
+}
 .loading-steps {
   list-style: none;
   margin: var(--cc-space-0);

--- a/app/src/utils/manifestStream.ts
+++ b/app/src/utils/manifestStream.ts
@@ -21,8 +21,13 @@ import type { Manifest } from '@/types/manifest';
 // One variant per discriminant value so TS narrows cleanly through
 // `if (event.phase === 'cloning' || event.phase === 'scanning')` etc.
 export type ScanStreamEvent =
-  | { phase: 'cloning'; display_root?: string }
-  | { phase: 'scanning'; display_root?: string }
+  | {
+      phase: 'cloning';
+      display_root?: string;
+      stage?: 'receiving' | 'resolving' | 'counting';
+      percent?: number;
+    }
+  | { phase: 'scanning'; display_root?: string; files_scanned?: number }
   | { phase: 'skeleton'; manifest: Manifest }
   | { phase: 'final'; manifest: Manifest }
   | { phase: 'error'; error: string };

--- a/app/src/utils/manifestStream.ts
+++ b/app/src/utils/manifestStream.ts
@@ -3,11 +3,15 @@
 // transparently, so we read decoded UTF-8 text directly.
 //
 // Event variants (server emits in roughly this order):
-//   cloning  — marker, no payload. Sent for git sources before the clone
-//              subprocess runs so the UI can light up its "Cloning" step
-//              from real state instead of a wall-clock timer.
-//   scanning — marker, no payload. Sent once the clone (if any) is done
-//              and the on-disk scan is about to start.
+//   cloning  — first event for git sources, sent BEFORE the clone
+//              subprocess runs. Carries `display_root` so the UI can
+//              show a "{label} (pending)" header / document title from
+//              the moment the request starts, not from when the manifest
+//              finally arrives. The UI also uses it to light up its
+//              "Cloning" step from real state instead of a wall-clock
+//              timer.
+//   scanning — first event for local sources (and the second event for
+//              git sources). Same `display_root` payload, same UI role.
 //   skeleton — first paint manifest with placeholder building heights.
 //   final    — populated manifest ready for the final tween.
 //   error    — fatal mid-stream failure; client should surface and stop.
@@ -17,8 +21,8 @@ import type { Manifest } from '@/types/manifest';
 // One variant per discriminant value so TS narrows cleanly through
 // `if (event.phase === 'cloning' || event.phase === 'scanning')` etc.
 export type ScanStreamEvent =
-  | { phase: 'cloning' }
-  | { phase: 'scanning' }
+  | { phase: 'cloning'; display_root?: string }
+  | { phase: 'scanning'; display_root?: string }
   | { phase: 'skeleton'; manifest: Manifest }
   | { phase: 'final'; manifest: Manifest }
   | { phase: 'error'; error: string };

--- a/app/src/views/source/loadingOverlay.ts
+++ b/app/src/views/source/loadingOverlay.ts
@@ -169,7 +169,7 @@ export function createLoadingOverlay(): LoadingOverlay {
       // the DOM and any subsequent setPendingLabel call will find a card.
       const card = root.querySelector('.loading-card');
       if (!card) return;
-      const existing = card.querySelector('.loading-overlay__pending-label');
+      const existing = card.querySelector('.loading-pending-label');
       if (label === null) {
         existing?.remove();
         return;
@@ -179,7 +179,7 @@ export function createLoadingOverlay(): LoadingOverlay {
         return;
       }
       const header = document.createElement('div');
-      header.className = 'loading-overlay__pending-label';
+      header.className = 'loading-pending-label';
       header.textContent = label;
       card.insertBefore(header, card.firstChild);
     },

--- a/app/src/views/source/loadingOverlay.ts
+++ b/app/src/views/source/loadingOverlay.ts
@@ -13,6 +13,12 @@
 //                                    (resolving for git, scanning for local)
 //   setStep(step)                  — advance to a step in response to a
 //                                    server-emitted phase event
+//   setPendingLabel(label | null)  — mount/replace/remove a project-label
+//                                    header above the spinner. Called from
+//                                    main.ts when the first stream event
+//                                    carries the server-resolved
+//                                    display_root, so the overlay shows
+//                                    "owner/repo" before any manifest exists.
 //   hide()                         — dismiss overlay
 
 export type LoadingStep =
@@ -36,6 +42,7 @@ export interface LoadingOverlayShowOpts {
 export interface LoadingOverlay {
   show(opts: LoadingOverlayShowOpts): void;
   setStep(step: LoadingStep): void;
+  setPendingLabel(label: string | null): void;
   hide(): void;
 }
 
@@ -67,6 +74,7 @@ export function createLoadingOverlay(): LoadingOverlay {
     return {
       show: () => {},
       setStep: () => {},
+      setPendingLabel: () => {},
       hide: () => {},
     };
   }
@@ -152,6 +160,28 @@ export function createLoadingOverlay(): LoadingOverlay {
 
     setStep(step: LoadingStep) {
       _applyStep(step);
+    },
+
+    setPendingLabel(label: string | null) {
+      // Mounts the header into the loading-card so it sits above the
+      // spinner. If show() hasn't run yet there's no card to inject
+      // into — silently noop in that case; the next show() will rebuild
+      // the DOM and any subsequent setPendingLabel call will find a card.
+      const card = root.querySelector('.loading-card');
+      if (!card) return;
+      const existing = card.querySelector('.loading-overlay__pending-label');
+      if (label === null) {
+        existing?.remove();
+        return;
+      }
+      if (existing) {
+        existing.textContent = label;
+        return;
+      }
+      const header = document.createElement('div');
+      header.className = 'loading-overlay__pending-label';
+      header.textContent = label;
+      card.insertBefore(header, card.firstChild);
     },
 
     hide() {

--- a/app/src/views/source/loadingOverlay.ts
+++ b/app/src/views/source/loadingOverlay.ts
@@ -19,6 +19,12 @@
 //                                    carries the server-resolved
 //                                    display_root, so the overlay shows
 //                                    "owner/repo" before any manifest exists.
+//   setStepTail(step, tail | null) — append a per-step tail string (e.g.
+//                                    "45% (receiving)" while cloning, or
+//                                    "1,234 files" while scanning). Driven
+//                                    from main.ts when the stream emits
+//                                    cloning/scanning events with progress
+//                                    fields. Passing null removes the tail.
 //   hide()                         — dismiss overlay
 
 export type LoadingStep =
@@ -43,6 +49,7 @@ export interface LoadingOverlay {
   show(opts: LoadingOverlayShowOpts): void;
   setStep(step: LoadingStep): void;
   setPendingLabel(label: string | null): void;
+  setStepTail(step: LoadingStep, tail: string | null): void;
   hide(): void;
 }
 
@@ -75,6 +82,7 @@ export function createLoadingOverlay(): LoadingOverlay {
       show: () => {},
       setStep: () => {},
       setPendingLabel: () => {},
+      setStepTail: () => {},
       hide: () => {},
     };
   }
@@ -182,6 +190,27 @@ export function createLoadingOverlay(): LoadingOverlay {
       header.className = 'loading-pending-label';
       header.textContent = label;
       card.insertBefore(header, card.firstChild);
+    },
+
+    setStepTail(step: LoadingStep, tail: string | null) {
+      // Append (or replace, or remove) a small trailing string on a
+      // step row — used for live progress like "45% (receiving)" while
+      // cloning and "1,234 files" while scanning. The tail lives in a
+      // dedicated <span> so the step label stays untouched and a single
+      // remove() restores the original DOM.
+      const row = _stepEls[step];
+      if (!row) return;
+      let tailEl = row.querySelector('.loading-step-tail');
+      if (tail === null) {
+        tailEl?.remove();
+        return;
+      }
+      if (!tailEl) {
+        tailEl = document.createElement('span');
+        tailEl.className = 'loading-step-tail';
+        row.appendChild(tailEl);
+      }
+      tailEl.textContent = ' ' + tail;
     },
 
     hide() {

--- a/app/src/views/source/loadingOverlay.ts
+++ b/app/src/views/source/loadingOverlay.ts
@@ -210,7 +210,7 @@ export function createLoadingOverlay(): LoadingOverlay {
         tailEl.className = 'loading-step-tail';
         row.appendChild(tailEl);
       }
-      tailEl.textContent = ' ' + tail;
+      tailEl.textContent = ` ${tail}`;
     },
 
     hide() {

--- a/app/src/views/widgets/displayLabel.ts
+++ b/app/src/views/widgets/displayLabel.ts
@@ -1,9 +1,19 @@
-// views/widgets/displayLabel.ts — Shared helper for deriving a short,
-// human-friendly project label from a manifest's `display_root` value.
+// views/widgets/displayLabel.ts — Shared helpers for deriving a short,
+// human-friendly project label.
 //
-// Exported as a standalone module so coordinator.ts, main.ts, and any
-// future callers share one implementation instead of duplicating the
-// URL/path parsing logic.
+// Two entry points:
+//   - labelFromUrl     — pure URL/path → label transform. Used by
+//                        applyPendingTitle in main.ts, where we have a
+//                        bare display_root string from the first stream
+//                        event and NO manifest yet.
+//   - labelFromManifest — manifest-aware: prefers display_root, falls
+//                        back to repo.remote_url, then tree.name.
+//
+// Exported as a standalone module so coordinator.ts, main.ts, renderLoop.ts,
+// and any future callers share one implementation instead of duplicating
+// the URL/path parsing logic.
+
+import type { Manifest } from '@/types/manifest';
 
 /**
  * Convert any recognisable repo URL form to an https:// URL.
@@ -24,28 +34,18 @@ export function toHttpsRepoUrl(src: string): string {
 }
 
 /**
- * Derive a short, human-friendly label for a repo.
- *
- * Source preference, in order:
- *   1. `displayRoot` — set by the API for git-URL-synced sources (carries
- *      an optional `@branch` suffix that is stripped before parsing).
- *   2. `remoteUrl` — `manifest.repo.remote_url` from the scanner; set for
- *      any local repo whose working tree has a remote configured, so that
- *      a local clone of github.com/foo/bar still labels as "foo/bar"
- *      instead of the on-disk basename.
- *   3. `fallbackName` — the raw tree name (basename) when no URL signal is
- *      available (e.g. a local repo with no remote).
+ * Pure URL/path → label transform.
  *
  * For any URL form (http/https/ssh) we extract "owner/repo" from the last
  * two path segments. For a local-path display root we return the basename.
+ * Returns null only when the input is empty/null/undefined — in that case
+ * callers should fall back to whatever else they have (tree.name, etc.).
+ *
+ * Strips an optional `@branch` suffix the server appends for git sources
+ * before parsing.
  */
-export function labelFromDisplayRoot(
-  displayRoot: string | undefined,
-  remoteUrl: string | null | undefined,
-  fallbackName: string
-): string {
-  const src = displayRoot || remoteUrl || null;
-  if (!src) return fallbackName;
+export function labelFromUrl(src: string | null | undefined): string | null {
+  if (!src) return null;
   // Strip optional @branch suffix before analysing the URL/path.
   const noBranch = src.replace(/@[^@/]+$/, '');
   // git URL: derive "owner/repo" from the last two path segments.
@@ -57,4 +57,30 @@ export function labelFromDisplayRoot(
   // Local path: basename.
   const parts = noBranch.split(/[/\\]/).filter(Boolean);
   return parts.length ? parts[parts.length - 1] : noBranch;
+}
+
+/**
+ * Derive a short, human-friendly label for a manifest.
+ *
+ * Source preference, in order:
+ *   1. `manifest.display_root` — set by the API for git-URL-synced sources
+ *      (carries an optional `@branch` suffix that is stripped before parsing).
+ *   2. `manifest.repo.remote_url` — set for any local repo whose working
+ *      tree has a remote configured, so that a local clone of
+ *      github.com/foo/bar still labels as "foo/bar" instead of the on-disk
+ *      basename.
+ *   3. `manifest.tree.name` — the raw tree name (basename) when no URL signal
+ *      is available (e.g. a local repo with no remote).
+ */
+export function labelFromManifest(m: Manifest | null | undefined): string | null {
+  if (!m) return null;
+  if (m.display_root) {
+    const fromDisplay = labelFromUrl(m.display_root);
+    if (fromDisplay) return fromDisplay;
+  }
+  if (m.repo?.remote_url) {
+    const fromRemote = labelFromUrl(m.repo.remote_url);
+    if (fromRemote) return fromRemote;
+  }
+  return m.tree?.name ?? null;
 }

--- a/app/tests/manifestStream.test.ts
+++ b/app/tests/manifestStream.test.ts
@@ -62,9 +62,7 @@ describe('streamManifest', () => {
 
   it('parses display_root from a cloning event', async () => {
     const fetchMock = async () =>
-      mockResponse([
-        '{"phase":"cloning","display_root":"https://example.com/foo.git"}\n',
-      ]);
+      mockResponse(['{"phase":"cloning","display_root":"https://example.com/foo.git"}\n']);
     const events = [];
     for await (const ev of streamManifest('http://x', fetchMock as typeof fetch)) {
       events.push(ev);

--- a/app/tests/manifestStream.test.ts
+++ b/app/tests/manifestStream.test.ts
@@ -59,4 +59,22 @@ describe('streamManifest', () => {
       }
     }).rejects.toThrow('boom');
   });
+
+  it('parses display_root from a cloning event', async () => {
+    const fetchMock = async () =>
+      mockResponse([
+        '{"phase":"cloning","display_root":"https://example.com/foo.git"}\n',
+      ]);
+    const events = [];
+    for await (const ev of streamManifest('http://x', fetchMock as typeof fetch)) {
+      events.push(ev);
+    }
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.phase).toBe('cloning');
+    // Discriminator narrow — display_root must be on the cloning variant
+    // of ScanStreamEvent, not accessed via a cast that would hide drift.
+    if (ev.phase !== 'cloning') throw new Error('expected cloning');
+    expect(ev.display_root).toBe('https://example.com/foo.git');
+  });
 });

--- a/app/tests/scene/components/labels/instanced-labels-atlas.test.ts
+++ b/app/tests/scene/components/labels/instanced-labels-atlas.test.ts
@@ -30,25 +30,33 @@ describe('buildLabelAtlas', () => {
     expect(result.rectByText.size).toBe(0);
   });
 
-  it('paginates when one page would overflow', () => {
-    // Generate enough labels to force >1 page but stay well under MAX_PAGES
-    // (16) so no truncation/overflow kicks in. Atlas uses hardcoded
-    // FONT_SIZE_PX = 192 and CANVAS_PADDING_FRAC = 0.25, so each label is
-    // 192 + 2×48 = 288px tall. ATLAS_HEIGHT_MAX is 8192 → ~28 rows per page.
-    // Labels are 22-25 chars wide; jsdom measureText at 192px ≈ 2.3k px/row →
-    // ~3 per row × 28 rows = ~84 capacity per page. 200 labels force ~3 pages,
-    // comfortably below the MAX_PAGES × per-page ceiling (~1344). Empirical
-    // arithmetic — if jsdom canvas measurement shifts in CI, recalibrate.
-    const wide = Array.from({ length: 200 }, (_, i) => `${'x'.repeat(20)}-${i}`);
-    const result = buildLabelAtlas(wide, TYPOGRAPHY);
-    expect(result.pages.length).toBeGreaterThan(1);
-    // Every label must have a rect on a real page.
-    for (const text of wide) {
-      const rect = result.rectByText.get(text);
-      expect(rect).toBeDefined();
-      expect(rect!.page).toBeLessThan(result.pages.length);
+  it(
+    'paginates when one page would overflow',
+    { timeout: 15_000 },
+    () => {
+      // Generate enough labels to force >1 page but stay well under MAX_PAGES
+      // (16) so no truncation/overflow kicks in. Atlas uses hardcoded
+      // FONT_SIZE_PX = 192 and CANVAS_PADDING_FRAC = 0.25, so each label is
+      // 192 + 2×48 = 288px tall. ATLAS_HEIGHT_MAX is 8192 → ~28 rows per page.
+      // Labels are 22-25 chars wide; jsdom measureText at 192px ≈ 2.3k px/row →
+      // ~3 per row × 28 rows = ~84 capacity per page. 200 labels force ~3 pages,
+      // comfortably below the MAX_PAGES × per-page ceiling (~1344). Empirical
+      // arithmetic — if jsdom canvas measurement shifts in CI, recalibrate.
+      //
+      // Explicit 15s timeout (vs vitest's 5s default): under parallel
+      // pytest+vitest load (`just test`) the 200×jsdom measureText calls
+      // can spike past 5s and time out. Locally the test finishes in 1-3s.
+      const wide = Array.from({ length: 200 }, (_, i) => `${'x'.repeat(20)}-${i}`);
+      const result = buildLabelAtlas(wide, TYPOGRAPHY);
+      expect(result.pages.length).toBeGreaterThan(1);
+      // Every label must have a rect on a real page.
+      for (const text of wide) {
+        const rect = result.rectByText.get(text);
+        expect(rect).toBeDefined();
+        expect(rect!.page).toBeLessThan(result.pages.length);
+      }
     }
-  });
+  );
 
   it(
     'truncates labels when atlas overflows MAX_PAGES instead of throwing',

--- a/app/tests/scene/components/labels/instanced-labels-atlas.test.ts
+++ b/app/tests/scene/components/labels/instanced-labels-atlas.test.ts
@@ -30,33 +30,29 @@ describe('buildLabelAtlas', () => {
     expect(result.rectByText.size).toBe(0);
   });
 
-  it(
-    'paginates when one page would overflow',
-    { timeout: 15_000 },
-    () => {
-      // Generate enough labels to force >1 page but stay well under MAX_PAGES
-      // (16) so no truncation/overflow kicks in. Atlas uses hardcoded
-      // FONT_SIZE_PX = 192 and CANVAS_PADDING_FRAC = 0.25, so each label is
-      // 192 + 2×48 = 288px tall. ATLAS_HEIGHT_MAX is 8192 → ~28 rows per page.
-      // Labels are 22-25 chars wide; jsdom measureText at 192px ≈ 2.3k px/row →
-      // ~3 per row × 28 rows = ~84 capacity per page. 200 labels force ~3 pages,
-      // comfortably below the MAX_PAGES × per-page ceiling (~1344). Empirical
-      // arithmetic — if jsdom canvas measurement shifts in CI, recalibrate.
-      //
-      // Explicit 15s timeout (vs vitest's 5s default): under parallel
-      // pytest+vitest load (`just test`) the 200×jsdom measureText calls
-      // can spike past 5s and time out. Locally the test finishes in 1-3s.
-      const wide = Array.from({ length: 200 }, (_, i) => `${'x'.repeat(20)}-${i}`);
-      const result = buildLabelAtlas(wide, TYPOGRAPHY);
-      expect(result.pages.length).toBeGreaterThan(1);
-      // Every label must have a rect on a real page.
-      for (const text of wide) {
-        const rect = result.rectByText.get(text);
-        expect(rect).toBeDefined();
-        expect(rect!.page).toBeLessThan(result.pages.length);
-      }
+  it('paginates when one page would overflow', { timeout: 15_000 }, () => {
+    // Generate enough labels to force >1 page but stay well under MAX_PAGES
+    // (16) so no truncation/overflow kicks in. Atlas uses hardcoded
+    // FONT_SIZE_PX = 192 and CANVAS_PADDING_FRAC = 0.25, so each label is
+    // 192 + 2×48 = 288px tall. ATLAS_HEIGHT_MAX is 8192 → ~28 rows per page.
+    // Labels are 22-25 chars wide; jsdom measureText at 192px ≈ 2.3k px/row →
+    // ~3 per row × 28 rows = ~84 capacity per page. 200 labels force ~3 pages,
+    // comfortably below the MAX_PAGES × per-page ceiling (~1344). Empirical
+    // arithmetic — if jsdom canvas measurement shifts in CI, recalibrate.
+    //
+    // Explicit 15s timeout (vs vitest's 5s default): under parallel
+    // pytest+vitest load (`just test`) the 200×jsdom measureText calls
+    // can spike past 5s and time out. Locally the test finishes in 1-3s.
+    const wide = Array.from({ length: 200 }, (_, i) => `${'x'.repeat(20)}-${i}`);
+    const result = buildLabelAtlas(wide, TYPOGRAPHY);
+    expect(result.pages.length).toBeGreaterThan(1);
+    // Every label must have a rect on a real page.
+    for (const text of wide) {
+      const rect = result.rectByText.get(text);
+      expect(rect).toBeDefined();
+      expect(rect!.page).toBeLessThan(result.pages.length);
     }
-  );
+  });
 
   it(
     'truncates labels when atlas overflows MAX_PAGES instead of throwing',

--- a/app/tests/views/loadingOverlay.test.ts
+++ b/app/tests/views/loadingOverlay.test.ts
@@ -97,7 +97,7 @@ describe('loadingOverlay', () => {
     const o = createLoadingOverlay();
     o.show({ kind: 'git', label: 'owner/repo' });
     o.setPendingLabel('owner/repo');
-    const header = root.querySelector('.loading-overlay__pending-label');
+    const header = root.querySelector('.loading-pending-label');
     expect(header).not.toBeNull();
     expect(header!.textContent).toContain('owner/repo');
   });
@@ -107,7 +107,7 @@ describe('loadingOverlay', () => {
     o.show({ kind: 'git', label: 'owner/repo' });
     o.setPendingLabel('owner/repo');
     o.setPendingLabel(null);
-    const header = root.querySelector('.loading-overlay__pending-label');
+    const header = root.querySelector('.loading-pending-label');
     expect(header).toBeNull();
   });
 });

--- a/app/tests/views/loadingOverlay.test.ts
+++ b/app/tests/views/loadingOverlay.test.ts
@@ -110,4 +110,34 @@ describe('loadingOverlay', () => {
     const header = root.querySelector('.loading-pending-label');
     expect(header).toBeNull();
   });
+
+  // ── Step-tail render (Task 11) ──────────────────────────────────────────
+
+  it('renders a tail string next to a step row', () => {
+    const o = createLoadingOverlay();
+    o.show({ kind: 'git', label: 'owner/repo' });
+    o.setStepTail('cloning', '45% (receiving)');
+    const cloningRow = root.querySelector('[data-step="cloning"]');
+    expect(cloningRow?.textContent).toContain('45%');
+    expect(cloningRow?.textContent).toContain('receiving');
+  });
+
+  it('replaces an existing tail string with a new one', () => {
+    const o = createLoadingOverlay();
+    o.show({ kind: 'git', label: 'owner/repo' });
+    o.setStepTail('cloning', '10%');
+    o.setStepTail('cloning', '80%');
+    const cloningRow = root.querySelector('[data-step="cloning"]');
+    expect(cloningRow?.textContent).toContain('80%');
+    expect(cloningRow?.textContent).not.toContain('10%');
+  });
+
+  it('clears the tail when setStepTail is called with null', () => {
+    const o = createLoadingOverlay();
+    o.show({ kind: 'git', label: 'owner/repo' });
+    o.setStepTail('cloning', '45%');
+    o.setStepTail('cloning', null);
+    const cloningRow = root.querySelector('[data-step="cloning"]');
+    expect(cloningRow?.textContent).not.toContain('45%');
+  });
 });

--- a/app/tests/views/loadingOverlay.test.ts
+++ b/app/tests/views/loadingOverlay.test.ts
@@ -90,4 +90,24 @@ describe('loadingOverlay', () => {
       'pending'
     );
   });
+
+  // ── Pending-label header (Task 7) ───────────────────────────────────────
+
+  it('renders the pending label as a header when setPendingLabel is called', () => {
+    const o = createLoadingOverlay();
+    o.show({ kind: 'git', label: 'owner/repo' });
+    o.setPendingLabel('owner/repo');
+    const header = root.querySelector('.loading-overlay__pending-label');
+    expect(header).not.toBeNull();
+    expect(header!.textContent).toContain('owner/repo');
+  });
+
+  it('hides the pending label when setPendingLabel is called with null', () => {
+    const o = createLoadingOverlay();
+    o.show({ kind: 'git', label: 'owner/repo' });
+    o.setPendingLabel('owner/repo');
+    o.setPendingLabel(null);
+    const header = root.querySelector('.loading-overlay__pending-label');
+    expect(header).toBeNull();
+  });
 });

--- a/app/tests/views/pendingTitle.test.ts
+++ b/app/tests/views/pendingTitle.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { applyPendingTitle } from '@/main';
+
+// applyPendingTitle is called from main.ts's source-applying loop with the
+// `display_root` field on the first cloning/scanning event the server emits.
+// It sets document.title to "{label} (pending) — codecity" so the user sees
+// the project name before the manifest arrives. Coordinator's title-swap
+// (via labelFromManifest) takes over once the final manifest lands and the
+// "(pending)" suffix is gone.
+describe('applyPendingTitle', () => {
+  beforeEach(() => {
+    document.title = 'codecity';
+  });
+
+  it('sets "{label} (pending) — codecity" from a git URL display_root', () => {
+    applyPendingTitle('https://github.com/owner/repo.git');
+    expect(document.title).toBe('owner/repo (pending) — codecity');
+  });
+
+  it('handles local paths', () => {
+    applyPendingTitle('/home/user/Repos/myproj');
+    expect(document.title).toBe('myproj (pending) — codecity');
+  });
+
+  it('falls back to plain "codecity" if display_root is empty', () => {
+    applyPendingTitle('');
+    expect(document.title).toBe('codecity');
+  });
+});

--- a/app/tests/views/widgets/displayLabel.test.ts
+++ b/app/tests/views/widgets/displayLabel.test.ts
@@ -1,44 +1,102 @@
 import { describe, it, expect } from 'vitest';
-import { labelFromDisplayRoot, toHttpsRepoUrl } from '@/views/widgets/displayLabel.js';
+import { labelFromManifest, labelFromUrl, toHttpsRepoUrl } from '@/views/widgets/displayLabel.js';
+import type { Manifest } from '@/types/manifest';
 
-describe('labelFromDisplayRoot', () => {
-  it('parses org/repo from an https display root', () => {
-    expect(labelFromDisplayRoot('https://github.com/foo/bar', null, 'fallback')).toBe('foo/bar');
+// Test helper: build the minimal Manifest shape labelFromManifest reads,
+// stamping only the fields a given test cares about. We don't strictly
+// need full Manifest fidelity here — labelFromManifest only touches
+// display_root, repo.remote_url, and tree.name — so a Partial cast keeps
+// the test concise without widening prod types.
+function manifest(partial: {
+  display_root?: string;
+  remote_url?: string | null;
+  treeName?: string;
+}): Manifest {
+  return {
+    display_root: partial.display_root,
+    repo: { remote_url: partial.remote_url ?? null } as Manifest['repo'],
+    tree: { name: partial.treeName ?? '' } as Manifest['tree'],
+  } as Manifest;
+}
+
+describe('labelFromUrl', () => {
+  it('parses org/repo from an https URL', () => {
+    expect(labelFromUrl('https://github.com/foo/bar')).toBe('foo/bar');
+  });
+
+  it('strips an @branch suffix before parsing', () => {
+    expect(labelFromUrl('https://github.com/foo/bar@main')).toBe('foo/bar');
+  });
+
+  it('parses org/repo from an ssh URL', () => {
+    expect(labelFromUrl('git@github.com:foo/bar.git')).toBe('foo/bar');
+  });
+
+  it('falls back to the local-path basename for a path', () => {
+    expect(labelFromUrl('/Users/me/code/myproject')).toBe('myproject');
+  });
+
+  it('returns null for empty / nullish input', () => {
+    expect(labelFromUrl('')).toBeNull();
+    expect(labelFromUrl(null)).toBeNull();
+    expect(labelFromUrl(undefined)).toBeNull();
+  });
+});
+
+describe('labelFromManifest', () => {
+  it('parses org/repo from a display_root URL', () => {
+    expect(labelFromManifest(manifest({ display_root: 'https://github.com/foo/bar' }))).toBe(
+      'foo/bar'
+    );
   });
 
   it('strips an @branch suffix on the display root before parsing', () => {
-    expect(labelFromDisplayRoot('https://github.com/foo/bar@main', null, 'fallback')).toBe(
+    expect(labelFromManifest(manifest({ display_root: 'https://github.com/foo/bar@main' }))).toBe(
       'foo/bar'
     );
   });
 
   it('parses org/repo from an ssh display root', () => {
-    expect(labelFromDisplayRoot('git@github.com:foo/bar.git', null, 'fallback')).toBe('foo/bar');
-  });
-
-  it('falls back to the local-path basename when display root is a path', () => {
-    expect(labelFromDisplayRoot('/Users/me/code/myproject', null, 'fallback')).toBe('myproject');
-  });
-
-  it('uses remote_url when display_root is absent (local repo with a remote)', () => {
-    expect(labelFromDisplayRoot(undefined, 'https://github.com/foo/bar', 'myproject')).toBe(
+    expect(labelFromManifest(manifest({ display_root: 'git@github.com:foo/bar.git' }))).toBe(
       'foo/bar'
     );
   });
 
+  it('falls back to the local-path basename when display root is a path', () => {
+    expect(labelFromManifest(manifest({ display_root: '/Users/me/code/myproject' }))).toBe(
+      'myproject'
+    );
+  });
+
+  it('uses remote_url when display_root is absent (local repo with a remote)', () => {
+    expect(
+      labelFromManifest(
+        manifest({ remote_url: 'https://github.com/foo/bar', treeName: 'myproject' })
+      )
+    ).toBe('foo/bar');
+  });
+
   it('prefers display_root over remote_url when both are set', () => {
     expect(
-      labelFromDisplayRoot(
-        'https://github.com/displayed/repo',
-        'https://github.com/other/repo',
-        'fallback'
+      labelFromManifest(
+        manifest({
+          display_root: 'https://github.com/displayed/repo',
+          remote_url: 'https://github.com/other/repo',
+        })
       )
     ).toBe('displayed/repo');
   });
 
-  it('falls back to the supplied name when neither display_root nor remote_url is set', () => {
-    expect(labelFromDisplayRoot(undefined, null, 'myproject')).toBe('myproject');
-    expect(labelFromDisplayRoot(undefined, undefined, 'myproject')).toBe('myproject');
+  it('falls back to tree.name when neither display_root nor remote_url is set', () => {
+    expect(labelFromManifest(manifest({ treeName: 'myproject' }))).toBe('myproject');
+    expect(labelFromManifest(manifest({ remote_url: null, treeName: 'myproject' }))).toBe(
+      'myproject'
+    );
+  });
+
+  it('returns null for a null/undefined manifest', () => {
+    expect(labelFromManifest(null)).toBeNull();
+    expect(labelFromManifest(undefined)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Three coordinated improvements to how codecity surfaces itself when a project opens:

- **Pending project label + streamed progress** — the server emits `display_root` in the very first phase event so the page title and loading overlay show `owner/repo (pending) — codecity` the moment a clone starts. Clone and scan progress now stream as throttled NDJSON events with `stage`/`percent` (clone) and `files_scanned` (scan) — the overlay shows `Cloning… 45% (receiving)` and `Scanning… 1,234 files` instead of blank phase markers. Backed by `queue.Queue` + daemon thread pumps wrapped around the synchronous `ensure_clone` and `scan_tree`.
- **Site metadata** — `<title>CodeCity</title>` → `codecity`, plus the missing essentials: `description`, `theme-color` (matches the sky default `#010005`), `color-scheme: dark`, and a gem-silhouette `favicon.svg`.
- **README rewrite** — full restructure for accuracy + tone. Fixes the wrong "live updates is default" claim, documents `.codecityignore` syntax + the always-skipped list, inventories the actual world elements (buildings, streets, trees, fireflies, gem) with what data drives each, and tightens verbose sections.

Plus a flake fix on the atlas pagination test (5s timeout was too tight under parallel `just test` load — bumped to 15s, matching the neighboring overflow test).

## Test Plan

- [x] `just test` — 233 pytest + 5 subtests + 1971 vitest, all passing
- [x] `just lint` — typecheck + eslint + prettier clean (pre-push hook gate)
- [x] Live tested on `infisical/infisical` (~188k objects) — clone percent updates to 100%, scan file count updates throughout the walk
- [ ] Visual check on the loading overlay's pending label header alignment
- [ ] Tab favicon renders the gem silhouette in Chrome, Safari, Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)