### PR TITLE
Phase 8: stale-reference sweep

### DIFF
--- a/app/src/city/components/buildings/color.ts
+++ b/app/src/city/components/buildings/color.ts
@@ -11,8 +11,8 @@
 // the file has existed in the repo. That drives grime + tilt + lit-window
 // glow color in the shader, independent of recent edits.
 //
-// Tunables come from BUILDINGS in config/building.ts. Tests
-// mutate the store via .setKey() in setup + restore in teardown.
+// Tunables come from BUILDINGS in state/stores/settings/buildings.ts. Tests
+// set the signals directly in setup + restore in teardown.
 
 import { BUILDINGS } from '@/state/stores/settings/buildings';
 import { NodeKind } from '@/types';

--- a/app/src/city/components/pathLine/renderer.ts
+++ b/app/src/city/components/pathLine/renderer.ts
@@ -193,10 +193,9 @@ export function createPathLineRenderer({
   // _updateHoverPathLine reads picker.hover.value + HOVER_PATH_LINE.value
   // internally — if we called it directly inside the selection effect, the
   // selection effect would also track hover/HOVER_PATH_LINE and fire on
-  // their changes (same anti-pattern as the coordinator over-tracking bug
-  // fixed in 924371c). untracked() lets the selection effect refresh the
+  // their changes. untracked() lets the selection effect refresh the
   // hover line on selection change (the hover line's "hide when hover ==
-  // selection" rule needs re-evaluation) WITHOUT becoming a hover/config
+  // selection" rule needs re-evaluation) WITHOUT becoming a hover/settings
   // subscriber.
   const _disposeSelectionEffect = effect(() => {
     void picker.selection.value;

--- a/app/src/city/components/trees/outline.ts
+++ b/app/src/city/components/trees/outline.ts
@@ -3,7 +3,7 @@
 //     around the hovered tree's canopy)
 //   • the shared tree selected outline mesh (rainbow-chasing silhouette)
 //
-// Mirrors scene/effects/outlineRenderer.ts but for tree canopies.
+// Mirrors buildings/outline.ts but for tree canopies.
 // Exactly two LineSegments2 meshes exist regardless of tree count;
 // transforms are snapped per frame to the 0-2 currently-active outlines.
 //

--- a/app/src/city/index.ts
+++ b/app/src/city/index.ts
@@ -1,5 +1,5 @@
 // city/index.ts — the city composer. createCity(canvas, manifest) folds the
-// scene/component construction and the rendering pipeline into one async
+// scene and component construction and the rendering pipeline into one async
 // factory, then drives the frame loop via startFrameLoop. Returns the handle
 // App.tsx / the City component consume.
 

--- a/app/src/city/interaction/picker.ts
+++ b/app/src/city/interaction/picker.ts
@@ -1,8 +1,7 @@
 // city/interaction/picker.ts — owns the raycaster + the hover and selection
 // state machine. State rides on @preact/signals so consumers
-// (outlineRenderer, pathLineRenderer, buildingFader, coordinator)
-// use the same `effect` / `.value` idiom they already use for every
-// config store.
+// (the outline, path-line, and building-fader renderers) use the same
+// `effect` / `.value` idiom they already use for every settings store.
 //
 // Public contract:
 //

--- a/app/src/city/layout/algorithm.ts
+++ b/app/src/city/layout/algorithm.ts
@@ -3,8 +3,8 @@
 //   Building: { x, y, w, d, h, color, file, orient }
 //   Street:   { x, y, w, d, label, dir }
 //
-// All tunables come from the nanostores under src/config/. Tests that
-// need different values mutate the stores via .setKey() in setup +
+// All tunables come from the settings stores under state/stores/settings/.
+// Tests that need different values set the signals directly in setup +
 // restore in teardown — keeps the production callsites argument-free.
 //
 // Layout works via a global-occupancy packer: each directory becomes a

--- a/app/src/city/types/renderOrders.ts
+++ b/app/src/city/types/renderOrders.ts
@@ -43,8 +43,8 @@ export const RENDER_ORDERS = {
   PARK_FOLIAGE: 10,
   // Tree outlines — must draw above PARK_FOLIAGE so the wireframe reads
   // on top of the canopy. Hover beneath selected so a tree that is both
-  // hovered and selected (rare; coordinator dedup already prevents it for
-  // buildings — see comments in outlineRenderer.ts) shows the selected
+  // hovered and selected (rare; the picker's hover/selection dedup already
+  // prevents it for buildings — see buildings/outline.ts) shows the selected
   // rainbow on top.
   HOVER_TREE_OUTLINE: 11,
   SELECTED_TREE_OUTLINE: 12,

--- a/app/src/city/utils/path.ts
+++ b/app/src/city/utils/path.ts
@@ -3,7 +3,7 @@
 
 // parentDirPath(p) — return the parent directory path for a manifest path.
 // Returns null for root ('.' / ''). Examples:
-//   "src/scene/colors.js" → "src/scene"
+//   "src/utils/path.ts" → "src/utils"
 //   "src"                 → "."
 //   "."                   → null
 export function parentDirPath(p: string | null | undefined): string | null {

--- a/app/src/city/utils/shaders/fogChunk.ts
+++ b/app/src/city/utils/shaders/fogChunk.ts
@@ -2,7 +2,7 @@
 // buildings, and any other shader that wants atmospheric depth.
 //
 // Height fog: dense near y=0, thinning with altitude. Driven by
-//   SCENE.FOG_* in @/config/view.js. Buildings and the island consume this.
+//   SCENE.FOG_* in @/state/stores/settings/scene.ts. Buildings and the island consume this.
 //
 // This module exports ONLY the GLSL strings. Each consumer wires its
 // own uniforms — we don't centralize uniform defaults here because

--- a/app/src/constants/lighting.ts
+++ b/app/src/constants/lighting.ts
@@ -1,7 +1,7 @@
 // constants/lighting.ts — Scene-level directional lighting. Not user-tunable
 // (no Settings control was ever exposed — the scene's sun is fixed in code), so
 // plain constants rather than a persisted store. Read by the building shader
-// (scene/components/buildings) and the tree vertex-shading bake, both via
+// (city/components/buildings) and the tree vertex-shading bake, both via
 // city/utils/shaders/sunDir.
 //
 // Sun direction is expressed in spherical coords (compass bearing, height)

--- a/app/src/constants/storage.ts
+++ b/app/src/constants/storage.ts
@@ -3,7 +3,7 @@
 // silently splitting state across two slots.
 //
 // Persistence prefix is shared across all keys so a one-shot grep on
-// `cc.` finds every codecity-owned localStorage entry. config/persist.ts
+// `cc.` finds every codecity-owned localStorage entry. state/persist.ts
 // adds its own per-store keys with the same prefix.
 
 export const STORAGE_PREFIX = 'cc.';

--- a/app/src/layout/AppFooter/AppFooter.tsx
+++ b/app/src/layout/AppFooter/AppFooter.tsx
@@ -261,7 +261,7 @@ export function AppFooter() {
     errorMessage: LAST_REBUILD_ERROR.value,
   };
 
-  // Selection — hover takes priority over selection (same rule as coordinator).
+  // Selection — hover takes priority over selection.
   // Reading SCENE_HANDLE.value establishes tracking so AppFooter re-renders
   // when the scene first becomes available (CenterPane mount). Then
   // picker.hover.value and picker.selection.value are tracked for fine-grained

--- a/app/src/state/settingsSchema.ts
+++ b/app/src/state/settingsSchema.ts
@@ -43,7 +43,7 @@ export enum FieldKind {
 
 /** What changing a field requires the scene to do. Drives settingsReactions.ts's
  *  rebuild/material-refresh signatures (auto-generated from this metadata):
- *   Refresh — applyTheme only (material/uniform update). The default.
+ *   Refresh — material/uniform update only (reactive effect, no rebuild). The default.
  *   Rebuild — full world applyManifest (structural/geometry/layout change).
  *   Live    — neither; read fresh per frame (e.g. gem/firefly animation) or
  *             driven elsewhere (e.g. live-update polling). */

--- a/app/src/state/stores/settings/scene.ts
+++ b/app/src/state/stores/settings/scene.ts
@@ -5,7 +5,7 @@
 // panel still groups it under "Ground sizing" via sections/scene.ts.
 //
 // Schema-driven (see state/schema). Sky/stars/fog are all material-
-// refresh (applyTheme); GROUND_BUFFER_PERCENT triggers a rebuild.
+// refresh; GROUND_BUFFER_PERCENT triggers a rebuild.
 
 import {
   settingSignal,

--- a/app/src/state/stores/settings/streets.ts
+++ b/app/src/state/stores/settings/streets.ts
@@ -3,7 +3,7 @@
 // lines (STREETS, schema-driven), plus how streets are sized + packed
 // (STREET_TIERS + STREET_LAYOUT, worker-threaded object stores).
 //
-// Asphalt + sidewalk + path-line fields are material-refresh (applyTheme);
+// Asphalt + sidewalk + path-line fields are material-refresh;
 // the label fields are rebuild-required (label textures bake at build time).
 // Each field states its own route — settingsReactions.ts derives its rebuild/refresh
 // signatures from that metadata (see state/schema).

--- a/app/src/three-augment.d.ts
+++ b/app/src/three-augment.d.ts
@@ -4,7 +4,7 @@
 // Augmenting Object3D's userData here means the rest of the codebase
 // reads typed fields without `as` casts at every call site.
 //
-// The shape lists every userData key currently stamped in scene/ and
+// The shape lists every userData key currently stamped in city/ and
 // views/. All optional — most meshes only set a subset relevant to their
 // kind (a building stamps {type, building, …}, a label stamps
 // {type, baseRotY, flipped, …}, etc).

--- a/app/src/types/building.ts
+++ b/app/src/types/building.ts
@@ -1,4 +1,4 @@
-// types/building.ts — pairs with config/building.ts (the tunables).
+// types/building.ts — pairs with state/stores/settings/buildings.ts (the tunables).
 // Defines the Building shape the layout step produces; the city renderer
 // (city/index.ts createCity) reads it to instantiate three.js meshes.
 

--- a/app/src/types/street.ts
+++ b/app/src/types/street.ts
@@ -1,4 +1,4 @@
-// types/street.ts — pairs with config/street.ts (the tunables).
+// types/street.ts — pairs with state/stores/settings/streets.ts (the tunables).
 // Defines the Street shape the layout step produces.
 
 import type { DirNode } from './manifest';

--- a/app/src/views/CommitPane/CommitPane.tsx
+++ b/app/src/views/CommitPane/CommitPane.tsx
@@ -10,9 +10,8 @@
 // inside the "N commits that day" row (next to the same-day text)
 // when a color is provided.
 //
-// API matches filePreviewPane's shape (build once, push selection in
-// via setCommit) so the coordinator can swap panes in the right
-// sidebar without churn.
+// A Preact function component reading a `state` signal prop (the selected
+// commit); RightSidebar swaps panes by switching which one it renders.
 
 import './CommitPane.css';
 import { useState, useEffect, useRef } from 'preact/hooks';

--- a/app/src/views/ControlsPane/ControlsPane.tsx
+++ b/app/src/views/ControlsPane/ControlsPane.tsx
@@ -12,8 +12,8 @@
 //
 // Per-row affordance: every input mutates a single in-memory draft
 // layer (state/settingsDrafts.ts). Save commits drafts to the real signals,
-// which triggers the existing reaction effects (applyTheme or
-// world.applyManifest). Discard clears drafts without touching
+// which triggers the existing reaction effects (a material-refresh or a
+// full applyManifest rebuild). Discard clears drafts without touching
 // signals. Section / collapsible-subgroup open state is intentionally
 // NOT persisted — the `collapsed` prop (driven by the sidebar's collapsed
 // state) collapses every <details> when the panel is hidden, so it always

--- a/app/src/views/FilePreviewPane/FilePreviewPane.tsx
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.tsx
@@ -1,8 +1,8 @@
 // views/FilePreviewPane.tsx — body content for the right sidebar.
 // Renders a file preview (image, video, audio, pdf, or syntax-highlighted
-// code) for whatever file the coordinator pushes in via the state signal.
-// Falls back to an empty-state hint when no file is pushed (or when a
-// directory is selected — directories aren't previewable here).
+// code) for whatever file is selected via the state signal. Falls back to
+// an empty-state hint when no file is selected (or when a directory is
+// selected — directories aren't previewable here).
 //
 // The pane renders a `.editor-body` body declaratively via JSX. It owns
 // nothing about the sidebar shell (resize, open/close, persisted width) —

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -3,9 +3,8 @@
 // counts and a sorted breakdown of every file extension in the
 // descendant subtree.
 //
-// API matches commitPane's shape (build once, push selection via
-// setDirectory) so the coordinator can swap panes in the right sidebar
-// without churn.
+// A Preact function component reading a `state` signal prop (the selected
+// directory); RightSidebar swaps panes by switching which one it renders.
 
 import './StreetPane.css';
 import type { ReadonlySignal } from '@preact/signals';

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -4,7 +4,7 @@ declare module '*.css';
 
 // ?raw imports — Vite's built-in raw-text loader returns the file contents
 // as a plain string. TypeScript doesn't know about this query suffix, so we
-// declare it here. Used by app/scene/instanced/buildings.ts for GLSL shaders.
+// declare it here. Used across city/ for GLSL shader sources (buildings, island, footprint, ad-panels).
 declare module '*.glsl?raw' {
   const src: string;
   export default src;


### PR DESCRIPTION
Closes **Phase 8** of the Preact-migration spec (`2026-05-30-frontend-framework-preact-design.md`) — the final phase. **Phases 1–8 are now all complete.**

## What changed

20 stale comments across 23 files referenced things deleted or renamed across the migration + the CSS finish/colocate:
- `coordinator` (deleted Phase 4) → panes self-subscribe to signals
- `applyTheme` (deleted) → material refresh is a reactive effect
- `nanostores` / `.setKey()` → `@preact/signals` (`.value =`)
- `scene/` → `city/` · `config/` → `state/stores/settings/` · `config/persist` → `state/persist`
- the panes' old "build once, `setDirectory`/`setCommit` push" API → signal props (how they actually work now)

**Comment-only — no code changed** (net −4 LOC); the diff is provably all comment lines, so `tsc`/lint/tests are unaffected.

> A grep-based "stale-ref guard" script was considered but dropped — a hardcoded deny-list of deleted symbols goes stale, throws false positives as words get reused, and becomes a maintenance burden of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)