### PR TITLE
CSS: finish the UI component system (Workstream A) — DRY consolidations + surface/card vocabulary

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -58,6 +58,7 @@
 - [x] grime streaks scale by building age — Intensity and Coverage are now RangePair `[newest, oldest]` settings; the shader lerps each per-building by createdAge.
 - [x] building tilt scales by building age — TILT_DEGREES is now a RangePair `[newest, oldest]`; shader + CPU (outline/picker) lerp the lean by createdAge.
 - [ ] make the city fully signal-driven — today the manifest is passed in (`createCity(m)` + `handle.applyManifest(m)`), the explicit input contract both apply triggers funnel through: a MANIFEST change (City.tsx effect) and a Rebuild-route settings Save (`settingsReactions` → `applyManifest(MANIFEST.peek())`, MANIFEST unchanged). Having the city read MANIFEST from its store instead needs restructuring trigger ownership: `settingsReactions` bumps a "rebuild-requested" signal rather than calling `applyManifest`, and the city watches MANIFEST + that signal. Payoff: `City.tsx` shrinks to a mount/dispose shell (status + reframe already moved into `city/`). Cost: callback→signal-bump, testability shifts to driving global signals, the apply generation/skeleton handling moves inside city. (Follows the status-helpers + reframe-into-city refactors.)
+- [ ] image tooltips show image size, not line count — hovering a media/image billboard currently surfaces the generic building line-count tooltip; for image files show the image dimensions (e.g. `1920×1080`) instead.
 
 ## Agent Prompts ToDos
 

--- a/app/src/city/interaction/tooltip.ts
+++ b/app/src/city/interaction/tooltip.ts
@@ -21,6 +21,7 @@ function _ensure(): HTMLElement {
   if (_el && _el.isConnected) return _el;
   _el = document.createElement('div');
   _el.id = 'hover-tooltip';
+  _el.className = 'card-tooltip';
   _el.style.display = 'none';
   document.body.appendChild(_el);
   return _el;

--- a/app/src/components/Field.tsx
+++ b/app/src/components/Field.tsx
@@ -8,7 +8,7 @@
 
 import { FieldKind, getFieldDef } from '@/state/settingsSchema';
 import { useField } from '@/hooks/useSettings';
-import { Row } from './Row';
+import { ThemeRow } from './ThemeRow';
 import { TierWidthsField } from './TierWidthsField';
 import { HueMapField } from './HueMapField';
 import { ColorInput } from '@/components/ColorInput';
@@ -107,8 +107,8 @@ export function Field({ store, fieldKey }: FieldProps) {
   }
 
   return (
-    <Row label={def.label} tip={def.tip} store={store} keys={[fieldKey]}>
+    <ThemeRow label={def.label} tip={def.tip} store={store} keys={[fieldKey]}>
       {control}
-    </Row>
+    </ThemeRow>
   );
 }

--- a/app/src/components/LoadingOverlay.tsx
+++ b/app/src/components/LoadingOverlay.tsx
@@ -57,7 +57,7 @@ export function LoadingOverlay() {
 
   return (
     <div class="loading-backdrop">
-      <div class="loading-card">
+      <div class="loading-card card-overlay">
         {pendingLabel && <div class="loading-pending-label">{pendingLabel}</div>}
         <div class="loading-spinner" />
         <div class="text-card-title is-loading" role="status" aria-live="polite">

--- a/app/src/components/Section.tsx
+++ b/app/src/components/Section.tsx
@@ -33,7 +33,7 @@ export function Section({ name, hint, resetKeys, children }: SectionProps) {
   return (
     <details class="controls-section">
       <summary class="row row--bleed controls-section-summary">
-        <ChevronRight class="lucide-icon controls-section-chevron" />
+        <ChevronRight class="lucide-icon chevron" />
         <span class="text-label">{name}</span>
         {keys.length > 0 && (
           <button

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -62,7 +62,10 @@ function ResizeHandle({ side, targetRef, widthSignal }: ResizeHandleProps) {
     widthSignal.value = targetRef.current.offsetWidth;
   };
 
-  const cls = side === SidebarSide.Left ? 'sidebar-resize-handle' : 'sidebar-resize-handle-right';
+  const cls =
+    side === SidebarSide.Left
+      ? 'resize-handle resize-handle--right'
+      : 'resize-handle resize-handle--left';
   return (
     <div
       class={`${cls}${isDragging ? ' dragging' : ''}`}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -103,7 +103,7 @@ export function Sidebar({ id, side, class: cls, widthSignal, children }: Sidebar
   }, []);
 
   return (
-    <aside ref={ref} id={id} class={cls ?? ''}>
+    <aside ref={ref} id={id} class={cls ? `surface-sidebar ${cls}` : 'surface-sidebar'}>
       {children}
       <ResizeHandle side={side} targetRef={ref} widthSignal={widthSignal} />
     </aside>

--- a/app/src/components/Subgroup.tsx
+++ b/app/src/components/Subgroup.tsx
@@ -43,7 +43,7 @@ export function Subgroup({ name, collapsible = true, resetKeys, children }: Subg
   return (
     <details class="theme-subgroup theme-subgroup-collapsible">
       <summary class="row row--bleed text-label text-label--muted">
-        <ChevronRight class="lucide-icon theme-subgroup-chevron" />
+        <ChevronRight class="lucide-icon chevron" />
         <span class="theme-subgroup-label-text">{name}</span>
         {keys.length > 0 && (
           <button

--- a/app/src/components/ThemeRow.tsx
+++ b/app/src/components/ThemeRow.tsx
@@ -1,7 +1,7 @@
-// components/Row.tsx — Labeled form row used by every control
-// widget. Renders the label, the control element passed in `children`,
-// and (when `store` + `keys` are provided) a reset icon next to the
-// control that stages-reset on click.
+// components/ThemeRow.tsx — Labeled control-panel row (renders .theme-row)
+// used by every control widget. Renders the label, the control element passed
+// in `children`, and (when `store` + `keys` are provided) a reset icon next to
+// the control that stages-reset on click.
 //
 // `tip` is appended to the label-as-tooltip so users can hover and see
 // what a knob does without expanding documentation.
@@ -14,7 +14,7 @@ interface SignalLike {
   set value(v: any);
 }
 
-export interface RowProps {
+export interface ThemeRowProps {
   label: string;
   /** Extra hover text appended after `label — …` on the row title. */
   tip?: string;
@@ -25,7 +25,7 @@ export interface RowProps {
   children: ComponentChildren;
 }
 
-export function Row({ label, tip, store, keys, children }: RowProps) {
+export function ThemeRow({ label, tip, store, keys, children }: ThemeRowProps) {
   const fullTip = tip ? `${label} — ${tip}` : label;
   return (
     <label class="theme-row" title={fullTip}>

--- a/app/src/layout/AppFooter.tsx
+++ b/app/src/layout/AppFooter.tsx
@@ -295,7 +295,7 @@ export function AppFooter() {
   }
 
   return (
-    <footer id="app-footer">
+    <footer id="app-footer" class="surface-chrome">
       <div class="app-footer-section app-footer-left">
         <FooterStatusSection status={status} />
       </div>

--- a/app/src/layout/AppHeader.tsx
+++ b/app/src/layout/AppHeader.tsx
@@ -73,7 +73,7 @@ export function AppHeader({
   }
 
   return (
-    <header id="app-header">
+    <header id="app-header" class="surface-chrome">
       <div id="app-header-left">
         <ResetViewButton onResetView={onResetView} />
         <ProjectSwitcher

--- a/app/src/layout/LeftSidebar.tsx
+++ b/app/src/layout/LeftSidebar.tsx
@@ -89,7 +89,7 @@ function ActivityBar({ activeTab, collapsed, onIconClick }: ActivityBarProps) {
   };
 
   return (
-    <div class="activity-bar">
+    <div class="activity-bar surface-chrome">
       <div class="activity-bar-group activity-bar-top">{topTabs.map(renderTab)}</div>
       <div class="activity-bar-group activity-bar-bottom">{bottomTabs.map(renderTab)}</div>
     </div>

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -424,6 +424,7 @@ h6 {
    horizontal padding so depth-0 entries line up under pane titles.
 
    Variants:
+     .row--tight     — collapses the chevron/icon/label gap (tree rows).
      .row--bleed     — negative inline margins so the hover background
                        extends to the pane edge.
      .row--selected  — accent-tinted "selected" background (used by tree).
@@ -2782,6 +2783,9 @@ canvas {
   align-items: center;
   gap: var(--cc-space-2);
 }
+/* Recent button — composes the .row base for the flex/cursor shell; adds the
+   recents-specific size (looser gap, symmetric padding, medium radius) plus the
+   <button> reset and the flex-fill within .recent-item. */
 .recent-row {
   flex: 1 1 auto;
   min-width: 0;
@@ -2789,17 +2793,14 @@ canvas {
   background: none;
   border: none;
   text-align: left;
-  display: flex;
-  align-items: center;
-  gap: var(--cc-space-5);
-  padding: var(--cc-space-3) var(--cc-space-4); /* 6px 8px — symmetric */
-  border-radius: var(--cc-radius-md);
-  cursor: pointer;
   color: inherit;
   font: inherit;
+  gap: var(--cc-space-5); /* 10px (base row gap is 4px) */
+  padding: var(--cc-space-3) var(--cc-space-4); /* 6px 8px (base is 4px 16px) */
+  border-radius: var(--cc-radius-md); /* base row radius is sm */
 }
 .recent-row:hover {
-  background: var(--cc-overlay-bg);
+  background: var(--cc-overlay-bg); /* a touch stronger than the base soft hover */
 }
 .recent-row-body {
   flex: 1 1 auto;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -471,6 +471,21 @@ h6 {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   LAYER-2 COMPONENTS — Cards
+   ═══════════════════════════════════════════════════════════════════════════
+   .card-overlay — the elevated panel surface shared by the two things that
+   float on a backdrop: the source-picker modal and the loading overlay. Each
+   adds its own layout (size, flex); this is just the shared surface.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.card-overlay {
+  background: var(--cc-bg-modal);
+  color: var(--cc-text-base);
+  border-radius: var(--cc-radius-lg);
+  box-shadow: var(--cc-shadow-lg);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    LAYER-2 COMPONENTS — Form inputs
    ═══════════════════════════════════════════════════════════════════════════
    .form-input — base text-input style (sidebar/controls/modal).
@@ -2613,16 +2628,14 @@ canvas {
   z-index: 1000;
 }
 
+/* Surface (bg + radius + shadow + color) from .card-overlay; this adds the
+   modal's own size + column layout. */
 .modal-card {
   width: 560px;
   max-width: 92vw;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  background: var(--cc-bg-modal);
-  color: var(--cc-text-base);
-  border-radius: var(--cc-radius-lg);
-  box-shadow: var(--cc-shadow-lg);
   overflow: hidden;
   font-family: inherit;
 }
@@ -2861,17 +2874,14 @@ canvas {
   margin-top: var(--cc-space-2);
 }
 
-/* Loading overlay */
+/* Loading overlay. Surface from .card-overlay; this adds the centered column
+   layout + padding + min width. */
 .loading-card {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--cc-space-7);
   padding: var(--cc-space-8) var(--cc-space-9);
-  background: var(--cc-bg-modal);
-  color: var(--cc-text-base);
-  border-radius: var(--cc-radius-lg);
-  box-shadow: var(--cc-shadow-lg);
   min-width: 260px;
 }
 .loading-spinner {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1484,25 +1484,25 @@ canvas {
  * The chevron is a Lucide icon (via the LucideIcon component) rather than a
  * unicode triangle — sharper at small sizes and currentColor-aware. */
 /* Style in .row + .row--bleed; this rule only hides the native disclosure
-   triangle (a custom .controls-section-chevron renders instead). */
+   triangle (a custom .chevron renders instead). */
 .controls-section > summary.controls-section-summary {
   list-style: none;
 }
 .controls-section > summary.controls-section-summary::-webkit-details-marker {
   display: none;
 }
-/* Section chevrons — consolidated rule shared with .theme-subgroup-chevron.
-   Width matches .tree-chevron so labels at all depths line up. */
-.controls-section-chevron,
-.theme-subgroup-chevron {
+/* Disclosure chevron — shared by the controls-section and theme-subgroup
+   <details> summaries. Width matches .tree-chevron so labels at all depths
+   line up. The open state is driven purely by the parent <details open>. */
+.chevron {
   width: 14px;
   height: 14px;
   flex-shrink: 0;
   color: var(--cc-text-secondary);
   transition: transform var(--cc-t-fast) ease;
 }
-.controls-section[open] > summary.controls-section-summary > .controls-section-chevron,
-.theme-subgroup-collapsible[open] > summary > .theme-subgroup-chevron {
+.controls-section[open] > summary > .chevron,
+.theme-subgroup-collapsible[open] > summary > .chevron {
   transform: rotate(90deg);
 }
 
@@ -1673,14 +1673,13 @@ canvas {
  * at every level of the panel. The <summary> carries
  * .row + .row--bleed + .text-label + .text-label--muted in the DOM. */
 /* This rule only hides the native disclosure triangle (a custom
-   .theme-subgroup-chevron renders instead). */
+   .chevron renders instead). */
 .theme-subgroup-collapsible > summary {
   list-style: none;
 }
 .theme-subgroup-collapsible > summary::-webkit-details-marker {
   display: none;
 }
-/* Chevron rule consolidated with .controls-section-chevron above. */
 
 /* Nested subgroups inside a collapsible parent (e.g. Buildings > Facade >
  * Geometry / Contrast / Window lighting). A small left padding indents

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -512,6 +512,24 @@ h6 {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   LAYER-2 COMPONENTS — Surfaces
+   ═══════════════════════════════════════════════════════════════════════════
+   Background-only utilities naming the app's three base fills. The consuming
+   element keeps its own borders + layout; this just gives the chrome/backdrop
+   fill a single source so it's set once per role, not per selector.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.surface-app {
+  background: var(--cc-bg-app);
+}
+.surface-chrome {
+  background: var(--cc-bg-chrome);
+}
+.surface-sidebar {
+  background: var(--cc-bg-sidebar);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    LAYER-2 COMPONENTS — Form inputs
    ═══════════════════════════════════════════════════════════════════════════
    .form-input — base text-input style (sidebar/controls/modal).
@@ -849,7 +867,6 @@ body {
   column-gap: var(--cc-space-2);
   height: 32px;
   padding: 0 var(--cc-space-4);
-  background: var(--cc-bg-chrome);
   border-bottom: 1px solid var(--cc-border-subtle);
   font-family: var(--cc-font-mono);
   font-size: var(--cc-font-md);
@@ -901,7 +918,6 @@ canvas {
      handle can mutate it without fighting the open/close transitions. */
   width: 0;
   height: 100%;
-  background: var(--cc-bg-sidebar);
   border-left: 1px solid var(--cc-border-subtle);
   /* No transition during drag (would lag the cursor); transition is added
      by .is-animating which we toggle around open/close. */
@@ -1078,10 +1094,7 @@ canvas {
 
 /* ── Editor body — fills the panel under the tab bar + breadcrumb ─────── */
 
-/* Layout in .pane; this rule only adds the app-bg fill behind the canvas. */
-.editor-body {
-  background: var(--cc-bg-app);
-}
+/* Layout in .pane; the app-bg fill comes from .surface-app on the body. */
 .editor-body > * {
   flex: 1 1 auto;
   min-height: 0;
@@ -1104,7 +1117,6 @@ canvas {
   gap: var(--cc-space-7);
   padding: 0 var(--cc-space-6);
   height: 24px;
-  background: var(--cc-bg-chrome);
   border-top: 1px solid var(--cc-track);
   font-family: var(--cc-font-mono);
   font-size: var(--cc-font-sm);
@@ -1308,7 +1320,6 @@ canvas {
   min-width: 280px;
   max-width: 600px;
   height: 100%;
-  background: var(--cc-bg-sidebar);
   border-right: 1px solid var(--cc-border-subtle);
   display: flex;
   flex-direction: row;
@@ -1350,7 +1361,6 @@ canvas {
 .activity-bar {
   width: 44px;
   flex-shrink: 0;
-  background: var(--cc-bg-chrome);
   border-right: 1px solid var(--cc-border-subtle);
   display: flex;
   flex-direction: column;
@@ -1641,7 +1651,6 @@ canvas {
   justify-content: space-between;
   gap: var(--cc-space-4);
   padding: var(--cc-space-5) var(--cc-space-7);
-  background: var(--cc-bg-sidebar);
   border-top: 1px solid var(--cc-border-subtle);
 }
 .controls-actions-left,
@@ -2484,7 +2493,6 @@ canvas {
   align-items: stretch;
   width: 100%;
   overflow: auto;
-  background: var(--cc-bg-app);
   font-family: var(--cc-font-mono);
   font-size: var(--cc-font-lg);
   line-height: 1.55;
@@ -2632,7 +2640,6 @@ canvas {
   align-items: center;
   justify-content: space-between;
   padding: var(--cc-space-5) var(--cc-space-6); /* 10px 12px */
-  background: var(--cc-bg-chrome); /* chrome titlebar — matches activity bar surface */
   border-bottom: 1px solid var(--cc-border-subtle);
   font-weight: var(--cc-fw-semibold);
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1244,31 +1244,6 @@ canvas {
   scrollbar-color: var(--cc-border-input) transparent;
 }
 
-/* ── Selected building glow (applied by interactions.js) ────────────────────── */
-
-/* interactions.js adds .building-selected to a canvas overlay element if one
-   exists, or manages selection state internally. This class is a hook for
-   future visual indicator enhancements (e.g., a pulsing dot or label). */
-.building-selected-indicator {
-  position: fixed;
-  bottom: 16px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--cc-accent-bg);
-  border: 1px solid var(--cc-accent-border);
-  border-radius: var(--cc-radius-pill);
-  padding: var(--cc-space-3) var(--cc-space-7);
-  font-size: var(--cc-font-lg);
-  color: var(--cc-accent-light);
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity var(--cc-t-base);
-}
-
-.building-selected-indicator.visible {
-  opacity: 1;
-}
-
 /* ── Hover tooltip ─────────────────────────────────────────────────────────── */
 
 #hover-tooltip {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -891,13 +891,10 @@ canvas {
   max-width: 70vw;
 }
 
-/* Drag-handle on the LEFT edge (mirror of the left sidebar's right edge).
-   6px hit zone half-on/half-off so it's easy to grab. */
-/* Sidebar resize handles — base rule shared with .sidebar-resize-handle.
-   Per-class lines below set which edge (left/right) the handle anchors to
-   and the z-index. */
-.sidebar-resize-handle,
-.sidebar-resize-handle-right {
+/* Sidebar resize handle — a 6px drag zone straddling the sidebar edge
+   (half on / half off) so it's easy to grab. The edge modifier sets which
+   side it anchors to and its stacking order. */
+.resize-handle {
   position: absolute;
   top: 0;
   width: 6px;
@@ -905,18 +902,16 @@ canvas {
   cursor: ew-resize;
   background: transparent;
 }
-.sidebar-resize-handle-right {
+.resize-handle--left {
   left: -3px;
   z-index: 101;
 }
-.sidebar-resize-handle {
+.resize-handle--right {
   right: -3px;
   z-index: 91;
 }
-.sidebar-resize-handle:hover,
-.sidebar-resize-handle.dragging,
-.sidebar-resize-handle-right:hover,
-.sidebar-resize-handle-right.dragging {
+.resize-handle:hover,
+.resize-handle.dragging {
   background: var(--cc-accent-bg-strong);
 }
 
@@ -1304,10 +1299,6 @@ canvas {
   display: none;
 }
 
-/* Drag-handle on the right edge. Thin so it doesn't steal real estate; the
- * 6px hit zone makes it easy to grab. */
-/* Resize handle rules consolidated with .sidebar-resize-handle-right above. */
-
 /* Collapsed: just the activity bar shows. This rule outranks the base
  * `#left-sidebar { width: var(--sidebar-width) }` by specificity (id+class),
  * so the dragged width is restored automatically on un-collapse — no need to
@@ -1317,7 +1308,7 @@ canvas {
   min-width: 44px;
 }
 #left-sidebar.is-collapsed > .pane,
-#left-sidebar.is-collapsed .sidebar-resize-handle {
+#left-sidebar.is-collapsed .resize-handle {
   display: none;
 }
 

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -473,16 +473,42 @@ h6 {
 /* ═══════════════════════════════════════════════════════════════════════════
    LAYER-2 COMPONENTS — Cards
    ═══════════════════════════════════════════════════════════════════════════
-   .card-overlay — the elevated panel surface shared by the two things that
-   float on a backdrop: the source-picker modal and the loading overlay. Each
-   adds its own layout (size, flex); this is just the shared surface.
+   Reusable boxed surfaces. Each owns its background + border + radius (+ shadow
+   / padding); the consuming selector adds only its own layout. The element
+   composes the card class with its layout class, e.g. `modal-error card-error`.
    ═══════════════════════════════════════════════════════════════════════════ */
 
+/* Elevated panel floating on a backdrop — the source-picker modal + the
+   loading overlay. */
 .card-overlay {
   background: var(--cc-bg-modal);
   color: var(--cc-text-base);
   border-radius: var(--cc-radius-lg);
   box-shadow: var(--cc-shadow-lg);
+}
+
+/* Error notice box (modal error banner). */
+.card-error {
+  background: var(--cc-error-bg);
+  border: 1px solid var(--cc-error-border);
+  border-radius: var(--cc-radius-md);
+  padding: var(--cc-space-4) var(--cc-space-5);
+}
+
+/* Accent-tinted info strip with a bottom rule (file-preview banner). */
+.card-banner {
+  background: var(--cc-accent-bg-soft);
+  border-bottom: 1px solid var(--cc-accent-bg);
+  padding: var(--cc-space-3) var(--cc-space-6);
+}
+
+/* Floating tooltip surface (the hover tooltip). */
+.card-tooltip {
+  background: var(--cc-bg-tooltip);
+  border: 1px solid var(--cc-border-tooltip);
+  border-radius: var(--cc-radius-sm);
+  padding: var(--cc-space-2) var(--cc-space-4);
+  box-shadow: var(--cc-shadow-md);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -1241,19 +1267,16 @@ canvas {
 
 /* ── Hover tooltip ─────────────────────────────────────────────────────────── */
 
+/* Surface (bg + border + radius + padding + shadow) from .card-tooltip; this
+   adds positioning + text styling. */
 #hover-tooltip {
   position: fixed;
-  background: var(--cc-bg-tooltip);
-  border: 1px solid var(--cc-border-tooltip);
   color: var(--cc-text-primary);
   font-size: var(--cc-font-md);
-  padding: var(--cc-space-2) var(--cc-space-4);
-  border-radius: var(--cc-radius-sm);
   pointer-events: none;
   z-index: 200;
   font-family: var(--cc-font-mono);
   white-space: nowrap;
-  box-shadow: var(--cc-shadow-md);
 }
 
 /* ── Street labels (rendered on canvas, these styles are for overlay fallback) ── */
@@ -2436,14 +2459,13 @@ canvas {
   height: 100%;
 }
 
+/* Surface (bg + bottom rule + padding) from .card-banner; this adds the row
+   layout + text styling. */
 .code-editor-banner {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
   gap: var(--cc-space-4);
-  padding: var(--cc-space-3) var(--cc-space-6);
-  background: var(--cc-accent-bg-soft);
-  border-bottom: 1px solid var(--cc-accent-bg);
   color: var(--cc-accent-light);
   font-family: var(--cc-font-sans);
   font-size: var(--cc-font-md);
@@ -2689,12 +2711,10 @@ canvas {
 /* Visual style consolidated in the .modal-field input rule near the top
    of the file (next to .form-input). */
 
+/* Surface (bg + border + radius + padding) from .card-error; this adds the
+   error text color + spacing below. */
 .modal-error {
-  background: var(--cc-error-bg);
-  border: 1px solid var(--cc-error-border);
   color: var(--cc-error-light);
-  padding: var(--cc-space-4) var(--cc-space-5);
-  border-radius: var(--cc-radius-md);
   margin-bottom: var(--cc-space-6);
   font-size: var(--cc-font-lg);
 }

--- a/app/src/views/ControlsPane/ActionsBar.tsx
+++ b/app/src/views/ControlsPane/ActionsBar.tsx
@@ -27,7 +27,7 @@ export function ActionsBar() {
   const canReset = anyResettable();
 
   return (
-    <div class="controls-actions">
+    <div class="controls-actions surface-sidebar">
       <div class="controls-actions-left">
         <button
           type="button"

--- a/app/src/views/FilePreviewPane.tsx
+++ b/app/src/views/FilePreviewPane.tsx
@@ -187,7 +187,7 @@ function CodeEditor({ text, file }: CodeEditorProps) {
   return (
     <div class="code-editor-shell">
       {(skipHighlight || skipGutter) && (
-        <div class="code-editor-banner">
+        <div class="code-editor-banner card-banner">
           <Info class="lucide-icon" />
           <span>{bannerText}</span>
         </div>

--- a/app/src/views/FilePreviewPane.tsx
+++ b/app/src/views/FilePreviewPane.tsx
@@ -192,7 +192,7 @@ function CodeEditor({ text, file }: CodeEditorProps) {
           <span>{bannerText}</span>
         </div>
       )}
-      <div class="code-editor">
+      <div class="code-editor surface-app">
         {!skipGutter && (
           <div class="code-editor-gutter">
             {Array.from({ length: lineCount }, (_, i) => (
@@ -293,7 +293,7 @@ export function FilePreviewPane({ state, onClose, onFocus }: FilePreviewPaneProp
       onFocus={file && typeof onFocus === 'function' ? () => onFocus(file) : undefined}
       focusTitle={`Focus the camera on this file (${KEY_BINDINGS.FOCUS_SELECTION.label})`}
       onClose={onClose}
-      bodyClass="editor-body"
+      bodyClass="editor-body surface-app"
     >
       {_previewBody(file)}
     </Pane>

--- a/app/src/views/SourcePicker.tsx
+++ b/app/src/views/SourcePicker.tsx
@@ -143,7 +143,7 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
           )}
         </div>
         <div class="modal-body">
-          {s.error && <div class="modal-error">{s.error}</div>}
+          {s.error && <div class="modal-error card-error">{s.error}</div>}
           <div class="modal-tabs">
             <button
               type="button"

--- a/app/src/views/SourcePicker.tsx
+++ b/app/src/views/SourcePicker.tsx
@@ -261,7 +261,7 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
                   ? 'Local repos are disabled. Restart codecity with CODECITY_ALLOW_LOCAL_REPOS=1 to load this.'
                   : '';
                 const rowClasses = [
-                  'recent-row',
+                  'row recent-row',
                   isActive && 'recent-row--active',
                   isDisabled && 'recent-row--disabled',
                 ]

--- a/app/src/views/SourcePicker.tsx
+++ b/app/src/views/SourcePicker.tsx
@@ -128,7 +128,12 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
         if (s.dismissible && e.target === e.currentTarget) onClose();
       }}
     >
-      <div class="modal-card card-overlay" role="dialog" aria-modal="true" aria-label="Open project">
+      <div
+        class="modal-card card-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Open project"
+      >
         <div class="modal-header surface-chrome">
           <span>Open project</span>
           {s.dismissible && (

--- a/app/src/views/SourcePicker.tsx
+++ b/app/src/views/SourcePicker.tsx
@@ -128,7 +128,7 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
         if (s.dismissible && e.target === e.currentTarget) onClose();
       }}
     >
-      <div class="modal-card" role="dialog" aria-modal="true" aria-label="Open project">
+      <div class="modal-card card-overlay" role="dialog" aria-modal="true" aria-label="Open project">
         <div class="modal-header">
           <span>Open project</span>
           {s.dismissible && (

--- a/app/src/views/SourcePicker.tsx
+++ b/app/src/views/SourcePicker.tsx
@@ -129,7 +129,7 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
       }}
     >
       <div class="modal-card card-overlay" role="dialog" aria-modal="true" aria-label="Open project">
-        <div class="modal-header">
+        <div class="modal-header surface-chrome">
           <span>Open project</span>
           {s.dismissible && (
             <button

--- a/app/tests/layout/rightSidebar.test.tsx
+++ b/app/tests/layout/rightSidebar.test.tsx
@@ -99,7 +99,7 @@ describe('RightSidebar', () => {
   });
 
   it('renders the resize handle on the inside (left) edge', () => {
-    const handle = container.querySelector('.sidebar-resize-handle-right');
+    const handle = container.querySelector('.resize-handle--left');
     expect(handle).not.toBeNull();
   });
 });


### PR DESCRIPTION
Finishes the half-done `ui-component-system.md` migration so every selector in `app/src/styles.css` composes from the shared token + component layers — no rule re-implements what a sibling already covers — leaving a clean, fully-layered file ready for the Phase-6 colocated split (Workstream B, separate).

## Key context: the file was already tokenized

The plan/spec were written against a pre-tokenization `styles.css`. The real file already feeds **every** `color`/`font`/`bg`/`radius`/`shadow` from `--cc-*` tokens, so the layering goal is met at the *value* level. That means the genuine remaining work was **structural DRY** (collapse sibling selectors that re-implement each other), not a value sweep — and several plan families (form-inputs, the Layer-3 colour/font sweep, `.text-faintest`) were already done or had nothing to consolidate. Decisions were made **DRY-minimal**: mint a shared class only where 2+ elements genuinely share it; don't create single-use classes.

## Structural consolidations
- **`Row` → `ThemeRow`** — the component renders `.theme-row`, not the `.row` utility; removed the naming collision (sole consumer: `Field.tsx`).
- **`.recent-row` composes `.row`** — dropped the duplicated flex/cursor shell.
- **`.card-overlay`** — the one real card share: `.modal-card` + `.loading-card`.
- **Deleted dead `.building-selected-indicator`** (no JS/TSX user).
- **`.chevron`** — unified the two disclosure chevrons (open state stays pure-CSS via parent `[open]`).
- **`.resize-handle` + `--left/--right`** — unified both sidebar handles; fixed the backwards names.

## Vocabulary pass (populates Workstream B's cross-cutting global partials)
- **`.card-error` / `.card-banner` / `.card-tooltip`** ← `.modal-error` / `.code-editor-banner` / `#hover-tooltip`.
- **`.surface-app` / `.surface-chrome` / `.surface-sidebar`** — bg-only utilities on the 9 genuine component surfaces (header, footer, activity-bar, modal-header, both sidebars, controls-actions, code-editor, editor-body). Per-element borders stay inline (header `border-subtle` vs footer `track` intentionally differ); control fills, root `html/body`/`canvas`, and generated markdown are left inline (not component surfaces).

## Verification
Every value copied verbatim from the old selectors — **no intended visual change** except one accepted shift: the recents list hover now fades ~0.1s (it inherits `.row`'s transition).

`tsc --noEmit` · `eslint src` · **2293/2293 vitest** green at every commit. The regression gate for CSS is a manual browser visual-diff (vitest/jsdom can't compute stylesheet CSS) — **pending reviewer eyeball** of: header/footer/sidebars/activity-bar backgrounds, source-picker modal + recents + error banner, loading overlay, file-preview banner + code editor, hover tooltip, section/subgroup chevrons, and both sidebar resize edges.

Does **not** start Workstream B (the Phase-6 file split). Also includes one unrelated one-line `TODO.md` addition (image tooltips should show image size, not line count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)