### PR TITLE
feat(street): composition-forward Street pane (#80)

### DIFF
--- a/api/models/manifest.py
+++ b/api/models/manifest.py
@@ -78,6 +78,8 @@ class DirNode(BaseModel):
     descendants_file_count: int
     descendants_dir_count: int
     descendants_size: int
+    descendants_created_min: Optional[str]
+    descendants_modified_max: Optional[str]
     descendants_ext_breakdown: list[ExtBreakdownEntry]
 
 

--- a/api/models/manifest.py
+++ b/api/models/manifest.py
@@ -60,7 +60,7 @@ class FileNode(BaseModel):
 
 
 class ExtBreakdownEntry(BaseModel):
-    ext: str
+    ext: str | None
     count: int
     size: int
 

--- a/api/services/cache.py
+++ b/api/services/cache.py
@@ -66,7 +66,9 @@ class FileEntry(TypedDict):
 _FILE_CACHE_VERSION = 1
 _GIT_HISTORY_CACHE_VERSION = 12  # v12: dates UTC-normalized (file maps + commit days)
 _MANIFEST_SCHEMA_VERSION = (
-    12  # v12: per-dir descendants_created_min / descendants_modified_max
+    # v12: per-dir descendants_created_min / descendants_modified_max
+    # v13: ext_breakdown `ext` is null (was "(none)") for extensionless files
+    13
 )
 # Composite: invalidates when EITHER the manifest schema OR the git-history
 # shape changes. Stored as a string in the cache file's `version` field.

--- a/api/services/cache.py
+++ b/api/services/cache.py
@@ -66,7 +66,7 @@ class FileEntry(TypedDict):
 _FILE_CACHE_VERSION = 1
 _GIT_HISTORY_CACHE_VERSION = 12  # v12: dates UTC-normalized (file maps + commit days)
 _MANIFEST_SCHEMA_VERSION = (
-    11  # v11: dir leaders by direct children (max/minChildrenDir) + totals
+    12  # v12: per-dir descendants_created_min / descendants_modified_max
 )
 # Composite: invalidates when EITHER the manifest schema OR the git-history
 # shape changes. Stored as a string in the cache file's `version` field.

--- a/api/services/date_utils.py
+++ b/api/services/date_utils.py
@@ -1,0 +1,26 @@
+"""Small date-string helpers shared across the scan/rollup code.
+
+Dates flow through the manifest as ISO strings, which are lexically
+comparable (earlier date → smaller string), so min/max reduce to a string
+compare that also tolerates missing (None) operands.
+"""
+
+from __future__ import annotations
+
+
+def min_iso(a: str | None, b: str | None) -> str | None:
+    """Lexically-smaller (earliest) of two ISO date strings, ignoring None."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if a < b else b
+
+
+def max_iso(a: str | None, b: str | None) -> str | None:
+    """Lexically-larger (latest) of two ISO date strings, ignoring None."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if a > b else b

--- a/api/services/manifest_types.py
+++ b/api/services/manifest_types.py
@@ -68,11 +68,11 @@ class FileNode(TypedDict):
 
 class ExtBreakdownEntry(TypedDict):
     """One file-extension bucket within a directory's descendant breakdown.
-    `ext` is the lowercase extension (e.g. ".ts") or "(none)" for files with
-    no extension. Computed once during the tree walk so the UI's street view
+    `ext` is the lowercase extension (e.g. ".ts"), or null for files with no
+    extension. Computed once during the tree walk so the UI's street view
     reads it instead of re-walking the subtree on every selection."""
 
-    ext: str
+    ext: str | None
     count: int
     size: int
 

--- a/api/services/manifest_types.py
+++ b/api/services/manifest_types.py
@@ -92,6 +92,10 @@ class DirNode(TypedDict):
     descendants_file_count: int
     descendants_dir_count: int
     descendants_size: int
+    # Oldest created / newest modified date over ALL descendant files (ISO
+    # strings, lexically comparable). Both None for a directory with no files.
+    descendants_created_min: str | None
+    descendants_modified_max: str | None
     # Per-extension counts/sizes aggregated over ALL descendant files,
     # sorted by count desc (ext asc tiebreak). Baked here so the street
     # view reads it directly. Empty list for directories with no files.

--- a/api/services/scan.py
+++ b/api/services/scan.py
@@ -987,6 +987,8 @@ class _DirFrame:
         "descendants_file_count",
         "descendants_dir_count",
         "descendants_size",
+        "descendants_created_min",
+        "descendants_modified_max",
         "ext_breakdown",
     )
 
@@ -1008,9 +1010,31 @@ class _DirFrame:
         self.descendants_file_count = 0
         self.descendants_dir_count = 0
         self.descendants_size = 0
+        # Oldest created / newest modified date over all descendant files (ISO
+        # strings, lexically comparable). None until the first file is seen.
+        self.descendants_created_min: str | None = None
+        self.descendants_modified_max: str | None = None
         # ext (lowercase, "(none)" if absent) -> [count, total_size], over
         # all descendant files. Merged up from child frames as they pop.
         self.ext_breakdown: dict[str, list[int]] = {}
+
+
+def _min_iso(a: str | None, b: str | None) -> str | None:
+    """Lexically-smaller (earliest) of two ISO date strings, ignoring None."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if a < b else b
+
+
+def _max_iso(a: str | None, b: str | None) -> str | None:
+    """Lexically-larger (latest) of two ISO date strings, ignoring None."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if a > b else b
 
 
 def _build_tree(
@@ -1062,6 +1086,12 @@ def _build_tree(
                 top.descendants_count += 1
                 top.descendants_file_count += 1
                 top.descendants_size += node["size"]
+                top.descendants_created_min = _min_iso(
+                    top.descendants_created_min, node["created"]
+                )
+                top.descendants_modified_max = _max_iso(
+                    top.descendants_modified_max, node["modified"]
+                )
                 ext = (node["extension"] or "(none)").lower()
                 bucket = top.ext_breakdown.get(ext)
                 if bucket is None:
@@ -1099,6 +1129,8 @@ def _build_tree(
             "descendants_file_count": finished.descendants_file_count,
             "descendants_dir_count": finished.descendants_dir_count,
             "descendants_size": finished.descendants_size,
+            "descendants_created_min": finished.descendants_created_min,
+            "descendants_modified_max": finished.descendants_modified_max,
             "descendants_ext_breakdown": ext_breakdown_out,
             "children": children,
         }
@@ -1110,6 +1142,12 @@ def _build_tree(
         parent.descendants_file_count += node_out["descendants_file_count"]
         parent.descendants_dir_count += 1 + node_out["descendants_dir_count"]
         parent.descendants_size += node_out["descendants_size"]
+        parent.descendants_created_min = _min_iso(
+            parent.descendants_created_min, node_out["descendants_created_min"]
+        )
+        parent.descendants_modified_max = _max_iso(
+            parent.descendants_modified_max, node_out["descendants_modified_max"]
+        )
         # Merge the child's per-extension breakdown up into the parent.
         for ext, (cnt, size) in finished.ext_breakdown.items():
             bucket = parent.ext_breakdown.get(ext)

--- a/api/services/scan.py
+++ b/api/services/scan.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Iterator
 
 from api.config import quiet
 from api.models.events import ScanEvent
+from .date_utils import max_iso, min_iso
 from .cache import (
     FileEntry,
     cache_load_files,
@@ -1014,27 +1015,9 @@ class _DirFrame:
         # strings, lexically comparable). None until the first file is seen.
         self.descendants_created_min: str | None = None
         self.descendants_modified_max: str | None = None
-        # ext (lowercase, "(none)" if absent) -> [count, total_size], over
-        # all descendant files. Merged up from child frames as they pop.
-        self.ext_breakdown: dict[str, list[int]] = {}
-
-
-def _min_iso(a: str | None, b: str | None) -> str | None:
-    """Lexically-smaller (earliest) of two ISO date strings, ignoring None."""
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return a if a < b else b
-
-
-def _max_iso(a: str | None, b: str | None) -> str | None:
-    """Lexically-larger (latest) of two ISO date strings, ignoring None."""
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return a if a > b else b
+        # ext (lowercase, None for extensionless files) -> [count, total_size],
+        # over all descendant files. Merged up from child frames as they pop.
+        self.ext_breakdown: dict[str | None, list[int]] = {}
 
 
 def _build_tree(
@@ -1086,13 +1069,14 @@ def _build_tree(
                 top.descendants_count += 1
                 top.descendants_file_count += 1
                 top.descendants_size += node["size"]
-                top.descendants_created_min = _min_iso(
+                top.descendants_created_min = min_iso(
                     top.descendants_created_min, node["created"]
                 )
-                top.descendants_modified_max = _max_iso(
+                top.descendants_modified_max = max_iso(
                     top.descendants_modified_max, node["modified"]
                 )
-                ext = (node["extension"] or "(none)").lower()
+                raw_ext = node["extension"]
+                ext = raw_ext.lower() if raw_ext else None
                 bucket = top.ext_breakdown.get(ext)
                 if bucket is None:
                     top.ext_breakdown[ext] = [1, node["size"]]
@@ -1110,11 +1094,13 @@ def _build_tree(
         # (root) or attach to the parent.
         finished = stack.pop()
         children: list[FileNode | DirNode] = [*finished.files, *finished.subdirs]
-        # Sort by count desc, then ext asc for deterministic output.
+        # Sort by count desc, then ext asc for deterministic output; the
+        # extensionless (None) bucket sorts last within its count tier.
         ext_breakdown_out: list[ExtBreakdownEntry] = [
             {"ext": ext, "count": cnt, "size": size}
             for ext, (cnt, size) in sorted(
-                finished.ext_breakdown.items(), key=lambda kv: (-kv[1][0], kv[0])
+                finished.ext_breakdown.items(),
+                key=lambda kv: (-kv[1][0], kv[0] is None, kv[0] or ""),
             )
         ]
         node_out: DirNode = {
@@ -1142,10 +1128,10 @@ def _build_tree(
         parent.descendants_file_count += node_out["descendants_file_count"]
         parent.descendants_dir_count += 1 + node_out["descendants_dir_count"]
         parent.descendants_size += node_out["descendants_size"]
-        parent.descendants_created_min = _min_iso(
+        parent.descendants_created_min = min_iso(
             parent.descendants_created_min, node_out["descendants_created_min"]
         )
-        parent.descendants_modified_max = _max_iso(
+        parent.descendants_modified_max = max_iso(
             parent.descendants_modified_max, node_out["descendants_modified_max"]
         )
         # Merge the child's per-extension breakdown up into the parent.

--- a/api/tests/test_date_utils.py
+++ b/api/tests/test_date_utils.py
@@ -1,0 +1,31 @@
+"""min_iso / max_iso: earliest/latest ISO string, tolerating None."""
+
+from __future__ import annotations
+
+import unittest
+
+from api.services.date_utils import max_iso, min_iso
+
+
+class DateUtilTests(unittest.TestCase):
+    def test_min_iso_picks_earliest(self) -> None:
+        self.assertEqual(min_iso("2024-03-01", "2026-06-01"), "2024-03-01")
+        self.assertEqual(min_iso("2026-06-01", "2024-03-01"), "2024-03-01")
+
+    def test_max_iso_picks_latest(self) -> None:
+        self.assertEqual(max_iso("2024-03-01", "2026-06-01"), "2026-06-01")
+        self.assertEqual(max_iso("2026-06-01", "2024-03-01"), "2026-06-01")
+
+    def test_none_operands_are_ignored(self) -> None:
+        self.assertEqual(min_iso(None, "2024-03-01"), "2024-03-01")
+        self.assertEqual(min_iso("2024-03-01", None), "2024-03-01")
+        self.assertEqual(max_iso(None, "2026-06-01"), "2026-06-01")
+        self.assertEqual(max_iso("2026-06-01", None), "2026-06-01")
+
+    def test_both_none_returns_none(self) -> None:
+        self.assertIsNone(min_iso(None, None))
+        self.assertIsNone(max_iso(None, None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -93,6 +93,8 @@ class ModelTests(unittest.TestCase):
                 "descendants_file_count": 0,
                 "descendants_dir_count": 0,
                 "descendants_size": 0,
+                "descendants_created_min": None,
+                "descendants_modified_max": None,
                 "descendants_ext_breakdown": [],
             },
             repo={

--- a/api/tests/test_scan.py
+++ b/api/tests/test_scan.py
@@ -412,6 +412,22 @@ class ScanTreeIntegrationTests(_CacheRedirectMixin, unittest.TestCase):
                 sub["descendants_file_count"],
             )
 
+    def test_descendant_date_range_matches_repo_ranges(self):
+        m = _final_manifest(str(FIXTURE))
+        tree = m["tree"]
+        # The root dir's oldest-created / newest-modified span the whole repo, so
+        # they match the independently-computed repo-wide dateRanges.
+        self.assertIsNotNone(tree["descendants_created_min"])
+        self.assertIsNotNone(tree["descendants_modified_max"])
+        self.assertEqual(tree["descendants_created_min"], m["dateRanges"]["minCreated"])
+        self.assertEqual(
+            tree["descendants_modified_max"], m["dateRanges"]["maxModified"]
+        )
+        # Every file's created <= its modified, so the min/max span is ordered.
+        self.assertLessEqual(
+            tree["descendants_created_min"], tree["descendants_modified_max"]
+        )
+
     def test_busyness_present_in_manifest(self):
         m = _final_manifest(str(FIXTURE))
         b = m["busyness"]

--- a/api/tests/test_scan.py
+++ b/api/tests/test_scan.py
@@ -412,6 +412,24 @@ class ScanTreeIntegrationTests(_CacheRedirectMixin, unittest.TestCase):
                 sub["descendants_file_count"],
             )
 
+    def test_ext_breakdown_extensionless_files_use_null(self):
+        # Extensionless files bucket under a null `ext` (not a "(none)"
+        # sentinel string), so the UI can branch on null instead of a
+        # magic value.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            (root / "LICENSE").write_text("mit")
+            (root / "main.py").write_text("print()")
+            _commit_all(root)
+
+            m = _final_manifest(str(root))
+            breakdown = m["tree"]["descendants_ext_breakdown"]
+            exts = {e["ext"] for e in breakdown}
+            self.assertIn(None, exts)
+            self.assertNotIn("(none)", exts)
+            self.assertIn(".py", exts)
+
     def test_descendant_date_range_matches_repo_ranges(self):
         m = _final_manifest(str(FIXTURE))
         tree = m["tree"]

--- a/app/src/city/components/buildings/color.ts
+++ b/app/src/city/components/buildings/color.ts
@@ -59,6 +59,22 @@ export function getHue(extension: string, palette: Record<string, number>): numb
   return Math.abs(hash) % 360;
 }
 
+/**
+ * The badge/chip fill color for a file extension: the extension's hue at the
+ * ExtensionBadge's fixed saturation/lightness (`hsl(hue, 60%, 35%)`, matching
+ * its CSS `hsl(var(--badge-hue), 60%, 35%)`). Used wherever an ext is painted
+ * as a solid swatch — badges, composition bars, legend chips — so they all
+ * track one another. `null`/'' (extensionless) hues off '' like the dir chip.
+ *
+ * @param {string|null} extension - File extension including the dot (".ts"), or
+ *                                   null/'' for extensionless files.
+ * @param {Object} palette         - Map of extension → hue.
+ * @returns {string} CSS HSL string, e.g. "hsl(215, 60%, 35%)".
+ */
+export function extHueColor(extension: string | null, palette: Record<string, number>): string {
+  return `hsl(${getHue(extension ?? '', palette)}, 60%, 35%)`;
+}
+
 // ── Saturation ────────────────────────────────────────────────────────────────
 
 /**

--- a/app/src/city/components/buildings/fader.ts
+++ b/app/src/city/components/buildings/fader.ts
@@ -21,6 +21,7 @@ import type { BuildingsConfig } from '@/state/stores/settings/buildings';
 import { FadeDetail, NodeKind } from '@/types';
 import type { DirNode, FileNode, PickTarget } from '@/types';
 import { parentDirPath } from '@/city/utils/path';
+import { ROOT_PATH } from '@/constants/manifest';
 import type { CellTile } from './cellTile';
 import type { InstancedAdPanels } from './adPanels';
 import type { createPicker } from '@/city/interaction/picker';
@@ -50,9 +51,9 @@ interface TierResult {
 function _tierLevelFor(file: FileNode | null, dir: DirNode): 1 | 2 | 3 | 4 {
   if (!file?.path || !dir || dir.path == null) return 4;
   let parent = parentDirPath(file.path);
-  if (parent == null) parent = '.';
-  const ap = parent === '.' || parent === '' ? [] : parent.split('/');
-  const dp = dir.path === '.' || dir.path === '' ? [] : dir.path.split('/');
+  if (parent == null) parent = ROOT_PATH;
+  const ap = parent === ROOT_PATH ? [] : parent.split('/');
+  const dp = dir.path === ROOT_PATH ? [] : dir.path.split('/');
   let lca = 0;
   while (lca < ap.length && lca < dp.length && ap[lca] === dp[lca]) lca++;
   const distance = ap.length - lca + (dp.length - lca);

--- a/app/src/city/interaction/tooltipText.ts
+++ b/app/src/city/interaction/tooltipText.ts
@@ -8,15 +8,15 @@
 import { NodeKind } from '@/types';
 import type { PickTarget } from '@/types';
 import { formatRelativeAge } from '@/utils/dates';
+import { ROOT_PATH } from '@/constants/manifest';
 
 // Prepend the root directory name (with a leading slash) to a manifest-
 // relative path so the tooltip reads as an absolute-looking path (e.g.
-// "/codecity/app/main.ts" rather than "app/main.ts"). The manifest uses '.'
-// as the root directory's own path; that sentinel is treated the same as
-// empty — we don't render "codecity/.".
+// "/codecity/app/main.ts" rather than "app/main.ts"). The root's own path is
+// ROOT_PATH — we render just "/codecity", not "codecity/.".
 function withRoot(relPath: string, rootName: string | null): string {
   if (!rootName) return relPath || '';
-  if (!relPath || relPath === '.') return `/${rootName}`;
+  if (!relPath || relPath === ROOT_PATH) return `/${rootName}`;
   return `/${rootName}/${relPath}`;
 }
 

--- a/app/src/city/utils/path.ts
+++ b/app/src/city/utils/path.ts
@@ -1,13 +1,15 @@
 // city/utils/path.ts — Generic manifest-path string helper. No DOM, no
 // Three.js scene access — just data → data.
 
+import { ROOT_PATH } from '@/constants/manifest';
+
 // parentDirPath(p) — return the parent directory path for a manifest path.
-// Returns null for root ('.' / ''). Examples:
+// Returns null for root (ROOT_PATH / empty). Examples:
 //   "src/utils/path.ts" → "src/utils"
 //   "src"                 → "."
 //   "."                   → null
 export function parentDirPath(p: string | null | undefined): string | null {
-  if (!p || p === '.' || p === '') return null;
+  if (!p || p === ROOT_PATH) return null;
   const idx = p.lastIndexOf('/');
-  return idx >= 0 ? p.slice(0, idx) : '.';
+  return idx >= 0 ? p.slice(0, idx) : ROOT_PATH;
 }

--- a/app/src/components/PathBreadcrumbs/PathBreadcrumbs.tsx
+++ b/app/src/components/PathBreadcrumbs/PathBreadcrumbs.tsx
@@ -10,6 +10,7 @@ import { KEY_BINDINGS } from '@/constants/keyboard';
 import { ExtensionBadge } from '@/components/Badge/Badge';
 import { CopyButton } from '@/components/CopyButton/CopyButton';
 import { useMiddleEllipsis } from '@/hooks/useMiddleEllipsis';
+import { buildPathCrumbs } from '@/utils/pathCrumbs';
 
 export interface PathBreadcrumbsProps {
   /** Selected path relative to the project root. */
@@ -42,15 +43,7 @@ export function PathBreadcrumbs({
   );
 
   const isFileSel = !isDir;
-  // The root directory has no relative path to walk — show the repo label as a
-  // single crumb (clicking re-selects root) instead of a bare "." segment.
-  const isRoot = isDir && (path === rootPath || path === '.');
-  const crumbs: { label: string; segPath: string }[] = isRoot
-    ? [{ label: rootLabel, segPath: rootPath }]
-    : path
-        .split('/')
-        .filter(Boolean)
-        .map((seg, i, all) => ({ label: seg, segPath: all.slice(0, i + 1).join('/') }));
+  const { isRoot, crumbs } = buildPathCrumbs(path, { isDir, rootLabel, rootPath });
   const focusTitle = `Focus camera on selection (${KEY_BINDINGS.FOCUS_SELECTION.label})`;
 
   return (

--- a/app/src/components/PathBreadcrumbs/PathBreadcrumbs.tsx
+++ b/app/src/components/PathBreadcrumbs/PathBreadcrumbs.tsx
@@ -28,6 +28,7 @@ export function PathBreadcrumbs({
   extension,
   isDir,
   rootLabel,
+  rootPath,
   onSegmentClick,
   onFocus,
 }: PathBreadcrumbsProps) {
@@ -41,8 +42,15 @@ export function PathBreadcrumbs({
   );
 
   const isFileSel = !isDir;
-  const segs = path.split('/').filter(Boolean);
-  let acc = '';
+  // The root directory has no relative path to walk — show the repo label as a
+  // single crumb (clicking re-selects root) instead of a bare "." segment.
+  const isRoot = isDir && (path === rootPath || path === '.');
+  const crumbs: { label: string; segPath: string }[] = isRoot
+    ? [{ label: rootLabel, segPath: rootPath }]
+    : path
+        .split('/')
+        .filter(Boolean)
+        .map((seg, i, all) => ({ label: seg, segPath: all.slice(0, i + 1).join('/') }));
   const focusTitle = `Focus camera on selection (${KEY_BINDINGS.FOCUS_SELECTION.label})`;
 
   return (
@@ -59,11 +67,13 @@ export function PathBreadcrumbs({
         </button>
       )}
       <ExtensionBadge extension={isFileSel ? (extension ?? null) : null} isDir={!isFileSel} />
-      <div ref={crumbsRef} class="app-header-crumbs" title={`${rootLabel}/${path}`}>
-        {segs.map((seg, i) => {
-          acc = acc ? `${acc}/${seg}` : seg;
-          const segPath = acc;
-          const isLeaf = i === segs.length - 1;
+      <div
+        ref={crumbsRef}
+        class="app-header-crumbs"
+        title={isRoot ? rootLabel : `${rootLabel}/${path}`}
+      >
+        {crumbs.map((crumb, i) => {
+          const isLeaf = i === crumbs.length - 1;
           return (
             <Fragment key={`seg-${i}`}>
               {i > 0 && <span class="app-header-sep">›</span>}
@@ -71,16 +81,16 @@ export function PathBreadcrumbs({
                 type="button"
                 class={`btn-icon btn-icon--text btn-icon--no-drag app-header-seg${isLeaf ? ' is-leaf' : ''}`}
                 onClick={() => {
-                  if (onSegmentClick) onSegmentClick(segPath);
+                  if (onSegmentClick) onSegmentClick(crumb.segPath);
                 }}
               >
-                {seg}
+                {crumb.label}
               </button>
             </Fragment>
           );
         })}
       </div>
-      <CopyButton text={path} />
+      <CopyButton text={isRoot ? rootPath : path} />
     </>
   );
 }

--- a/app/src/constants/manifest.ts
+++ b/app/src/constants/manifest.ts
@@ -52,6 +52,8 @@ export const EMPTY_MANIFEST: Manifest = {
     descendants_file_count: 0,
     descendants_dir_count: 0,
     descendants_size: 0,
+    descendants_created_min: null,
+    descendants_modified_max: null,
     descendants_ext_breakdown: [],
   },
   repo: {

--- a/app/src/constants/manifest.ts
+++ b/app/src/constants/manifest.ts
@@ -5,6 +5,14 @@
 import { NodeKind } from '../types';
 import type { Manifest, RepoStats } from '../types';
 
+// The manifest's root directory carries this as its `path` — the POSIX
+// "current directory" token, since every node path is repo-relative (the
+// absolute path lives in `fullPath`). Children join off it as `app`,
+// `app/src`, … with no leading slash. It's the single root representation
+// across real scans AND the empty sentinel below, so `path === ROOT_PATH`
+// reliably means "this is the root".
+export const ROOT_PATH = '.';
+
 export const EMPTY_REPO_STATS: RepoStats = {
   lineCountRange: { min: 0, max: 0 },
   byteSizeRange: { min: 0, max: 0 },
@@ -42,7 +50,7 @@ export const EMPTY_MANIFEST: Manifest = {
   tree: {
     name: '',
     type: NodeKind.Directory,
-    path: '',
+    path: ROOT_PATH,
     fullPath: '',
     children: [],
     children_count: 0,

--- a/app/src/layout/AppHeader/AppHeader.tsx
+++ b/app/src/layout/AppHeader/AppHeader.tsx
@@ -58,7 +58,10 @@ export function AppHeader({
     const node = isDir ? pickerSel.dir : pickerSel.file;
     const path = node.path || node.fullPath || node.name || '';
     const extension = pickerSel.kind === NodeKind.File ? pickerSel.file.extension || '' : undefined;
-    if (path && path !== rootPath) {
+    // Show the breadcrumb for any selection with a path — including root (a
+    // selected dir whose path equals rootPath), which PathBreadcrumbs renders
+    // as the repo label.
+    if (path && (isDir || path !== rootPath)) {
       title = (
         <PathBreadcrumbs
           path={path}

--- a/app/src/layout/AppHeader/AppHeader.tsx
+++ b/app/src/layout/AppHeader/AppHeader.tsx
@@ -61,7 +61,7 @@ export function AppHeader({
     // Show the breadcrumb for any selection with a path — including root (a
     // selected dir whose path equals rootPath), which PathBreadcrumbs renders
     // as the repo label.
-    if (path && (isDir || path !== rootPath)) {
+    if (path) {
       title = (
         <PathBreadcrumbs
           path={path}

--- a/app/src/layout/AppHeader/AppHeader.tsx
+++ b/app/src/layout/AppHeader/AppHeader.tsx
@@ -12,6 +12,7 @@ import './AppHeader.css';
 import type { ComponentChildren } from 'preact';
 import { SCENE_HANDLE } from '@/state/stores/scene';
 import { MANIFEST } from '@/state/stores/manifest';
+import { ROOT_PATH } from '@/constants/manifest';
 import { SOURCE_INFO } from '@/state/stores/source';
 import { openSourcePicker } from '@/state/stores/ui';
 import { NodeKind, type Manifest } from '@/types';
@@ -44,7 +45,7 @@ export function AppHeader({
   // Root path off the canonical MANIFEST signal. peek() so the header doesn't
   // gain a redundant subscription — it already re-renders on every manifest
   // change via SOURCE_INFO (a computed off MANIFEST).
-  const rootPath = (MANIFEST.peek() as Manifest)?.tree?.path ?? '';
+  const rootPath = (MANIFEST.peek() as Manifest)?.tree?.path ?? ROOT_PATH;
 
   // Build the title-slot content from the current selection. Null/root-only
   // selections render nothing.

--- a/app/src/types/manifest.generated.ts
+++ b/app/src/types/manifest.generated.ts
@@ -329,6 +329,10 @@ export interface components {
             descendants_dir_count: number;
             /** Descendants Size */
             descendants_size: number;
+            /** Descendants Created Min */
+            descendants_created_min: string | null;
+            /** Descendants Modified Max */
+            descendants_modified_max: string | null;
             /** Descendants Ext Breakdown */
             descendants_ext_breakdown: components["schemas"]["ExtBreakdownEntry"][];
         };

--- a/app/src/types/manifest.generated.ts
+++ b/app/src/types/manifest.generated.ts
@@ -347,7 +347,7 @@ export interface components {
         /** ExtBreakdownEntry */
         ExtBreakdownEntry: {
             /** Ext */
-            ext: string;
+            ext: string | null;
             /** Count */
             count: number;
             /** Size */

--- a/app/src/types/manifest.ts
+++ b/app/src/types/manifest.ts
@@ -51,12 +51,12 @@ export interface FileNode {
 
 /**
  * One file-extension bucket in a directory's descendant breakdown. `ext` is
- * the lowercase extension (".ts") or "(none)" for extensionless files.
+ * the lowercase extension (".ts"), or null for extensionless files.
  * Computed once on the backend during the tree walk (see api/scan.py); the
  * street view reads it instead of re-walking the subtree on each selection.
  */
 export interface ExtBreakdownEntry {
-  ext: string;
+  ext: string | null;
   count: number;
   size: number;
 }

--- a/app/src/types/manifest.ts
+++ b/app/src/types/manifest.ts
@@ -74,6 +74,11 @@ export interface DirNode {
   descendants_file_count: number;
   descendants_dir_count: number;
   descendants_size: number;
+  /** Oldest created / newest modified date (ISO) over all descendant files.
+   *  Both null for a directory with no files. Computed once on the backend
+   *  (api/services/scan.py) so the street view reads it instead of walking. */
+  descendants_created_min: string | null;
+  descendants_modified_max: string | null;
   /** Per-extension counts/sizes over all descendant files, sorted by count
    *  desc (ext asc tiebreak). Empty for directories with no files. */
   descendants_ext_breakdown: ExtBreakdownEntry[];

--- a/app/src/utils/pathCrumbs.ts
+++ b/app/src/utils/pathCrumbs.ts
@@ -1,0 +1,37 @@
+// utils/pathCrumbs.ts — pure derivation of header breadcrumb segments from a
+// selected path. Kept out of the component so it's unit-testable.
+
+export interface PathCrumb {
+  /** Text shown on the crumb button. */
+  label: string;
+  /** Path this crumb re-selects when clicked (relative to the repo root). */
+  segPath: string;
+}
+
+export interface PathCrumbs {
+  /** True when the selection is the repo root — rendered as one repo-label crumb. */
+  isRoot: boolean;
+  crumbs: PathCrumb[];
+}
+
+/**
+ * Split a selected path into clickable breadcrumb segments. The repo root (a
+ * directory whose path is the root path or ".") has no relative path to walk,
+ * so it collapses to a single crumb carrying the repo label instead of a bare
+ * "." segment. Every other path splits on "/", each crumb's `segPath` being the
+ * path up to and including that segment.
+ */
+export function buildPathCrumbs(
+  path: string,
+  opts: { isDir?: boolean; rootLabel: string; rootPath: string }
+): PathCrumbs {
+  const { isDir, rootLabel, rootPath } = opts;
+  const isRoot = !!isDir && (path === rootPath || path === '.');
+  const crumbs: PathCrumb[] = isRoot
+    ? [{ label: rootLabel, segPath: rootPath }]
+    : path
+        .split('/')
+        .filter(Boolean)
+        .map((seg, i, all) => ({ label: seg, segPath: all.slice(0, i + 1).join('/') }));
+  return { isRoot, crumbs };
+}

--- a/app/src/utils/pathCrumbs.ts
+++ b/app/src/utils/pathCrumbs.ts
@@ -16,9 +16,9 @@ export interface PathCrumbs {
 
 /**
  * Split a selected path into clickable breadcrumb segments. The repo root (a
- * directory whose path is the root path or ".") has no relative path to walk,
- * so it collapses to a single crumb carrying the repo label instead of a bare
- * "." segment. Every other path splits on "/", each crumb's `segPath` being the
+ * directory whose path is the root path) has no relative path to walk, so it
+ * collapses to a single crumb carrying the repo label instead of a bare "."
+ * segment. Every other path splits on "/", each crumb's `segPath` being the
  * path up to and including that segment.
  */
 export function buildPathCrumbs(
@@ -26,7 +26,7 @@ export function buildPathCrumbs(
   opts: { isDir?: boolean; rootLabel: string; rootPath: string }
 ): PathCrumbs {
   const { isDir, rootLabel, rootPath } = opts;
-  const isRoot = !!isDir && (path === rootPath || path === '.');
+  const isRoot = !!isDir && path === rootPath;
   const crumbs: PathCrumb[] = isRoot
     ? [{ label: rootLabel, segPath: rootPath }]
     : path

--- a/app/src/utils/syntaxLanguages.ts
+++ b/app/src/utils/syntaxLanguages.ts
@@ -35,12 +35,12 @@ export function humanLanguageFor(file: FileNode): string {
 
 /**
  * Friendly language label for a bare extension (".ts" → "TypeScript"). Unknown
- * extensions fall back to the uppercased extension ("EXR"). Returns null for an
- * empty extension or the "(none)" sentinel — there's no language to name, so
- * callers drop the clause instead of printing "(none)".
+ * extensions fall back to the uppercased extension ("EXR"). Returns null for a
+ * missing extension (empty/null) — there's no language to name, so callers drop
+ * the clause instead of printing a placeholder.
  */
-export function languageLabelForExt(ext: string): string | null {
-  if (!ext || ext === '(none)') return null;
+export function languageLabelForExt(ext: string | null): string | null {
+  if (!ext) return null;
   const key = EXT_LANG[ext.toLowerCase()];
   if (key) return LANGUAGE_LABELS[key] || key;
   return ext.replace(/^\./, '').toUpperCase();

--- a/app/src/views/InfoPane/OverviewPane.tsx
+++ b/app/src/views/InfoPane/OverviewPane.tsx
@@ -16,7 +16,7 @@ import { ExtensionBadge } from '@/components/Badge/Badge';
 import { selectPath, focusPath, selectCommit, focusCommit } from '@/state/stores/scene';
 import { TREES } from '@/state/stores/settings/trees';
 import { BUILDINGS } from '@/state/stores/settings/buildings';
-import { getHue } from '@/city/components/buildings/color';
+import { extHueColor } from '@/city/components/buildings/color';
 import { humanAge, formatRelativeAge } from '@/utils/dates';
 import { commitUrl } from '@/utils/commit';
 import { languageLabelForExt } from '@/utils/syntaxLanguages';
@@ -169,16 +169,15 @@ function LanguageBar({
   return (
     <div class="almanac-langbar" aria-hidden="true">
       {languages.map((l) => {
-        const name = languageLabelForExt(l.ext) ?? (l.ext === '(none)' ? 'No extension' : l.ext);
+        const name = languageLabelForExt(l.ext) ?? 'No extension';
         return (
           <span
-            key={l.ext}
+            key={l.ext ?? ''}
             class="almanac-langbar-seg"
             title={`${name} · ${pluralize(l.count, 'file')} (${share(l.count)})`}
             style={{
               width: share(l.count),
-              // Match ExtensionBadge: the "(none)" sentinel hues off '' like its chip.
-              background: `hsl(${getHue(l.ext === '(none)' ? '' : l.ext, palette)}, 60%, 35%)`,
+              background: extHueColor(l.ext, palette),
             }}
           />
         );
@@ -292,8 +291,8 @@ export function OverviewPane({ manifest }: OverviewPaneProps) {
             />
             <ul class="almanac-languages">
               {overview.languages.map((l) => (
-                <li key={l.ext} class="almanac-language">
-                  <ExtensionBadge extension={l.ext === '(none)' ? null : l.ext} isDir={false} />
+                <li key={l.ext ?? ''} class="almanac-language">
+                  <ExtensionBadge extension={l.ext} isDir={false} />
                   <span class="almanac-language-count">{formatCount(l.count)}</span>
                 </li>
               ))}

--- a/app/src/views/InfoPane/almanac.ts
+++ b/app/src/views/InfoPane/almanac.ts
@@ -54,7 +54,7 @@ export interface AlmanacSection {
 }
 
 export interface LanguageStat {
-  ext: string;
+  ext: string | null;
   count: number;
 }
 
@@ -69,7 +69,8 @@ export interface AlmanacOverview {
    *  there are no commits. */
   latestDate: string | null;
   /** Friendly name of the dominant language ("TypeScript"), for the flavor
-   *  blurb. Null when the top file type has no nameable language ("(none)"). */
+   *  blurb. Null when the top file type has no nameable language (extensionless
+   *  or unrecognized). */
   topLanguage: string | null;
   /** Building count for the blurb — non-media files, matching the Buildings
    *  section (media render as billboards, not buildings). */

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -90,24 +90,12 @@
   border-radius: 0 var(--cc-radius-sm) var(--cc-radius-sm) 0;
 }
 
-.street-ext-label {
-  position: relative;
-  z-index: 1;
-  flex: 1 1 0;
-  padding-left: var(--cc-space-3); /* 6px */
-  font-family: var(--cc-font-mono);
-  color: var(--cc-text-base);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
-
 .street-ext-count {
   position: relative;
   z-index: 1;
+  margin-left: auto; /* pin to the trailing end of the track */
   flex-shrink: 0;
-  padding-right: var(--cc-space-3); /* 6px */
+  padding: 0 var(--cc-space-3); /* 6px */
   color: var(--cc-text-secondary);
   font-size: var(--cc-font-md); /* 11px */
 }

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -1,6 +1,4 @@
-/* ── Street pane ── */
-
-/* ── Street labels (rendered on canvas, these styles are for overlay fallback) ── */
+/* ── Street labels (rendered on canvas; these are the overlay fallback) ── */
 
 .street-label {
   position: absolute;
@@ -15,10 +13,11 @@
 }
 
 /* ── Street pane (right sidebar) ────────────────────────────────────────
-   Shown when a directory (road) is selected. Mirrors commit-pane layout:
-     - pane-header (from buildPaneHeader) — title is the directory leaf
-     - .street-body — scrollable area with path row, two-column counts,
-       and a "By extension" breakdown matching commit-meta typography. */
+   Shown when a directory (road) is selected. Composition-forward:
+     - pane header (badge + leaf, like FilePreviewPane)
+     - .street-summary — subtree totals + dominant language
+     - .street-ext-list — one ranked bar per file extension
+     - .street-meta — local direct/nested folder structure */
 
 .street-body {
   padding: var(--cc-space-7); /* 16px */
@@ -27,38 +26,22 @@
   gap: var(--cc-space-6); /* 12px */
 }
 
-/* Folder icon + path text, like .commit-author's icon + text row. */
-.street-path {
-  display: flex;
-  align-items: center;
-  gap: var(--cc-space-3); /* 6px */
-  color: var(--cc-text-secondary);
+/* One-line summary: bold totals, muted "mostly <Language>" tail. */
+.street-summary {
   font-size: var(--cc-font-lg); /* 12px */
+  line-height: 1.4;
 }
 
-.street-path-text {
-  font-family: var(--cc-font-mono);
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  min-width: 0;
+.street-summary-totals {
+  color: var(--cc-text-secondary);
+  font-weight: var(--cc-fw-medium);
 }
 
-/* Two-column count grid: Direct | Descendants. */
-.street-counts {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--cc-space-6); /* 12px */
+.street-summary-lang {
+  color: var(--cc-text-muted);
 }
 
-.street-counts-col {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cc-space-2); /* 4px */
-  min-width: 0;
-}
-
-/* Column heading — muted, same character as .commit-meta-sep. */
-.street-counts-h,
+/* "By extension" heading — muted uppercase label. */
 .street-ext-h {
   font-size: var(--cc-font-md); /* 11px */
   text-transform: uppercase;
@@ -67,57 +50,77 @@
   font-weight: var(--cc-fw-bold);
 }
 
-.street-counts-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--cc-space-3);
-  font-size: var(--cc-font-lg); /* 12px */
-}
-
-.street-counts-k {
-  color: var(--cc-text-muted);
-}
-
-.street-counts-v {
-  color: var(--cc-text-secondary);
-  font-weight: 500;
-}
-
-/* "By extension" list — one row per file extension, badge + label +
-   count + sep + size, sized to match .commit-meta typography. */
 .street-ext-list {
   display: flex;
   flex-direction: column;
-  gap: var(--cc-space-3); /* 6px */
+  gap: var(--cc-space-4); /* 8px */
 }
 
+/* badge · proportional bar · byte size */
 .street-ext-row {
   display: flex;
   align-items: center;
   gap: var(--cc-space-3); /* 6px */
-  color: var(--cc-text-muted);
   font-size: var(--cc-font-lg); /* 12px */
   min-width: 0;
 }
 
+/* The bar: a dark track with a hue-colored fill; the ext label + count sit on
+   top of (not inside) the fill so text contrast never depends on the hue. */
+.street-ext-track {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  height: 18px;
+  border-radius: var(--cc-radius-sm); /* --cc-radius-2 absent; --cc-radius-sm = 4px */
+  background: var(
+    --cc-bg-app
+  ); /* --cc-surface-sunken absent; --cc-bg-app is the darkest bg, reads as sunken within a sidebar */
+  overflow: hidden;
+}
+
+.street-ext-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  opacity: 0.8;
+  border-radius: var(--cc-radius-sm);
+}
+
 .street-ext-label {
+  position: relative;
+  z-index: 1;
+  padding-left: var(--cc-space-3); /* 6px */
   font-family: var(--cc-font-mono);
-  color: var(--cc-text-secondary);
+  color: var(--cc-text-base);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1 1 auto;
   min-width: 0;
 }
 
-.street-ext-count,
-.street-ext-size {
-  color: var(--cc-text-muted);
-  flex-shrink: 0;
+.street-ext-count {
+  position: relative;
+  z-index: 1;
+  margin-left: auto;
+  padding-right: var(--cc-space-3); /* 6px */
+  color: var(--cc-text-secondary);
+  font-size: var(--cc-font-md); /* 11px */
 }
 
-.street-ext-sep {
-  color: var(--cc-text-ghost);
+.street-ext-size {
   flex-shrink: 0;
+  width: 56px;
+  text-align: right;
+  color: var(--cc-text-muted);
+  font-size: var(--cc-font-md); /* 11px */
+}
+
+/* Local structure line, divided off the breakdown above it. */
+.street-meta {
+  padding-top: var(--cc-space-4); /* 8px */
+  border-top: 1px solid var(--cc-border-subtle);
+  font-size: var(--cc-font-md); /* 11px */
+  color: var(--cc-text-muted);
 }

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -16,8 +16,7 @@
    Shown when a directory (road) is selected. Composition-forward:
      - pane header (badge + leaf, like FilePreviewPane)
      - .street-summary — subtree totals + dominant language
-     - .street-ext-list — one ranked bar per file extension
-     - .street-meta — local direct/nested folder structure */
+     - .street-ext-list — one ranked bar per file extension */
 
 .street-body {
   padding: var(--cc-space-7); /* 16px */
@@ -110,12 +109,4 @@
   text-align: right;
   color: var(--cc-text-muted);
   font-size: var(--cc-font-md); /* 11px */
-}
-
-/* Local direct/nested structure — a hairline sets it apart from the composition breakdown above. */
-.street-meta {
-  padding-top: var(--cc-space-4); /* 8px */
-  border-top: 1px solid var(--cc-border-subtle);
-  font-size: var(--cc-font-md); /* 11px */
-  color: var(--cc-text-muted);
 }

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -78,6 +78,7 @@
     --cc-bg-app
   ); /* --cc-surface-sunken absent; --cc-bg-app is the darkest bg, reads as sunken within a sidebar */
   overflow: hidden;
+  isolation: isolate; /* confine the count's blend to the track (fill + groove) */
 }
 
 .street-ext-fill {
@@ -96,7 +97,10 @@
   margin-left: auto; /* pin to the trailing end of the track */
   flex-shrink: 0;
   padding: 0 var(--cc-space-3); /* 6px */
-  color: var(--cc-text-secondary);
+  /* The count overlaps both the dark groove (short bars) and the colored fill
+     (near-full bars); difference-blending white keeps it legible on either. */
+  color: var(--cc-white);
+  mix-blend-mode: difference;
   font-size: var(--cc-font-md); /* 11px */
 }
 

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -63,21 +63,17 @@
   min-width: 0;
 }
 
-/* The bar: a dark track with a hue-colored fill; the ext label + count sit on
-   top of (not inside) the fill so text contrast never depends on the hue. */
+/* The bar: a dark groove holding a single hue-colored fill (count-proportional). */
 .street-ext-track {
   position: relative;
   flex: 1 1 auto;
   min-width: 0;
-  display: flex;
-  align-items: center;
   height: 18px;
   border-radius: var(--cc-radius-sm); /* --cc-radius-2 absent; --cc-radius-sm = 4px */
   background: var(
     --cc-bg-app
   ); /* --cc-surface-sunken absent; --cc-bg-app is the darkest bg, reads as sunken within a sidebar */
   overflow: hidden;
-  isolation: isolate; /* confine the count's blend to the track (fill + groove) */
 }
 
 .street-ext-fill {
@@ -90,23 +86,12 @@
   border-radius: 0 var(--cc-radius-sm) var(--cc-radius-sm) 0;
 }
 
+/* File count, right-aligned in a column sized to the widest count in the list
+   (--street-count-ch, set on .street-ext-list) so it hugs the bars. */
 .street-ext-count {
-  position: relative;
-  z-index: 1;
-  margin-left: auto; /* pin to the trailing end of the track */
   flex-shrink: 0;
-  padding: 0 var(--cc-space-3); /* 6px */
-  /* The count overlaps both the dark groove (short bars) and the colored fill
-     (near-full bars); difference-blending white keeps it legible on either. */
-  color: var(--cc-white);
-  mix-blend-mode: difference;
-  font-size: var(--cc-font-md); /* 11px */
-}
-
-.street-ext-size {
-  flex-shrink: 0;
-  width: 56px;
+  width: calc(var(--street-count-ch, 2) * 1ch);
   text-align: right;
-  color: var(--cc-text-muted);
+  color: var(--cc-text-secondary);
   font-size: var(--cc-font-md); /* 11px */
 }

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -19,18 +19,18 @@
      - .street-ext-list — one ranked bar per file extension */
 
 .street-body {
-  padding: var(--cc-space-7); /* 16px */
+  padding: var(--cc-space-7);
   display: flex;
   flex-direction: column;
-  gap: var(--cc-space-6); /* 12px */
+  gap: var(--cc-space-6);
 }
 
 /* Activity span: oldest file created → newest change. */
 .street-dates {
   display: flex;
   align-items: center;
-  gap: var(--cc-space-3); /* 6px */
-  font-size: var(--cc-font-md); /* 11px */
+  gap: var(--cc-space-3);
+  font-size: var(--cc-font-md);
   color: var(--cc-text-muted);
 }
 
@@ -45,8 +45,8 @@
 .street-ext-h {
   display: flex;
   align-items: center;
-  gap: var(--cc-space-3); /* 6px */
-  font-size: var(--cc-font-md); /* 11px */
+  gap: var(--cc-space-3);
+  font-size: var(--cc-font-md);
   text-transform: uppercase;
   letter-spacing: var(--cc-track-label);
   color: var(--cc-text-secondary);
@@ -66,9 +66,9 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  column-gap: var(--cc-space-3); /* 6px */
-  row-gap: var(--cc-space-4); /* 8px */
-  font-size: var(--cc-font-lg); /* 12px */
+  column-gap: var(--cc-space-3);
+  row-gap: var(--cc-space-4);
+  font-size: var(--cc-font-lg);
 }
 
 /* Rows place their cells into the list's shared columns rather than forming
@@ -87,10 +87,9 @@
   position: relative;
   min-width: 0;
   height: 18px;
-  border-radius: var(--cc-radius-sm); /* --cc-radius-2 absent; --cc-radius-sm = 4px */
-  background: var(
-    --cc-bg-app
-  ); /* --cc-surface-sunken absent; --cc-bg-app is the darkest bg, reads as sunken within a sidebar */
+  border-radius: var(--cc-radius-sm);
+  /* Darkest app bg reads as a sunken groove within the sidebar. */
+  background: var(--cc-bg-app);
   overflow: hidden;
 }
 

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -84,6 +84,10 @@
   position: absolute;
   inset: 0 auto 0 0;
   opacity: 0.8;
+  /* Round only the leading end — a partial fill stops mid-track where the
+     track's overflow:hidden can't reach; the left end is flush at the track's
+     own rounded corner. */
+  border-radius: 0 var(--cc-radius-sm) var(--cc-radius-sm) 0;
 }
 
 .street-ext-label {

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -25,48 +25,51 @@
   gap: var(--cc-space-6); /* 12px */
 }
 
-/* One-line summary: bold totals, muted "mostly <Language>" tail. */
-.street-summary {
-  font-size: var(--cc-font-lg); /* 12px */
-  line-height: 1.4;
-}
-
-.street-summary-totals {
-  color: var(--cc-text-secondary);
-  font-weight: var(--cc-fw-medium);
-}
-
-.street-summary-lang {
-  color: var(--cc-text-muted);
-}
-
-/* "By extension" heading — muted uppercase label. */
+/* "By extension" heading — icon + uppercase label, matching the almanac's
+   .almanac-section-title treatment. */
 .street-ext-h {
-  font-size: var(--cc-font-md); /* 11px */
-  text-transform: uppercase;
-  letter-spacing: var(--cc-track-label);
-  color: var(--cc-text-ghost);
-  font-weight: var(--cc-fw-bold);
-}
-
-.street-ext-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cc-space-4); /* 8px */
-}
-
-.street-ext-row {
   display: flex;
   align-items: center;
   gap: var(--cc-space-3); /* 6px */
+  font-size: var(--cc-font-md); /* 11px */
+  text-transform: uppercase;
+  letter-spacing: var(--cc-track-label);
+  color: var(--cc-text-secondary);
+  font-weight: var(--cc-fw-semibold);
+}
+
+.street-ext-icon {
+  width: 15px;
+  height: 15px;
+  color: #d3a85f; /* the almanac's "streets" accent */
+}
+
+/* Shared 3-column grid (badge | bar | metric) so every row's bar is the same
+   length and starts/ends at the same x; the badge + metric columns auto-size to
+   their widest content across all rows. */
+.street-ext-list {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  column-gap: var(--cc-space-3); /* 6px */
+  row-gap: var(--cc-space-4); /* 8px */
   font-size: var(--cc-font-lg); /* 12px */
-  min-width: 0;
+}
+
+/* Rows place their cells into the list's shared columns rather than forming
+   their own box. */
+.street-ext-row {
+  display: contents;
+}
+
+/* Keep the badge pill its natural width (don't stretch it to the column). */
+.street-ext-row .path-badge {
+  justify-self: start;
 }
 
 /* The bar: a dark groove holding a single hue-colored fill (count-proportional). */
 .street-ext-track {
   position: relative;
-  flex: 1 1 auto;
   min-width: 0;
   height: 18px;
   border-radius: var(--cc-radius-sm); /* --cc-radius-2 absent; --cc-radius-sm = 4px */
@@ -86,12 +89,11 @@
   border-radius: 0 var(--cc-radius-sm) var(--cc-radius-sm) 0;
 }
 
-/* File count, right-aligned in a column sized to the widest count in the list
-   (--street-count-ch, set on .street-ext-list) so it hugs the bars. */
-.street-ext-count {
-  flex-shrink: 0;
-  width: calc(var(--street-count-ch, 2) * 1ch);
-  text-align: right;
+/* "share · count" metric — one color + inline middot, matching the Info
+   Overview tab's .almanac-section-overview dot-stat style. Right-aligned in its
+   column so every row's metric ends at the same x. */
+.street-ext-meta {
+  justify-self: end;
   color: var(--cc-text-secondary);
-  font-size: var(--cc-font-md); /* 11px */
+  white-space: nowrap;
 }

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -25,6 +25,21 @@
   gap: var(--cc-space-6); /* 12px */
 }
 
+/* Activity span: oldest file created → newest change. */
+.street-dates {
+  display: flex;
+  align-items: center;
+  gap: var(--cc-space-3); /* 6px */
+  font-size: var(--cc-font-md); /* 11px */
+  color: var(--cc-text-muted);
+}
+
+.street-dates-icon {
+  width: 14px;
+  height: 14px;
+  color: var(--cc-text-ghost);
+}
+
 /* "By extension" heading — icon + uppercase label, matching the almanac's
    .almanac-section-title treatment. */
 .street-ext-h {

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -56,7 +56,6 @@
   gap: var(--cc-space-4); /* 8px */
 }
 
-/* badge · proportional bar · byte size */
 .street-ext-row {
   display: flex;
   align-items: center;
@@ -85,12 +84,12 @@
   position: absolute;
   inset: 0 auto 0 0;
   opacity: 0.8;
-  border-radius: var(--cc-radius-sm);
 }
 
 .street-ext-label {
   position: relative;
   z-index: 1;
+  flex: 1 1 0;
   padding-left: var(--cc-space-3); /* 6px */
   font-family: var(--cc-font-mono);
   color: var(--cc-text-base);
@@ -103,7 +102,7 @@
 .street-ext-count {
   position: relative;
   z-index: 1;
-  margin-left: auto;
+  flex-shrink: 0;
   padding-right: var(--cc-space-3); /* 6px */
   color: var(--cc-text-secondary);
   font-size: var(--cc-font-md); /* 11px */
@@ -117,7 +116,7 @@
   font-size: var(--cc-font-md); /* 11px */
 }
 
-/* Local structure line, divided off the breakdown above it. */
+/* Local direct/nested structure — a hairline sets it apart from the composition breakdown above. */
 .street-meta {
   padding-top: var(--cc-space-4); /* 8px */
   border-top: 1px solid var(--cc-border-subtle);

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -60,10 +60,6 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
   const maxCount = stats.length > 0 ? stats[0].count : 0;
   const summary = streetSummary(d);
 
-  const directFiles = d.children_file_count ?? 0;
-  const directDirs = d.children_dir_count ?? 0;
-  const nestedDirs = d.descendants_dir_count ?? 0;
-
   return (
     <Pane
       paneClass="street-pane"
@@ -89,10 +85,6 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
           </div>
         </>
       )}
-      <div class="street-meta">
-        {pluralize(directFiles, 'file')}, {pluralize(directDirs, 'folder')} here
-        {nestedDirs > directDirs && <> · {nestedDirs} nested</>}
-      </div>
     </Pane>
   );
 }

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -77,9 +77,7 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
     >
       <div class="street-summary">
         <span class="street-summary-totals">{summary.totals}</span>
-        {summary.language && (
-          <span class="street-summary-lang"> — mostly {summary.language}</span>
-        )}
+        {summary.language && <span class="street-summary-lang"> — mostly {summary.language}</span>}
       </div>
       {stats.length > 0 && (
         <>

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -1,7 +1,9 @@
-// views/StreetPane.tsx — right-sidebar pane shown when a directory
-// (road) is selected in the city. Shows direct + descendant child
-// counts and a sorted breakdown of every file extension in the
-// descendant subtree.
+// views/StreetPane/StreetPane.tsx — right-sidebar pane shown when a directory
+// (road) is selected. Leads with the subtree's composition: a one-line summary
+// (totals + dominant language), a ranked by-extension bar list, then a local
+// structure line. Path orientation lives in the app-header breadcrumb and tree
+// navigation in the Explore sidebar — this pane answers "what is this
+// neighborhood made of".
 //
 // A Preact function component reading a `state` signal prop (the selected
 // directory); RightSidebar swaps panes by switching which one it renders.
@@ -13,7 +15,11 @@ import { Pane, PaneEmpty } from '@/components/Pane';
 import { KEY_BINDINGS } from '@/constants/keyboard';
 import { Route } from 'lucide-preact';
 import { ExtensionBadge } from '@/components/Badge/Badge';
+import { getHue } from '@/city/components/buildings/color';
+import { BUILDINGS } from '@/state/stores/settings/buildings';
 import { formatBytes } from '@/utils/bytes';
+import { pluralize } from '@/utils/format';
+import { streetSummary, extBarPct } from './streetStats';
 
 // ── State shape for Preact component ─────────────────────────────────────────
 
@@ -44,71 +50,74 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
     );
   }
 
-  const leaf =
-    (d.path && d.path !== '.' ? d.path.split('/').filter(Boolean).pop() : null) || d.name || 'Road';
+  const path = d.path && d.path !== '.' ? d.path : '';
+  const leaf = (path ? path.split('/').filter(Boolean).pop() : null) || d.name || 'Road';
 
-  // Backend-computed (api/scan.py). Guard against a manifest that predates
-  // the field (stale cache / skeleton / in-flight) so a missing breakdown
-  // renders an empty section instead of crashing the pane.
+  // Backend-computed (api/scan.py), sorted by count desc. Guard against a
+  // manifest that predates the field (stale cache / skeleton / in-flight) so a
+  // missing breakdown renders without the section instead of crashing the pane.
   const stats = d.descendants_ext_breakdown ?? [];
+  const maxCount = stats.length > 0 ? stats[0].count : 0;
+  const summary = streetSummary(d);
+
+  const directFiles = d.children_file_count ?? 0;
+  const directDirs = d.children_dir_count ?? 0;
+  const nestedDirs = d.descendants_dir_count ?? 0;
 
   return (
     <Pane
       paneClass="street-pane"
-      title={leaf}
+      prefixSlot={<ExtensionBadge extension={null} isDir />}
+      titleSlot={<span title={path || undefined}>{leaf}</span>}
+      mono
       onFocus={typeof onFocus === 'function' ? () => onFocus(d) : undefined}
       focusTitle={`Focus the camera on this road (${KEY_BINDINGS.FOCUS_SELECTION.label})`}
       onClose={onClose}
       bodyClass="street-body"
     >
-      <div class="street-counts">
-        <div class="street-counts-col">
-          <div class="street-counts-h">Direct</div>
-          <div class="street-counts-row">
-            <span class="street-counts-v">{String(d.children_file_count ?? 0)}</span>
-            <span class="street-counts-k">files</span>
-          </div>
-          <div class="street-counts-row">
-            <span class="street-counts-v">{String(d.children_dir_count ?? 0)}</span>
-            <span class="street-counts-k">dirs</span>
-          </div>
-        </div>
-        <div class="street-counts-col">
-          <div class="street-counts-h">Descendants</div>
-          <div class="street-counts-row">
-            <span class="street-counts-v">{String(d.descendants_file_count ?? 0)}</span>
-            <span class="street-counts-k">files</span>
-          </div>
-          <div class="street-counts-row">
-            <span class="street-counts-v">{String(d.descendants_dir_count ?? 0)}</span>
-            <span class="street-counts-k">dirs</span>
-          </div>
-        </div>
+      <div class="street-summary">
+        <span class="street-summary-totals">{summary.totals}</span>
+        {summary.language && (
+          <span class="street-summary-lang"> — mostly {summary.language}</span>
+        )}
       </div>
       {stats.length > 0 && (
         <>
           <div class="street-ext-h">By extension</div>
           <div class="street-ext-list">
             {stats.map((s) => (
-              <StreetExtRow key={s.ext} s={s} />
+              <StreetExtRow key={s.ext} s={s} maxCount={maxCount} />
             ))}
           </div>
         </>
       )}
+      <div class="street-meta">
+        {pluralize(directFiles, 'file')}, {pluralize(directDirs, 'folder')} here
+        {nestedDirs > directDirs && <> · {nestedDirs} nested</>}
+      </div>
     </Pane>
   );
 }
 
-function StreetExtRow({ s }: { s: ExtBreakdownEntry }) {
+// One ranked extension row: badge · proportional bar (ext label + count inside)
+// · byte size. The fill width is count-relative to the busiest extension; its
+// hue matches the badge + the city's buildings (live theme palette).
+function StreetExtRow({ s, maxCount }: { s: ExtBreakdownEntry; maxCount: number }) {
   const badgeExt = s.ext === '(none)' ? null : s.ext;
+  const hue = getHue(s.ext === '(none)' ? '' : s.ext, BUILDINGS.value.HUE_EXT_MAP);
+  const pct = extBarPct(s.count, maxCount);
   return (
     <div class="street-ext-row">
       <ExtensionBadge extension={badgeExt} isDir={false} />
-      <span class="street-ext-label">{s.ext}</span>
-      <span class="street-ext-count">{`${s.count} file${s.count === 1 ? '' : 's'}`}</span>
-      <span class="street-ext-sep" aria-hidden="true">
-        ·
-      </span>
+      <div class="street-ext-track">
+        <span
+          class="street-ext-fill"
+          aria-hidden="true"
+          style={{ width: `${pct}%`, background: `hsl(${hue}, 60%, 35%)` }}
+        />
+        <span class="street-ext-label">{s.ext}</span>
+        <span class="street-ext-count">{s.count}</span>
+      </div>
       <span class="street-ext-size">{formatBytes(s.size)}</span>
     </div>
   );

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -1,8 +1,9 @@
 // views/StreetPane/StreetPane.tsx — right-sidebar pane shown when a directory
-// (road) is selected. Shows the subtree's composition as a ranked by-extension
-// bar list (each bar an extension's share of the directory's files). Path
-// orientation lives in the app-header breadcrumb and tree navigation in the
-// Explore sidebar — this pane answers "what is this neighborhood made of".
+// (road) is selected. Shows the subtree's activity-date span and its
+// composition as a ranked by-extension bar list (each bar an extension's share
+// of the directory's files). Path orientation lives in the app-header
+// breadcrumb and tree navigation in the Explore sidebar — this pane answers
+// "what is this neighborhood made of".
 //
 // A Preact function component reading a `state` signal prop (the selected
 // directory); RightSidebar swaps panes by switching which one it renders.
@@ -12,12 +13,12 @@ import type { ReadonlySignal } from '@preact/signals';
 import type { DirNode, ExtBreakdownEntry } from '@/types';
 import { Pane, PaneEmpty } from '@/components/Pane';
 import { KEY_BINDINGS } from '@/constants/keyboard';
-import { Route, FileType } from 'lucide-preact';
+import { Route, FileType, CalendarRange } from 'lucide-preact';
 import { ExtensionBadge } from '@/components/Badge/Badge';
 import { getHue } from '@/city/components/buildings/color';
 import { BUILDINGS } from '@/state/stores/settings/buildings';
 import { pluralize } from '@/utils/format';
-import { extBarPct, extShareLabel, extTypeLabel } from './streetStats';
+import { extBarPct, extShareLabel, extTypeLabel, streetDateRange } from './streetStats';
 
 // ── State shape for Preact component ─────────────────────────────────────────
 
@@ -57,6 +58,7 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
   const stats = d.descendants_ext_breakdown ?? [];
   // Total descendant files — each bar's width is its extension's share of this.
   const total = stats.reduce((n, s) => n + s.count, 0);
+  const dateRange = streetDateRange(d.descendants_created_min, d.descendants_modified_max);
 
   return (
     <Pane
@@ -69,6 +71,12 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
       onClose={onClose}
       bodyClass="street-body"
     >
+      {dateRange && (
+        <div class="street-dates" title="Oldest file created → newest change">
+          <CalendarRange class="lucide-icon street-dates-icon" aria-hidden="true" />
+          {dateRange}
+        </div>
+      )}
       {stats.length > 0 && (
         <>
           <div class="street-ext-h">

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -15,7 +15,7 @@ import { Pane, PaneEmpty } from '@/components/Pane';
 import { KEY_BINDINGS } from '@/constants/keyboard';
 import { Route, FileType, CalendarRange } from 'lucide-preact';
 import { ExtensionBadge } from '@/components/Badge/Badge';
-import { getHue } from '@/city/components/buildings/color';
+import { extHueColor } from '@/city/components/buildings/color';
 import { BUILDINGS } from '@/state/stores/settings/buildings';
 import { pluralize } from '@/utils/format';
 import { extBarPct, extShareLabel, extTypeLabel, streetDateRange } from './streetStats';
@@ -85,7 +85,7 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
           </div>
           <div class="street-ext-list">
             {stats.map((s) => (
-              <StreetExtRow key={s.ext} s={s} total={total} />
+              <StreetExtRow key={s.ext ?? ''} s={s} total={total} />
             ))}
           </div>
         </>
@@ -100,18 +100,16 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
 // type; the bar's title names it in full ("TypeScript (.ts)"), which the 4-char
 // badge can't.
 function StreetExtRow({ s, total }: { s: ExtBreakdownEntry; total: number }) {
-  const badgeExt = s.ext === '(none)' ? null : s.ext;
-  const hue = getHue(s.ext === '(none)' ? '' : s.ext, BUILDINGS.value.HUE_EXT_MAP);
   const pct = extBarPct(s.count, total);
   const share = extShareLabel(s.count, total);
   return (
     <div class="street-ext-row">
-      <ExtensionBadge extension={badgeExt} isDir={false} />
+      <ExtensionBadge extension={s.ext} isDir={false} />
       <div class="street-ext-track" title={extTypeLabel(s.ext)}>
         <span
           class="street-ext-fill"
           aria-hidden="true"
-          style={{ width: `${pct}%`, background: `hsl(${hue}, 60%, 35%)` }}
+          style={{ width: `${pct}%`, background: extHueColor(s.ext, BUILDINGS.value.HUE_EXT_MAP) }}
         />
       </div>
       <span class="street-ext-meta" aria-label={`${share}, ${pluralize(s.count, 'file')}`}>

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -18,6 +18,7 @@ import { ExtensionBadge } from '@/components/Badge/Badge';
 import { extHueColor } from '@/city/components/buildings/color';
 import { BUILDINGS } from '@/state/stores/settings/buildings';
 import { pluralize } from '@/utils/format';
+import { ROOT_PATH } from '@/constants/manifest';
 import { extBarPct, extShareLabel, extTypeLabel, streetDateRange } from './streetStats';
 
 // ── State shape for Preact component ─────────────────────────────────────────
@@ -49,7 +50,7 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
     );
   }
 
-  const path = d.path && d.path !== '.' ? d.path : '';
+  const path = d.path && d.path !== ROOT_PATH ? d.path : '';
   const leaf = (path ? path.split('/').filter(Boolean).pop() : null) || d.name || 'Road';
 
   // Backend-computed (api/scan.py), sorted by count desc. Guard against a

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -116,7 +116,9 @@ function StreetExtRow({ s, maxCount }: { s: ExtBreakdownEntry; maxCount: number 
           style={{ width: `${pct}%`, background: `hsl(${hue}, 60%, 35%)` }}
         />
         <span class="street-ext-label">{s.ext}</span>
-        <span class="street-ext-count">{s.count}</span>
+        <span class="street-ext-count" aria-label={pluralize(s.count, 'file')}>
+          {s.count}
+        </span>
       </div>
       <span class="street-ext-size">{formatBytes(s.size)}</span>
     </div>

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -1,6 +1,6 @@
 // views/StreetPane/StreetPane.tsx — right-sidebar pane shown when a directory
-// (road) is selected. Leads with the subtree's composition: a one-line summary
-// (totals + dominant language) and a ranked by-extension bar list. Path
+// (road) is selected. Shows the subtree's composition as a ranked by-extension
+// bar list (each bar an extension's share of the directory's files). Path
 // orientation lives in the app-header breadcrumb and tree navigation in the
 // Explore sidebar — this pane answers "what is this neighborhood made of".
 //
@@ -12,12 +12,12 @@ import type { ReadonlySignal } from '@preact/signals';
 import type { DirNode, ExtBreakdownEntry } from '@/types';
 import { Pane, PaneEmpty } from '@/components/Pane';
 import { KEY_BINDINGS } from '@/constants/keyboard';
-import { Route } from 'lucide-preact';
+import { Route, FileType } from 'lucide-preact';
 import { ExtensionBadge } from '@/components/Badge/Badge';
 import { getHue } from '@/city/components/buildings/color';
 import { BUILDINGS } from '@/state/stores/settings/buildings';
 import { pluralize } from '@/utils/format';
-import { streetSummary, extBarPct } from './streetStats';
+import { extBarPct, extShareLabel, extTypeLabel } from './streetStats';
 
 // ── State shape for Preact component ─────────────────────────────────────────
 
@@ -55,8 +55,8 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
   // manifest that predates the field (stale cache / skeleton / in-flight) so a
   // missing breakdown renders without the section instead of crashing the pane.
   const stats = d.descendants_ext_breakdown ?? [];
-  const maxCount = stats.length > 0 ? stats[0].count : 0;
-  const summary = streetSummary(d);
+  // Total descendant files — each bar's width is its extension's share of this.
+  const total = stats.reduce((n, s) => n + s.count, 0);
 
   return (
     <Pane
@@ -69,23 +69,15 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
       onClose={onClose}
       bodyClass="street-body"
     >
-      <div class="street-summary">
-        <span class="street-summary-totals">{summary.totals}</span>
-        {summary.language && <span class="street-summary-lang"> — mostly {summary.language}</span>}
-      </div>
       {stats.length > 0 && (
         <>
-          <div class="street-ext-h">By extension</div>
-          {/* Size the count column to the widest count present (maxCount is the
-              top row) so the numbers sit in a tight column just past the bars. */}
-          <div
-            class="street-ext-list"
-            style={
-              { '--street-count-ch': String(String(maxCount).length) } as Record<string, string>
-            }
-          >
+          <div class="street-ext-h">
+            <FileType class="lucide-icon street-ext-icon" aria-hidden="true" />
+            By extension
+          </div>
+          <div class="street-ext-list">
             {stats.map((s) => (
-              <StreetExtRow key={s.ext} s={s} maxCount={maxCount} />
+              <StreetExtRow key={s.ext} s={s} total={total} />
             ))}
           </div>
         </>
@@ -94,27 +86,28 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
   );
 }
 
-// One ranked extension row: badge · proportional bar · file count. The fill
-// width is count-relative to the busiest extension; its hue matches the badge +
-// the city's buildings (live theme palette). The badge identifies the type; the
-// row's title holds the exact extension, which the 4-char badge (and the generic
-// "(none)" badge) can't always show in full.
-function StreetExtRow({ s, maxCount }: { s: ExtBreakdownEntry; maxCount: number }) {
+// One ranked extension row: badge · proportional bar · "share · count". The fill
+// width is this extension's share of the directory's files; its hue matches the
+// badge + the city's buildings (live theme palette). The badge identifies the
+// type; the bar's title names it in full ("TypeScript (.ts)"), which the 4-char
+// badge can't.
+function StreetExtRow({ s, total }: { s: ExtBreakdownEntry; total: number }) {
   const badgeExt = s.ext === '(none)' ? null : s.ext;
   const hue = getHue(s.ext === '(none)' ? '' : s.ext, BUILDINGS.value.HUE_EXT_MAP);
-  const pct = extBarPct(s.count, maxCount);
+  const pct = extBarPct(s.count, total);
+  const share = extShareLabel(s.count, total);
   return (
-    <div class="street-ext-row" title={s.ext}>
+    <div class="street-ext-row">
       <ExtensionBadge extension={badgeExt} isDir={false} />
-      <div class="street-ext-track">
+      <div class="street-ext-track" title={extTypeLabel(s.ext)}>
         <span
           class="street-ext-fill"
           aria-hidden="true"
           style={{ width: `${pct}%`, background: `hsl(${hue}, 60%, 35%)` }}
         />
       </div>
-      <span class="street-ext-count" aria-label={pluralize(s.count, 'file')}>
-        {s.count}
+      <span class="street-ext-meta" aria-label={`${share}, ${pluralize(s.count, 'file')}`}>
+        {share} · {s.count}
       </span>
     </div>
   );

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -97,15 +97,17 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
   );
 }
 
-// One ranked extension row: badge · proportional bar (ext label + count inside)
-// · byte size. The fill width is count-relative to the busiest extension; its
-// hue matches the badge + the city's buildings (live theme palette).
+// One ranked extension row: badge · proportional bar (count inside) · byte size.
+// The fill width is count-relative to the busiest extension; its hue matches the
+// badge + the city's buildings (live theme palette). The badge identifies the
+// type; the row's title holds the exact extension, which the 4-char badge (and
+// the generic "(none)" badge) can't always show in full.
 function StreetExtRow({ s, maxCount }: { s: ExtBreakdownEntry; maxCount: number }) {
   const badgeExt = s.ext === '(none)' ? null : s.ext;
   const hue = getHue(s.ext === '(none)' ? '' : s.ext, BUILDINGS.value.HUE_EXT_MAP);
   const pct = extBarPct(s.count, maxCount);
   return (
-    <div class="street-ext-row">
+    <div class="street-ext-row" title={s.ext}>
       <ExtensionBadge extension={badgeExt} isDir={false} />
       <div class="street-ext-track">
         <span
@@ -113,7 +115,6 @@ function StreetExtRow({ s, maxCount }: { s: ExtBreakdownEntry; maxCount: number 
           aria-hidden="true"
           style={{ width: `${pct}%`, background: `hsl(${hue}, 60%, 35%)` }}
         />
-        <span class="street-ext-label">{s.ext}</span>
         <span class="street-ext-count" aria-label={pluralize(s.count, 'file')}>
           {s.count}
         </span>

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -1,9 +1,8 @@
 // views/StreetPane/StreetPane.tsx — right-sidebar pane shown when a directory
 // (road) is selected. Leads with the subtree's composition: a one-line summary
-// (totals + dominant language), a ranked by-extension bar list, then a local
-// structure line. Path orientation lives in the app-header breadcrumb and tree
-// navigation in the Explore sidebar — this pane answers "what is this
-// neighborhood made of".
+// (totals + dominant language) and a ranked by-extension bar list. Path
+// orientation lives in the app-header breadcrumb and tree navigation in the
+// Explore sidebar — this pane answers "what is this neighborhood made of".
 //
 // A Preact function component reading a `state` signal prop (the selected
 // directory); RightSidebar swaps panes by switching which one it renders.
@@ -17,7 +16,6 @@ import { Route } from 'lucide-preact';
 import { ExtensionBadge } from '@/components/Badge/Badge';
 import { getHue } from '@/city/components/buildings/color';
 import { BUILDINGS } from '@/state/stores/settings/buildings';
-import { formatBytes } from '@/utils/bytes';
 import { pluralize } from '@/utils/format';
 import { streetSummary, extBarPct } from './streetStats';
 
@@ -78,7 +76,14 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
       {stats.length > 0 && (
         <>
           <div class="street-ext-h">By extension</div>
-          <div class="street-ext-list">
+          {/* Size the count column to the widest count present (maxCount is the
+              top row) so the numbers sit in a tight column just past the bars. */}
+          <div
+            class="street-ext-list"
+            style={
+              { '--street-count-ch': String(String(maxCount).length) } as Record<string, string>
+            }
+          >
             {stats.map((s) => (
               <StreetExtRow key={s.ext} s={s} maxCount={maxCount} />
             ))}
@@ -89,11 +94,11 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
   );
 }
 
-// One ranked extension row: badge · proportional bar (count inside) · byte size.
-// The fill width is count-relative to the busiest extension; its hue matches the
-// badge + the city's buildings (live theme palette). The badge identifies the
-// type; the row's title holds the exact extension, which the 4-char badge (and
-// the generic "(none)" badge) can't always show in full.
+// One ranked extension row: badge · proportional bar · file count. The fill
+// width is count-relative to the busiest extension; its hue matches the badge +
+// the city's buildings (live theme palette). The badge identifies the type; the
+// row's title holds the exact extension, which the 4-char badge (and the generic
+// "(none)" badge) can't always show in full.
 function StreetExtRow({ s, maxCount }: { s: ExtBreakdownEntry; maxCount: number }) {
   const badgeExt = s.ext === '(none)' ? null : s.ext;
   const hue = getHue(s.ext === '(none)' ? '' : s.ext, BUILDINGS.value.HUE_EXT_MAP);
@@ -107,11 +112,10 @@ function StreetExtRow({ s, maxCount }: { s: ExtBreakdownEntry; maxCount: number 
           aria-hidden="true"
           style={{ width: `${pct}%`, background: `hsl(${hue}, 60%, 35%)` }}
         />
-        <span class="street-ext-count" aria-label={pluralize(s.count, 'file')}>
-          {s.count}
-        </span>
       </div>
-      <span class="street-ext-size">{formatBytes(s.size)}</span>
+      <span class="street-ext-count" aria-label={pluralize(s.count, 'file')}>
+        {s.count}
+      </span>
     </div>
   );
 }

--- a/app/src/views/StreetPane/streetStats.ts
+++ b/app/src/views/StreetPane/streetStats.ts
@@ -1,0 +1,38 @@
+// views/StreetPane/streetStats.ts — pure derivations for the Street pane,
+// split out so the bar-width math and the one-line summary are unit-testable
+// without rendering. No signal reads here (the live hue palette is read in the
+// component); inputs are plain DirNode fields baked by the backend.
+
+import type { DirNode } from '@/types';
+import { pluralize } from '@/utils/format';
+import { formatBytes } from '@/utils/bytes';
+import { languageLabelForExt } from '@/utils/syntaxLanguages';
+
+// A count-1 extension still gets a visible sliver so the row never reads as empty.
+const MIN_BAR_PCT = 4;
+
+/** Bar fill percent for one extension, normalized to the busiest extension's
+ *  count (the list is pre-sorted count desc, so the top row is always 100%).
+ *  0 when there's nothing to normalize against. */
+export function extBarPct(count: number, max: number): number {
+  if (max <= 0) return 0;
+  return Math.max(MIN_BAR_PCT, Math.round((count / max) * 100));
+}
+
+export interface StreetSummary {
+  /** "214 files · 1.2 MB" — subtree totals. */
+  totals: string;
+  /** Dominant language label ("TypeScript"), or null when there's no nameable
+   *  language (empty dir, or a (none)/unknown-only top extension). */
+  language: string | null;
+}
+
+/** One-line summary of a directory's subtree: total files + size, plus the
+ *  dominant language (from the most common extension). */
+export function streetSummary(d: DirNode): StreetSummary {
+  const files = d.descendants_file_count ?? 0;
+  const totals = `${pluralize(files, 'file')} · ${formatBytes(d.descendants_size ?? 0)}`;
+  const top = (d.descendants_ext_breakdown ?? [])[0];
+  const language = top ? languageLabelForExt(top.ext) : null;
+  return { totals, language };
+}

--- a/app/src/views/StreetPane/streetStats.ts
+++ b/app/src/views/StreetPane/streetStats.ts
@@ -1,14 +1,12 @@
-// views/StreetPane/streetStats.ts — pure derivations for the Street pane,
-// split out so the bar-width math and the one-line summary are unit-testable
-// without rendering. No signal reads here (the live hue palette is read in the
-// component); inputs are plain DirNode fields baked by the backend.
+// views/StreetPane/streetStats.ts — pure derivations for the Street pane.
+// No signal reads; inputs are plain DirNode fields baked by the backend.
 
 import type { DirNode } from '@/types';
 import { pluralize } from '@/utils/format';
 import { formatBytes } from '@/utils/bytes';
 import { languageLabelForExt } from '@/utils/syntaxLanguages';
 
-// A count-1 extension still gets a visible sliver so the row never reads as empty.
+// A low-share extension still gets a visible sliver so the row never reads as empty.
 const MIN_BAR_PCT = 4;
 
 /** Bar fill percent for one extension, normalized to the busiest extension's

--- a/app/src/views/StreetPane/streetStats.ts
+++ b/app/src/views/StreetPane/streetStats.ts
@@ -25,8 +25,8 @@ export function extShareLabel(count: number, total: number): string {
 /** Full file-type name for the row tooltip: the language label plus the exact
  *  extension ("TypeScript (.ts)"), or "No extension" for extensionless files.
  *  Unknown extensions fall back to the uppercased ext ("SKETCH (.sketch)"). */
-export function extTypeLabel(ext: string): string {
-  if (ext === '(none)') return 'No extension';
+export function extTypeLabel(ext: string | null): string {
+  if (!ext) return 'No extension';
   const name = languageLabelForExt(ext);
   return name ? `${name} (${ext})` : ext;
 }

--- a/app/src/views/StreetPane/streetStats.ts
+++ b/app/src/views/StreetPane/streetStats.ts
@@ -20,8 +20,9 @@ export function extBarPct(count: number, max: number): number {
 export interface StreetSummary {
   /** "214 files · 1.2 MB" — subtree totals. */
   totals: string;
-  /** Dominant language label ("TypeScript"), or null when there's no nameable
-   *  language (empty dir, or a (none)/unknown-only top extension). */
+  /** Dominant language label ("TypeScript"), or the uppercased extension for an
+   *  unknown type ("SKETCH"). Null only for an empty dir or a (none) top
+   *  extension — there's no language to name. */
   language: string | null;
 }
 

--- a/app/src/views/StreetPane/streetStats.ts
+++ b/app/src/views/StreetPane/streetStats.ts
@@ -2,6 +2,7 @@
 // ranked by-extension bars. No signal reads; inputs are plain counts/extensions.
 
 import { languageLabelForExt } from '@/utils/syntaxLanguages';
+import { formatShortDate } from '@/utils/dates';
 
 // A low-share extension still gets a visible sliver so the row never reads as empty.
 const MIN_BAR_PCT = 4;
@@ -28,4 +29,14 @@ export function extTypeLabel(ext: string): string {
   if (ext === '(none)') return 'No extension';
   const name = languageLabelForExt(ext);
   return name ? `${name} (${ext})` : ext;
+}
+
+/** Display span from the directory's oldest-created to newest-modified file
+ *  ("Mar 12, 2024 → Jun 20, 2026"), collapsed to one date when they're equal,
+ *  or null when the directory has no dated files. */
+export function streetDateRange(from: string | null, to: string | null): string | null {
+  if (!from || !to) return null;
+  const a = formatShortDate(from);
+  const b = formatShortDate(to);
+  return a === b ? a : `${a} → ${b}`;
 }

--- a/app/src/views/StreetPane/streetStats.ts
+++ b/app/src/views/StreetPane/streetStats.ts
@@ -1,37 +1,31 @@
-// views/StreetPane/streetStats.ts — pure derivations for the Street pane.
-// No signal reads; inputs are plain DirNode fields baked by the backend.
+// views/StreetPane/streetStats.ts — pure derivations for the Street pane's
+// ranked by-extension bars. No signal reads; inputs are plain counts/extensions.
 
-import type { DirNode } from '@/types';
-import { pluralize } from '@/utils/format';
-import { formatBytes } from '@/utils/bytes';
 import { languageLabelForExt } from '@/utils/syntaxLanguages';
 
 // A low-share extension still gets a visible sliver so the row never reads as empty.
 const MIN_BAR_PCT = 4;
 
-/** Bar fill percent for one extension, normalized to the busiest extension's
- *  count (the list is pre-sorted count desc, so the top row is always 100%).
- *  0 when there's nothing to normalize against. */
-export function extBarPct(count: number, max: number): number {
-  if (max <= 0) return 0;
-  return Math.max(MIN_BAR_PCT, Math.round((count / max) * 100));
+/** Bar fill percent for one extension as its share of the directory's total
+ *  files. 0 when there are no files to take a share of. */
+export function extBarPct(count: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.max(MIN_BAR_PCT, Math.round((count / total) * 100));
 }
 
-export interface StreetSummary {
-  /** "214 files · 1.2 MB" — subtree totals. */
-  totals: string;
-  /** Dominant language label ("TypeScript"), or the uppercased extension for an
-   *  unknown type ("SKETCH"). Null only for an empty dir or a (none) top
-   *  extension — there's no language to name. */
-  language: string | null;
+/** This extension's share of the directory's files as a display string ("64%",
+ *  or "<1%" for a nonzero share that rounds down to zero). */
+export function extShareLabel(count: number, total: number): string {
+  if (total <= 0) return '0%';
+  const pct = Math.round((count / total) * 100);
+  return pct === 0 && count > 0 ? '<1%' : `${pct}%`;
 }
 
-/** One-line summary of a directory's subtree: total files + size, plus the
- *  dominant language (from the most common extension). */
-export function streetSummary(d: DirNode): StreetSummary {
-  const files = d.descendants_file_count ?? 0;
-  const totals = `${pluralize(files, 'file')} · ${formatBytes(d.descendants_size ?? 0)}`;
-  const top = (d.descendants_ext_breakdown ?? [])[0];
-  const language = top ? languageLabelForExt(top.ext) : null;
-  return { totals, language };
+/** Full file-type name for the row tooltip: the language label plus the exact
+ *  extension ("TypeScript (.ts)"), or "No extension" for extensionless files.
+ *  Unknown extensions fall back to the uppercased ext ("SKETCH (.sketch)"). */
+export function extTypeLabel(ext: string): string {
+  if (ext === '(none)') return 'No extension';
+  const name = languageLabelForExt(ext);
+  return name ? `${name} (${ext})` : ext;
 }

--- a/app/src/views/TreePane/TreePane.tsx
+++ b/app/src/views/TreePane/TreePane.tsx
@@ -78,8 +78,8 @@ function TreeItem({
   const path = node.path ?? '';
   // .value reads track the signal so the row re-renders on each change.
   const isExpanded = isDir && expanded.value.has(path);
-  const isSelected = path !== '' && selectedPath.value === path;
-  const isHovered = path !== '' && hoveredPath.value === path;
+  const isSelected = selectedPath.value === path;
+  const isHovered = hoveredPath.value === path;
   const ref = useRef<HTMLLIElement>(null);
 
   // Selected → scroll into view (matches the imperative version). Only

--- a/app/tests/city/applyManifestScenic.test.ts
+++ b/app/tests/city/applyManifestScenic.test.ts
@@ -40,7 +40,7 @@ function makeRootStreet(): Street {
     label: 'root',
     orientation: StreetAxis.X,
     isRoot: true,
-    dir: { name: 'root', path: '', type: NodeKind.Directory },
+    dir: { name: 'root', path: '.', type: NodeKind.Directory },
   } as unknown as Street;
 }
 

--- a/app/tests/city/components/buildings/color.test.ts
+++ b/app/tests/city/components/buildings/color.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   getHue,
+  extHueColor,
   getSaturation,
   getLightness,
   getBuildingColor,
@@ -140,6 +141,19 @@ describe('getHue', () => {
   it('does not crash on empty extension', () => {
     const hue = getHue('', TEST_HUE_EXT_MAP);
     expect(typeof hue).toBe('number');
+  });
+});
+
+// ---- extHueColor ----
+describe('extHueColor', () => {
+  it('paints a known extension at the badge saturation/lightness', () => {
+    expect(extHueColor('.ts', TEST_HUE_EXT_MAP)).toBe('hsl(215, 60%, 35%)');
+  });
+
+  it('hues a null (extensionless) ext off the empty-string bucket', () => {
+    expect(extHueColor(null, TEST_HUE_EXT_MAP)).toBe(
+      `hsl(${getHue('', TEST_HUE_EXT_MAP)}, 60%, 35%)`
+    );
   });
 });
 

--- a/app/tests/city/components/gem/gem.test.ts
+++ b/app/tests/city/components/gem/gem.test.ts
@@ -20,7 +20,7 @@ function makeStreet(): Street {
     length: 400,
     orientation: StreetAxis.X,
     isRoot: true,
-    dir: { name: 'root', path: '', type: NodeKind.Directory },
+    dir: { name: 'root', path: '.', type: NodeKind.Directory },
   } as unknown as Street;
 }
 

--- a/app/tests/city/components/scenicReactivity.test.ts
+++ b/app/tests/city/components/scenicReactivity.test.ts
@@ -48,7 +48,7 @@ function makeRootStreet(): Street {
     label: 'root',
     orientation: StreetAxis.X,
     isRoot: true,
-    dir: { name: 'root', path: '', type: NodeKind.Directory },
+    dir: { name: 'root', path: '.', type: NodeKind.Directory },
   } as unknown as Street;
 }
 

--- a/app/tests/city/layout/runner.test.ts
+++ b/app/tests/city/layout/runner.test.ts
@@ -41,6 +41,8 @@ function makeMinimalManifest(): Manifest {
       descendants_file_count: 1,
       descendants_dir_count: 0,
       descendants_size: 10,
+      descendants_created_min: null,
+      descendants_modified_max: null,
       descendants_ext_breakdown: [],
     },
   };
@@ -138,6 +140,8 @@ describe('layoutClient', () => {
         descendants_file_count: 2,
         descendants_dir_count: 0,
         descendants_size: 10010,
+        descendants_created_min: null,
+        descendants_modified_max: null,
         descendants_ext_breakdown: [],
       },
     };

--- a/app/tests/utils/pathCrumbs.test.ts
+++ b/app/tests/utils/pathCrumbs.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { buildPathCrumbs } from '@/utils/pathCrumbs';
+
+const ROOT = { isDir: true, rootLabel: 'codecity', rootPath: '' };
+
+describe('buildPathCrumbs', () => {
+  it('splits a nested path into cumulative segments', () => {
+    const { isRoot, crumbs } = buildPathCrumbs('app/src/utils', {
+      isDir: true,
+      rootLabel: 'codecity',
+      rootPath: '',
+    });
+    expect(isRoot).toBe(false);
+    expect(crumbs).toEqual([
+      { label: 'app', segPath: 'app' },
+      { label: 'src', segPath: 'app/src' },
+      { label: 'utils', segPath: 'app/src/utils' },
+    ]);
+  });
+
+  it('collapses the root directory to a single repo-label crumb', () => {
+    // Root path matches rootPath ('') — render the repo label, not a bare ".".
+    const { isRoot, crumbs } = buildPathCrumbs('', ROOT);
+    expect(isRoot).toBe(true);
+    expect(crumbs).toEqual([{ label: 'codecity', segPath: '' }]);
+  });
+
+  it('treats "." as root for a directory', () => {
+    const { isRoot, crumbs } = buildPathCrumbs('.', { ...ROOT, rootPath: '.' });
+    expect(isRoot).toBe(true);
+    expect(crumbs).toEqual([{ label: 'codecity', segPath: '.' }]);
+  });
+
+  it('does not treat a file whose path equals rootPath as root', () => {
+    // A file (isDir false) is never the repo root even if the guard path lines up.
+    const { isRoot, crumbs } = buildPathCrumbs('readme.md', {
+      isDir: false,
+      rootLabel: 'codecity',
+      rootPath: '',
+    });
+    expect(isRoot).toBe(false);
+    expect(crumbs).toEqual([{ label: 'readme.md', segPath: 'readme.md' }]);
+  });
+
+  it('drops empty segments from a trailing/leading slash', () => {
+    const { crumbs } = buildPathCrumbs('/app/', { isDir: true, rootLabel: 'x', rootPath: '' });
+    expect(crumbs).toEqual([{ label: 'app', segPath: 'app' }]);
+  });
+});

--- a/app/tests/utils/pathCrumbs.test.ts
+++ b/app/tests/utils/pathCrumbs.test.ts
@@ -1,15 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { buildPathCrumbs } from '@/utils/pathCrumbs';
+import { ROOT_PATH } from '@/constants/manifest';
 
-const ROOT = { isDir: true, rootLabel: 'codecity', rootPath: '' };
+const rootOpts = { isDir: true, rootLabel: 'codecity', rootPath: ROOT_PATH };
 
 describe('buildPathCrumbs', () => {
   it('splits a nested path into cumulative segments', () => {
-    const { isRoot, crumbs } = buildPathCrumbs('app/src/utils', {
-      isDir: true,
-      rootLabel: 'codecity',
-      rootPath: '',
-    });
+    const { isRoot, crumbs } = buildPathCrumbs('app/src/utils', rootOpts);
     expect(isRoot).toBe(false);
     expect(crumbs).toEqual([
       { label: 'app', segPath: 'app' },
@@ -19,31 +16,26 @@ describe('buildPathCrumbs', () => {
   });
 
   it('collapses the root directory to a single repo-label crumb', () => {
-    // Root path matches rootPath ('') — render the repo label, not a bare ".".
-    const { isRoot, crumbs } = buildPathCrumbs('', ROOT);
+    // The selected dir's path equals rootPath (ROOT_PATH) — render the repo
+    // label, not a bare "." segment.
+    const { isRoot, crumbs } = buildPathCrumbs(ROOT_PATH, rootOpts);
     expect(isRoot).toBe(true);
-    expect(crumbs).toEqual([{ label: 'codecity', segPath: '' }]);
-  });
-
-  it('treats "." as root for a directory', () => {
-    const { isRoot, crumbs } = buildPathCrumbs('.', { ...ROOT, rootPath: '.' });
-    expect(isRoot).toBe(true);
-    expect(crumbs).toEqual([{ label: 'codecity', segPath: '.' }]);
+    expect(crumbs).toEqual([{ label: 'codecity', segPath: ROOT_PATH }]);
   });
 
   it('does not treat a file whose path equals rootPath as root', () => {
-    // A file (isDir false) is never the repo root even if the guard path lines up.
+    // A file (isDir false) is never the repo root even if the path lines up.
     const { isRoot, crumbs } = buildPathCrumbs('readme.md', {
       isDir: false,
       rootLabel: 'codecity',
-      rootPath: '',
+      rootPath: ROOT_PATH,
     });
     expect(isRoot).toBe(false);
     expect(crumbs).toEqual([{ label: 'readme.md', segPath: 'readme.md' }]);
   });
 
   it('drops empty segments from a trailing/leading slash', () => {
-    const { crumbs } = buildPathCrumbs('/app/', { isDir: true, rootLabel: 'x', rootPath: '' });
+    const { crumbs } = buildPathCrumbs('/app/', rootOpts);
     expect(crumbs).toEqual([{ label: 'app', segPath: 'app' }]);
   });
 });

--- a/app/tests/utils/syntaxLanguages.test.ts
+++ b/app/tests/utils/syntaxLanguages.test.ts
@@ -15,8 +15,8 @@ describe('languageLabelForExt', () => {
     expect(languageLabelForExt('.exr')).toBe('EXR');
   });
 
-  it('returns null for an empty extension or the "(none)" sentinel', () => {
+  it('returns null for a missing extension (empty or null)', () => {
     expect(languageLabelForExt('')).toBeNull();
-    expect(languageLabelForExt('(none)')).toBeNull();
+    expect(languageLabelForExt(null)).toBeNull();
   });
 });

--- a/app/tests/views/InfoPane/almanac.test.ts
+++ b/app/tests/views/InfoPane/almanac.test.ts
@@ -35,6 +35,8 @@ function dir(name: string, path: string, children: (FileNode | DirNode)[]): DirN
     descendants_file_count: files,
     descendants_dir_count: dirs,
     descendants_size: 0,
+    descendants_created_min: null,
+    descendants_modified_max: null,
     descendants_ext_breakdown: [{ ext: '.ts', count: files, size: 0 }],
   };
 }

--- a/app/tests/views/InfoPane/almanac.test.ts
+++ b/app/tests/views/InfoPane/almanac.test.ts
@@ -163,7 +163,7 @@ describe('computeAlmanac — overview + buildings', () => {
   it('topLanguage is null when the dominant file type has no nameable language', () => {
     const t = {
       ...dir('repo', '', []),
-      descendants_ext_breakdown: [{ ext: '(none)', count: 4, size: 0 }],
+      descendants_ext_breakdown: [{ ext: null, count: 4, size: 0 }],
     } as DirNode;
     expect(computeAlmanac(manifest(t))!.overview.topLanguage).toBeNull();
   });

--- a/app/tests/views/InfoPane/overviewPane.test.tsx
+++ b/app/tests/views/InfoPane/overviewPane.test.tsx
@@ -31,7 +31,7 @@ import { uniformFileStats } from '../../_helpers/statsFixtures';
 const tree = {
   name: 'repo',
   type: NodeKind.Directory,
-  path: '',
+  path: '.',
   fullPath: '/repo',
   children: [
     {

--- a/app/tests/views/searchPane.test.tsx
+++ b/app/tests/views/searchPane.test.tsx
@@ -11,7 +11,7 @@ import { flush } from '../_helpers/preact';
 const TREE = {
   name: 'project',
   type: NodeKind.Directory,
-  path: '',
+  path: '.',
   children: [
     {
       name: 'src',

--- a/app/tests/views/streetPane.test.tsx
+++ b/app/tests/views/streetPane.test.tsx
@@ -95,29 +95,33 @@ describe('StreetPane', () => {
     expect(container.querySelector('.empty-state')).not.toBeNull();
   });
 
-  it('setDirectory(d) renders direct + descendant counts', async () => {
+  it('summary shows descendant totals; meta shows direct structure', async () => {
     mount();
     const d = dir('src', [f('a.ts', '.ts', 100), f('b.md', '.md', 50)]);
     d.descendants_file_count = 4;
     d.descendants_dir_count = 1;
+    d.descendants_size = 260;
     d.children = [
       f('a.ts', '.ts', 100),
       f('b.md', '.md', 50),
       dir('sub', [f('c.ts', '.ts', 80), f('d.json', '.json', 30)]),
     ];
+    d.children_file_count = 2;
+    d.children_dir_count = 1;
     d.descendants_ext_breakdown = _extBreakdown(d.children);
 
     await setDirectory(d);
 
-    const body = container.querySelector('.pane-body, .street-body') as HTMLElement;
-    // Direct counts
-    expect(body.textContent).toMatch(/2.*files/i);
-    expect(body.textContent).toMatch(/1.*dirs?/i);
-    // Descendant counts
-    expect(body.textContent).toMatch(/4.*files/i);
+    const body = container.querySelector('.street-body') as HTMLElement;
+    // Summary line: descendant file total.
+    expect(container.querySelector('.street-summary')!.textContent).toMatch(/4\s*files/i);
+    // Meta line: direct structure (files + folders here).
+    expect(container.querySelector('.street-meta')!.textContent).toMatch(/2\s*files/i);
+    expect(container.querySelector('.street-meta')!.textContent).toMatch(/1\s*folder/i);
+    expect(body).not.toBeNull();
   });
 
-  it('lists every extension in the descendant subtree sorted by count desc', async () => {
+  it('lists every extension as a ranked row sorted by count desc', async () => {
     mount();
     const d = dir('src', [
       f('a.ts', '.ts', 100),
@@ -129,9 +133,12 @@ describe('StreetPane', () => {
     await setDirectory(d);
     const extRows = Array.from(container.querySelectorAll('.street-ext-row')) as HTMLElement[];
     expect(extRows.length).toBeGreaterThanOrEqual(3);
-    // First row is the most common extension (.ts with 3 files).
+    // First row is the most common extension (.ts with 3 files), and its bar
+    // fill is the full-width reference (100%).
     expect(extRows[0].textContent).toContain('.ts');
     expect(extRows[0].textContent).toContain('3');
+    const fill = extRows[0].querySelector('.street-ext-fill') as HTMLElement;
+    expect(fill.style.width).toBe('100%');
   });
 
   it('onFocus callback fires with the active directory when focus button clicked', async () => {

--- a/app/tests/views/streetPane.test.tsx
+++ b/app/tests/views/streetPane.test.tsx
@@ -145,8 +145,9 @@ describe('StreetPane', () => {
     const extRows = Array.from(container.querySelectorAll('.street-ext-row')) as HTMLElement[];
     expect(extRows.length).toBeGreaterThanOrEqual(3);
     // First row is the most common extension (.ts with 3 files), and its bar
-    // fill is the full-width reference (100%).
-    expect(extRows[0].textContent).toContain('.ts');
+    // fill is the full-width reference (100%). The exact ext lives in the row
+    // title (the badge truncates); the count shows in the bar.
+    expect(extRows[0].getAttribute('title')).toBe('.ts');
     expect(extRows[0].textContent).toContain('3');
     const fill = extRows[0].querySelector('.street-ext-fill') as HTMLElement;
     expect(fill.style.width).toBe('100%');

--- a/app/tests/views/streetPane.test.tsx
+++ b/app/tests/views/streetPane.test.tsx
@@ -95,41 +95,21 @@ describe('StreetPane', () => {
     expect(container.querySelector('.empty-state')).not.toBeNull();
   });
 
-  it('summary shows descendant totals; meta shows direct structure', async () => {
+  it('summary shows descendant totals (files + size)', async () => {
     mount();
     const d = dir('src', [f('a.ts', '.ts', 100), f('b.md', '.md', 50)]);
     d.descendants_file_count = 4;
-    d.descendants_dir_count = 1;
     d.descendants_size = 260;
-    d.children = [
+    d.descendants_ext_breakdown = _extBreakdown([
       f('a.ts', '.ts', 100),
       f('b.md', '.md', 50),
       dir('sub', [f('c.ts', '.ts', 80), f('d.json', '.json', 30)]),
-    ];
-    d.children_file_count = 2;
-    d.children_dir_count = 1;
-    d.descendants_ext_breakdown = _extBreakdown(d.children);
+    ]);
 
     await setDirectory(d);
 
-    const body = container.querySelector('.street-body') as HTMLElement;
-    // Summary line: descendant file total.
     expect(container.querySelector('.street-summary')!.textContent).toMatch(/4\s*files/i);
-    // Meta line: direct structure (files + folders here).
-    expect(container.querySelector('.street-meta')!.textContent).toMatch(/2\s*files/i);
-    expect(container.querySelector('.street-meta')!.textContent).toMatch(/1\s*folder/i);
-    expect(body).not.toBeNull();
-  });
-
-  it('meta line appends nested folder count when descendants exceed direct dirs', async () => {
-    mount();
-    const d = dir('src', [f('a.ts', '.ts', 100)]);
-    d.children_dir_count = 2;
-    d.descendants_dir_count = 5; // deeper than the direct subfolders
-    await setDirectory(d);
-    const meta = container.querySelector('.street-meta')!.textContent!;
-    expect(meta).toMatch(/2\s*folders\s*here/i);
-    expect(meta).toMatch(/5\s*nested/i);
+    expect(container.querySelector('.street-body')).not.toBeNull();
   });
 
   it('lists every extension as a ranked row sorted by count desc', async () => {

--- a/app/tests/views/streetPane.test.tsx
+++ b/app/tests/views/streetPane.test.tsx
@@ -121,6 +121,17 @@ describe('StreetPane', () => {
     expect(body).not.toBeNull();
   });
 
+  it('meta line appends nested folder count when descendants exceed direct dirs', async () => {
+    mount();
+    const d = dir('src', [f('a.ts', '.ts', 100)]);
+    d.children_dir_count = 2;
+    d.descendants_dir_count = 5; // deeper than the direct subfolders
+    await setDirectory(d);
+    const meta = container.querySelector('.street-meta')!.textContent!;
+    expect(meta).toMatch(/2\s*folders\s*here/i);
+    expect(meta).toMatch(/5\s*nested/i);
+  });
+
   it('lists every extension as a ranked row sorted by count desc', async () => {
     mount();
     const d = dir('src', [

--- a/app/tests/views/streetPane.test.tsx
+++ b/app/tests/views/streetPane.test.tsx
@@ -11,10 +11,10 @@ import { flush } from '../_helpers/preact';
 // fixtures carry a realistic descendants_ext_breakdown — StreetPane reads
 // that baked field rather than walking the subtree itself.
 function _extBreakdown(children: (FileNode | DirNode)[]): ExtBreakdownEntry[] {
-  const byExt = new Map<string, { count: number; size: number }>();
+  const byExt = new Map<string | null, { count: number; size: number }>();
   function walk(node: FileNode | DirNode): void {
     if (node.type === NodeKind.File) {
-      const ext = (node.extension || '(none)').toLowerCase();
+      const ext = node.extension ? node.extension.toLowerCase() : null;
       const cur = byExt.get(ext) || { count: 0, size: 0 };
       cur.count += 1;
       cur.size += node.size || 0;
@@ -116,6 +116,16 @@ describe('StreetPane', () => {
     expect(extRows[0].textContent).toContain('3');
     const fill = extRows[0].querySelector('.street-ext-fill') as HTMLElement;
     expect(fill.style.width).toBe('60%');
+  });
+
+  it('labels an extensionless file row as "No extension"', async () => {
+    mount();
+    const d = dir('bin', [f('LICENSE', '', 10), f('run.sh', '.sh', 10)]);
+    await setDirectory(d);
+    const titles = Array.from(container.querySelectorAll('.street-ext-track')).map((t) =>
+      t.getAttribute('title')
+    );
+    expect(titles).toContain('No extension');
   });
 
   it('onFocus callback fires with the active directory when focus button clicked', async () => {

--- a/app/tests/views/streetPane.test.tsx
+++ b/app/tests/views/streetPane.test.tsx
@@ -95,23 +95,6 @@ describe('StreetPane', () => {
     expect(container.querySelector('.empty-state')).not.toBeNull();
   });
 
-  it('summary shows descendant totals (files + size)', async () => {
-    mount();
-    const d = dir('src', [f('a.ts', '.ts', 100), f('b.md', '.md', 50)]);
-    d.descendants_file_count = 4;
-    d.descendants_size = 260;
-    d.descendants_ext_breakdown = _extBreakdown([
-      f('a.ts', '.ts', 100),
-      f('b.md', '.md', 50),
-      dir('sub', [f('c.ts', '.ts', 80), f('d.json', '.json', 30)]),
-    ]);
-
-    await setDirectory(d);
-
-    expect(container.querySelector('.street-summary')!.textContent).toMatch(/4\s*files/i);
-    expect(container.querySelector('.street-body')).not.toBeNull();
-  });
-
   it('lists every extension as a ranked row sorted by count desc', async () => {
     mount();
     const d = dir('src', [
@@ -124,13 +107,15 @@ describe('StreetPane', () => {
     await setDirectory(d);
     const extRows = Array.from(container.querySelectorAll('.street-ext-row')) as HTMLElement[];
     expect(extRows.length).toBeGreaterThanOrEqual(3);
-    // First row is the most common extension (.ts with 3 files), and its bar
-    // fill is the full-width reference (100%). The exact ext lives in the row
-    // title (the badge truncates); the count shows in the bar.
-    expect(extRows[0].getAttribute('title')).toBe('.ts');
+    // First row is the most common extension (.ts: 3 of 5 files → 60% share).
+    // The bar's title names the type in full (the badge truncates); the count
+    // and share show on the right.
+    expect(extRows[0].querySelector('.street-ext-track')!.getAttribute('title')).toBe(
+      'TypeScript (.ts)'
+    );
     expect(extRows[0].textContent).toContain('3');
     const fill = extRows[0].querySelector('.street-ext-fill') as HTMLElement;
-    expect(fill.style.width).toBe('100%');
+    expect(fill.style.width).toBe('60%');
   });
 
   it('onFocus callback fires with the active directory when focus button clicked', async () => {

--- a/app/tests/views/streetStats.test.ts
+++ b/app/tests/views/streetStats.test.ts
@@ -1,75 +1,43 @@
 import { describe, it, expect } from 'vitest';
-import { extBarPct, streetSummary } from '@/views/StreetPane/streetStats';
-import { NodeKind } from '@/types';
-import type { DirNode, ExtBreakdownEntry } from '@/types';
-
-function dir(over: Partial<DirNode>): DirNode {
-  return {
-    name: 'src',
-    type: NodeKind.Directory,
-    path: 'src',
-    fullPath: '/tmp/src',
-    children: [],
-    children_count: 0,
-    children_file_count: 0,
-    children_dir_count: 0,
-    descendants_count: 0,
-    descendants_file_count: 0,
-    descendants_dir_count: 0,
-    descendants_size: 0,
-    descendants_ext_breakdown: [],
-    ...over,
-  } as DirNode;
-}
-
-function ext(e: string, count: number, size = 0): ExtBreakdownEntry {
-  return { ext: e, count, size };
-}
+import { extBarPct, extShareLabel, extTypeLabel } from '@/views/StreetPane/streetStats';
 
 describe('extBarPct', () => {
-  it('is 100 when count equals max', () => {
+  it('is 100 when one extension is all the files', () => {
     expect(extBarPct(98, 98)).toBe(100);
   });
-  it('scales linearly between 0 and max', () => {
+  it('is the share of the total (half of all files → 50%)', () => {
     expect(extBarPct(49, 98)).toBe(50);
   });
   it('floors a tiny share to a visible sliver (4%)', () => {
     expect(extBarPct(1, 1000)).toBe(4);
   });
-  it('is 0 when max is non-positive', () => {
+  it('is 0 when the total is non-positive', () => {
     expect(extBarPct(5, 0)).toBe(0);
     expect(extBarPct(0, 0)).toBe(0);
   });
 });
 
-describe('streetSummary', () => {
-  it('totals descendant files + size and names the dominant language', () => {
-    const s = streetSummary(
-      dir({
-        descendants_file_count: 214,
-        descendants_size: 1_300_000,
-        descendants_ext_breakdown: [ext('.tsx', 98), ext('.ts', 64)],
-      })
-    );
-    expect(s.totals).toContain('214 files');
-    expect(s.totals).toContain('1.2 MB');
-    expect(s.language).toBe('TypeScript');
+describe('extShareLabel', () => {
+  it('formats a share as a rounded percent', () => {
+    expect(extShareLabel(7, 11)).toBe('64%');
+    expect(extShareLabel(1, 2)).toBe('50%');
   });
-  it('drops the language clause for the (none) sentinel', () => {
-    const s = streetSummary(
-      dir({ descendants_file_count: 3, descendants_ext_breakdown: [ext('(none)', 3)] })
-    );
-    expect(s.language).toBeNull();
+  it('shows <1% for a nonzero share that rounds to zero', () => {
+    expect(extShareLabel(1, 1000)).toBe('<1%');
   });
-  it('falls back to the uppercased extension for an unknown type', () => {
-    const s = streetSummary(
-      dir({ descendants_file_count: 2, descendants_ext_breakdown: [ext('.sketch', 2)] })
-    );
-    expect(s.language).toBe('SKETCH');
+  it('is 0% when the total is non-positive', () => {
+    expect(extShareLabel(0, 0)).toBe('0%');
   });
-  it('handles a directory with no files', () => {
-    const s = streetSummary(dir({ descendants_file_count: 0 }));
-    expect(s.totals).toContain('0 files');
-    expect(s.language).toBeNull();
+});
+
+describe('extTypeLabel', () => {
+  it('names a known extension with the language label + ext', () => {
+    expect(extTypeLabel('.ts')).toBe('TypeScript (.ts)');
+  });
+  it('uppercases an unknown extension', () => {
+    expect(extTypeLabel('.sketch')).toBe('SKETCH (.sketch)');
+  });
+  it('labels the (none) sentinel as "No extension"', () => {
+    expect(extTypeLabel('(none)')).toBe('No extension');
   });
 });

--- a/app/tests/views/streetStats.test.ts
+++ b/app/tests/views/streetStats.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { extBarPct, streetSummary } from '@/views/StreetPane/streetStats';
+import { NodeKind } from '@/types';
+import type { DirNode, ExtBreakdownEntry } from '@/types';
+
+function dir(over: Partial<DirNode>): DirNode {
+  return {
+    name: 'src',
+    type: NodeKind.Directory,
+    path: 'src',
+    fullPath: '/tmp/src',
+    children: [],
+    children_count: 0,
+    children_file_count: 0,
+    children_dir_count: 0,
+    descendants_count: 0,
+    descendants_file_count: 0,
+    descendants_dir_count: 0,
+    descendants_size: 0,
+    descendants_ext_breakdown: [],
+    ...over,
+  } as DirNode;
+}
+
+function ext(e: string, count: number, size = 0): ExtBreakdownEntry {
+  return { ext: e, count, size };
+}
+
+describe('extBarPct', () => {
+  it('is 100 when count equals max', () => {
+    expect(extBarPct(98, 98)).toBe(100);
+  });
+  it('scales linearly between 0 and max', () => {
+    expect(extBarPct(49, 98)).toBe(50);
+  });
+  it('floors a tiny share to a visible sliver (4%)', () => {
+    expect(extBarPct(1, 1000)).toBe(4);
+  });
+  it('is 0 when max is non-positive', () => {
+    expect(extBarPct(5, 0)).toBe(0);
+    expect(extBarPct(0, 0)).toBe(0);
+  });
+});
+
+describe('streetSummary', () => {
+  it('totals descendant files + size and names the dominant language', () => {
+    const s = streetSummary(
+      dir({
+        descendants_file_count: 214,
+        descendants_size: 1_300_000,
+        descendants_ext_breakdown: [ext('.tsx', 98), ext('.ts', 64)],
+      })
+    );
+    expect(s.totals).toContain('214 files');
+    expect(s.totals).toContain('1.2 MB');
+    expect(s.language).toBe('TypeScript');
+  });
+  it('drops the language clause for the (none) sentinel', () => {
+    const s = streetSummary(
+      dir({ descendants_file_count: 3, descendants_ext_breakdown: [ext('(none)', 3)] })
+    );
+    expect(s.language).toBeNull();
+  });
+  it('handles a directory with no files', () => {
+    const s = streetSummary(dir({ descendants_file_count: 0 }));
+    expect(s.totals).toContain('0 files');
+    expect(s.language).toBeNull();
+  });
+});

--- a/app/tests/views/streetStats.test.ts
+++ b/app/tests/views/streetStats.test.ts
@@ -61,6 +61,12 @@ describe('streetSummary', () => {
     );
     expect(s.language).toBeNull();
   });
+  it('falls back to the uppercased extension for an unknown type', () => {
+    const s = streetSummary(
+      dir({ descendants_file_count: 2, descendants_ext_breakdown: [ext('.sketch', 2)] })
+    );
+    expect(s.language).toBe('SKETCH');
+  });
   it('handles a directory with no files', () => {
     const s = streetSummary(dir({ descendants_file_count: 0 }));
     expect(s.totals).toContain('0 files');

--- a/app/tests/views/streetStats.test.ts
+++ b/app/tests/views/streetStats.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { extBarPct, extShareLabel, extTypeLabel } from '@/views/StreetPane/streetStats';
+import {
+  extBarPct,
+  extShareLabel,
+  extTypeLabel,
+  streetDateRange,
+} from '@/views/StreetPane/streetStats';
 
 describe('extBarPct', () => {
   it('is 100 when one extension is all the files', () => {
@@ -39,5 +44,18 @@ describe('extTypeLabel', () => {
   });
   it('labels the (none) sentinel as "No extension"', () => {
     expect(extTypeLabel('(none)')).toBe('No extension');
+  });
+});
+
+describe('streetDateRange', () => {
+  it('formats an oldest→newest span', () => {
+    expect(streetDateRange('2024-03-12', '2026-06-20')).toBe('Mar 12, 2024 → Jun 20, 2026');
+  });
+  it('collapses to one date when oldest and newest are equal', () => {
+    expect(streetDateRange('2024-03-12', '2024-03-12')).toBe('Mar 12, 2024');
+  });
+  it('is null when either date is missing', () => {
+    expect(streetDateRange(null, '2026-06-20')).toBeNull();
+    expect(streetDateRange('2024-03-12', null)).toBeNull();
   });
 });

--- a/app/tests/views/streetStats.test.ts
+++ b/app/tests/views/streetStats.test.ts
@@ -42,8 +42,8 @@ describe('extTypeLabel', () => {
   it('uppercases an unknown extension', () => {
     expect(extTypeLabel('.sketch')).toBe('SKETCH (.sketch)');
   });
-  it('labels the (none) sentinel as "No extension"', () => {
-    expect(extTypeLabel('(none)')).toBe('No extension');
+  it('labels a null (extensionless) ext as "No extension"', () => {
+    expect(extTypeLabel(null)).toBe('No extension');
   });
 });
 


### PR DESCRIPTION
Redesigns the Street (directory) right-pane to lead with composition, per #80, plus two related changes folded in with owner sign-off (a sitewide-header fix and a new per-directory date field).

## StreetPane (the core of #80)
- **Header** matches `FilePreviewPane`: a `dir` badge + the folder's leaf name (monospace), keeping focus + close.
- **Activity span** at the top — oldest file created → newest changed (`Mar 2024 → Jun 2026`), collapsing to one date when equal.
- **`By extension`** ranked bars in a CSS grid (`badge | bar | metric`) so every bar is the same length and starts/ends at the same x. Each bar is the extension's **share of the directory's files**; the metric column reads `share · count` (one color + inline middot, matching the Info Overview dot-stat style). The `By extension` header carries an accent icon (almanac section style). Hovering a bar names the type in full (`TypeScript (.ts)`, `No extension`).
- Per-extension byte size and the `N files · size` summary line were dropped (the status-bar footer already shows totals), and the redundant structure meta line removed.
- Pure logic (`extBarPct`, `extShareLabel`, `extTypeLabel`, `streetDateRange`) lives in `streetStats.ts`, unit-tested. Dead `.street-path*` / `.street-counts*` CSS removed.

## Sitewide header (related)
- Selecting **root** left the center header empty while every other directory showed its breadcrumb. `PathBreadcrumbs` now renders the repo label as a single crumb for root; `AppHeader` no longer suppresses it.

## Wire-model change (related)
- New `DirNode.descendants_created_min` / `descendants_modified_max`, aggregated in the existing `api/scan.py` walk (like `descendants_size` / `ext_breakdown`) and rolled up to parents — no extra pass.
- `descendants_ext_breakdown[].ext` is now **`null`** (was the `"(none)"` sentinel string) for extensionless files — every FE consumer branches on null. Types regenerated via `just gen-types`; manifest cache schema bumped **v11 → v13** (one re-scan).

## Review follow-ups (this PR)
- `buildPathCrumbs` extracted from `PathBreadcrumbs` into a unit-tested util; `AppHeader`'s title guard simplified to `if (path)` (the old `path !== rootPath` clause was dead).
- Duplicated `hsl(hue, 60%, 35%)` badge-fill literal folded into one `extHueColor()` helper (StreetPane + OverviewPane).
- `min_iso`/`max_iso` lifted out of `scan.py` into a unit-tested `date_utils` module.
- Stale px-annotation comments dropped from `StreetPane.css`.
- **Root-path unification:** the empty-manifest sentinel used `''` for its root `tree.path` while real scans use `'.'`, forcing `|| x === ''` guards in the path helpers. Introduced a shared `ROOT_PATH = '.'` constant, pointed `EMPTY_MANIFEST` at it, and routed all root-token comparisons through it (`path.ts`, `fader`, `tooltipText`, `StreetPane`, `PathBreadcrumbs`, `AppHeader`). Emptiness is detected by identity (`m === EMPTY_MANIFEST`), not the path, so the dead `=== ''` branches (incl. TreePane's selection guard) drop out. One root representation everywhere.

## Testing
- api: **259 passed** (incl. date-rollup + a new null-`ext` breakdown test + `date_utils` unit tests).
- app vitest: **2404 passed** (the sole failure is the pre-existing, environment-pinned `layoutGolden.bench.test.ts`).
- `just lint` clean (ESLint + tsc contract guard + Prettier + ruff).

Closes #80
