### PR TITLE
Interactive affordance vocabulary + Info-pane header & world-switch polish

### DIFF
--- a/app/src/components/Pane.tsx
+++ b/app/src/components/Pane.tsx
@@ -16,6 +16,10 @@ import { PaneHeader } from './PaneHeader/PaneHeader';
 export interface PaneProps {
   /** Extra class on the outer `.pane` (e.g. 'commit-pane', 'tree-pane'). */
   paneClass?: string;
+  /** Replaces the entire default <PaneHeader> — for panes whose header isn't a
+   *  title bar (e.g. a tabbed pane whose tab strip IS the header). When set,
+   *  the title/focus/close header props are ignored. */
+  headerSlot?: ComponentChildren;
   /** Plain-text header title. */
   title?: string;
   /** Rich header title content; overrides `title` when set. */
@@ -47,6 +51,7 @@ export interface PaneProps {
 
 export function Pane({
   paneClass,
+  headerSlot,
   title,
   titleSlot,
   mono,
@@ -64,16 +69,18 @@ export function Pane({
   const ownsBody = bodyClass !== undefined || bodyRef !== undefined;
   return (
     <div class={paneClass ? `pane ${paneClass}` : 'pane'} ref={paneRef}>
-      <PaneHeader
-        title={title ?? ''}
-        titleSlot={titleSlot}
-        mono={mono}
-        prefixSlot={prefixSlot}
-        onFocus={onFocus}
-        focusTitle={focusTitle}
-        onClose={onClose}
-        closeTitle={closeTitle}
-      />
+      {headerSlot ?? (
+        <PaneHeader
+          title={title ?? ''}
+          titleSlot={titleSlot}
+          mono={mono}
+          prefixSlot={prefixSlot}
+          onFocus={onFocus}
+          focusTitle={focusTitle}
+          onClose={onClose}
+          closeTitle={closeTitle}
+        />
+      )}
       {ownsBody ? (
         <div class={bodyClass ? `pane-body ${bodyClass}` : 'pane-body'} ref={bodyRef}>
           {children}

--- a/app/src/components/PaneHeader/PaneHeader.css
+++ b/app/src/components/PaneHeader/PaneHeader.css
@@ -18,6 +18,23 @@
   gap: var(--cc-space-4);
 }
 
+/* Tabbed pane header — the tab strip IS the header row (no title bar), with the
+ * close button pinned right. The row's own border-bottom is the single divider;
+ * the inner strip draws none and stretches full-height so its tabs sit on that
+ * line (their active underline overlaps it). Folding the title bar + separate
+ * strip into one row is the vertical-space win. */
+.pane-header--tabs {
+  padding: 0 var(--cc-space-6) 0 0; /* first tab sits flush with the pane edge */
+  align-items: stretch;
+}
+.pane-header--tabs .pane-tabs {
+  flex: 1 1 auto;
+  border-bottom: 0;
+}
+.pane-header--tabs > .btn-icon--text {
+  align-self: center;
+}
+
 /* Pane-header close + action buttons use .btn-icon + .btn-icon--text. */
 .pane-header .btn-icon--text {
   line-height: 1;

--- a/app/src/components/PaneHeader/PaneHeader.tsx
+++ b/app/src/components/PaneHeader/PaneHeader.tsx
@@ -64,17 +64,31 @@ export function PaneHeader({
       )}
       {prefixSlot ?? null}
       <h3 class={`text-pane-title${mono ? ' is-mono' : ''}`}>{titleSlot ?? title}</h3>
-      {typeof onClose === 'function' && (
-        <button
-          type="button"
-          class="btn-icon btn-icon--text"
-          title={closeTitle}
-          aria-label={closeTitle}
-          onClick={() => onClose()}
-        >
-          <X class="lucide-icon" />
-        </button>
-      )}
+      {typeof onClose === 'function' && <PaneCloseButton onClose={onClose} title={closeTitle} />}
     </div>
+  );
+}
+
+// ── Close button ────────────────────────────────────────────────────────────
+
+export interface PaneCloseButtonProps {
+  onClose: () => void;
+  /** Tooltip / aria-label. Defaults to "Hide sidebar". */
+  title?: string;
+}
+
+/** The pane's × close button. Shared by the default header and by panes that
+ *  compose their own header (e.g. InfoPane's tab strip). */
+export function PaneCloseButton({ onClose, title = 'Hide sidebar' }: PaneCloseButtonProps) {
+  return (
+    <button
+      type="button"
+      class="btn-icon btn-icon--text"
+      title={title}
+      aria-label={title}
+      onClick={() => onClose()}
+    >
+      <X class="lucide-icon" />
+    </button>
   );
 }

--- a/app/src/components/PaneTabs/PaneTabs.css
+++ b/app/src/components/PaneTabs/PaneTabs.css
@@ -1,7 +1,7 @@
 .pane-tabs {
   display: flex;
-  gap: 2px;
-  padding: 6px 8px;
+  gap: 14px;
+  padding: 6px 12px 0;
   border-bottom: 1px solid var(--cc-border-subtle);
 }
 
@@ -9,9 +9,10 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 10px;
+  padding: 6px 2px 8px;
   border: 0;
-  border-radius: var(--cc-radius-sm);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px; /* overlap the strip's 1px baseline */
   background: transparent;
   color: var(--cc-text-faint);
   font: inherit;
@@ -19,17 +20,16 @@
   cursor: pointer;
   transition:
     color var(--cc-t-base),
-    background var(--cc-t-base);
+    border-color var(--cc-t-base);
 }
 
 .pane-tab:hover {
-  background: var(--cc-overlay-bg);
   color: var(--cc-text-primary);
 }
 
 .pane-tab--active {
-  background: var(--cc-accent-bg);
   color: var(--cc-text-primary);
+  border-bottom-color: var(--cc-accent);
 }
 
 .pane-tab .lucide-icon {

--- a/app/src/components/PaneTabs/PaneTabs.css
+++ b/app/src/components/PaneTabs/PaneTabs.css
@@ -1,15 +1,20 @@
 .pane-tabs {
   display: flex;
-  gap: 14px;
-  padding: 6px 12px 0;
+  padding: 6px 0 0; /* no side inset → first tab sits flush with content */
   border-bottom: 1px solid var(--cc-border-subtle);
+}
+
+/* Modal context (source picker): the strip sits above form fields and needs a
+   gap below that the in-pane usage doesn't. */
+.pane-tabs--modal {
+  margin-bottom: 10px;
 }
 
 .pane-tab {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 2px 8px;
+  padding: 6px 10px 8px; /* side padding runs the underline wider than the label */
   border: 0;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px; /* overlap the strip's 1px baseline */

--- a/app/src/components/PaneTabs/PaneTabs.css
+++ b/app/src/components/PaneTabs/PaneTabs.css
@@ -14,7 +14,7 @@
   border-bottom: 2px solid transparent;
   margin-bottom: -1px; /* overlap the strip's 1px baseline */
   background: transparent;
-  color: var(--cc-text-faint);
+  color: var(--cc-text-muted); /* AA: faint fails 4.5:1 on the modal (bg-sidebar) surface */
   font: inherit;
   font-size: var(--cc-font-lg);
   cursor: pointer;

--- a/app/src/components/PaneTabs/PaneTabs.tsx
+++ b/app/src/components/PaneTabs/PaneTabs.tsx
@@ -15,11 +15,13 @@ export interface PaneTabsProps {
   tabs: PaneTab[];
   active: string;
   onSelect: (id: string) => void;
+  /** Extra class on the strip root for context-specific spacing (e.g. modal). */
+  class?: string;
 }
 
-export function PaneTabs({ tabs, active, onSelect }: PaneTabsProps) {
+export function PaneTabs({ tabs, active, onSelect, class: className }: PaneTabsProps) {
   return (
-    <div class="pane-tabs" role="tablist">
+    <div class={className ? `pane-tabs ${className}` : 'pane-tabs'} role="tablist">
       {tabs.map((t) => {
         const Icon = t.icon;
         const selected = t.id === active;

--- a/app/src/layout/App/App.tsx
+++ b/app/src/layout/App/App.tsx
@@ -25,13 +25,13 @@ import { RightSidebar } from '../RightSidebar/RightSidebar';
 import { SourcePicker } from '@/views/SourcePicker/SourcePicker';
 import { LoadingOverlay } from '@/components/LoadingOverlay/LoadingOverlay';
 import { HljsThemeLink } from '@/components/HljsThemeLink/HljsThemeLink';
-import { selectPath, resetView, focusCurrentSelection } from '@/state/stores/scene';
+import { selectPath, resetView, focusCurrentSelection, clearSelection } from '@/state/stores/scene';
 import {
   openSourcePicker,
   openSourcePickerForCurrentSource,
   closeSourcePicker,
 } from '@/state/stores/ui';
-import { SOURCE_ERROR } from '@/state/stores/source';
+import { SOURCE_ERROR, CURRENT_SOURCE } from '@/state/stores/source';
 import { MANIFEST } from '@/state/stores/manifest';
 import { isEmptyManifest } from '@/utils/manifest';
 import { URL_PARAMS } from '@/constants/urlParams';
@@ -44,6 +44,14 @@ export function App() {
   const submitSource = useManifestSource();
 
   useEffect(() => attachLoadingReactions(), []);
+
+  // Reset the picker selection whenever a world commits, so panes derived from
+  // it (the right sidebar, tree highlight) don't carry a stale node into the
+  // new world. Keyed on CURRENT_SOURCE — live-reloads don't rewrite it, so an
+  // in-place refresh keeps your selection.
+  useSignalEffect(() => {
+    if (CURRENT_SOURCE.value) clearSelection();
+  });
 
   // App coordinates the source picker; the fetch hook only reports outcomes.
   const dismissPicker = () => {

--- a/app/src/layout/LeftSidebar/LeftSidebar.css
+++ b/app/src/layout/LeftSidebar/LeftSidebar.css
@@ -51,7 +51,7 @@
   flex-direction: column;
   justify-content: space-between;
   align-items: stretch;
-  padding: var(--cc-space-4) 0;
+  padding: 0 0 var(--cc-space-4); /* first icon sits flush with the top */
 }
 .activity-bar-group {
   display: flex;

--- a/app/src/layout/LeftSidebar/LeftSidebar.tsx
+++ b/app/src/layout/LeftSidebar/LeftSidebar.tsx
@@ -137,11 +137,15 @@ export function LeftSidebar() {
     LEFT_SIDEBAR_COLLAPSED.value = collapsed.value;
   });
 
-  // Open to Info whenever a world commits — cold-boot ?src= and a user source
-  // switch both write CURRENT_SOURCE; live-reloads don't, so this fires once per
-  // real load and won't fight a manual tab change between loads.
+  // Open to Info AND expand the panel whenever a world commits — cold-boot
+  // ?src= and a user source switch both write CURRENT_SOURCE; live-reloads
+  // don't, so this fires once per real load and won't fight a manual tab/
+  // collapse change between loads.
   useSignalEffect(() => {
-    if (CURRENT_SOURCE.value) activeTab.value = DEFAULT_SIDEBAR_TAB;
+    if (CURRENT_SOURCE.value) {
+      activeTab.value = DEFAULT_SIDEBAR_TAB;
+      collapsed.value = false;
+    }
   });
 
   // Auto-collapse when the manifest has no content (cold-boot empty state).

--- a/app/src/styles/buttons.css
+++ b/app/src/styles/buttons.css
@@ -96,6 +96,12 @@
   font: inherit;
   color: var(--cc-text-muted);
 }
+/* Non-leaf text buttons (breadcrumb segments) hint interactivity on hover with
+   an underline — they sit in body-text color and otherwise read as static. The
+   leaf segment is the current location (.is-leaf) and stays plain. */
+.btn-icon--text:not(.is-leaf):hover {
+  text-decoration: underline;
+}
 .btn-icon--link {
   text-decoration: none;
 }

--- a/app/src/styles/focus.css
+++ b/app/src/styles/focus.css
@@ -1,0 +1,20 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   GLOBAL FOCUS RING
+   ═══════════════════════════════════════════════════════════════════════════
+   One keyboard-affordance floor for every interactive element (button, link,
+   tab, row, input). :focus-visible only fires for keyboard focus, so mouse
+   clicks stay ring-free. Components may still add a richer focus state on top;
+   this guarantees nobody is left with no signal.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+:focus-visible {
+  outline: 2px solid var(--cc-accent);
+  outline-offset: 2px;
+}
+
+/* Edge-to-edge icon clusters (footer chrome, header) where a 2px offset would
+   collide with neighbors. outline never reflows layout, so this is purely a
+   visual-spacing override — opt in per cluster. */
+.focus-inset:focus-visible {
+  outline-offset: -2px;
+}

--- a/app/src/styles/index.css
+++ b/app/src/styles/index.css
@@ -16,3 +16,4 @@
 @import './resize-handles.css';
 @import './empty-state.css';
 @import './icons.css';
+@import './focus.css';

--- a/app/src/styles/text.css
+++ b/app/src/styles/text.css
@@ -60,7 +60,7 @@
   color: var(--cc-accent-light);
   text-decoration: underline;
   text-underline-offset: 2px;
-  text-decoration-color: color-mix(in oklch, var(--cc-accent-light) 45%, transparent);
+  text-decoration-color: var(--cc-accent-light-border);
 }
 .link:hover {
   text-decoration-color: var(--cc-accent-light);

--- a/app/src/styles/text.css
+++ b/app/src/styles/text.css
@@ -50,6 +50,30 @@
   font-family: var(--cc-font-mono);
 }
 
+/* ── Links ────────────────────────────────────────────────────────────────
+   Two roles, one accent token. reset.css strips all <a> affordance, so any
+   link must opt into one of these.
+     .link         — prose/markdown: ALWAYS underlined (not color-only, AA-safe).
+     .link--chrome — standalone chrome (repo URL, SHA): underline on hover only,
+                     where surrounding context already signals a link. */
+.link {
+  color: var(--cc-accent-light);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: color-mix(in oklch, var(--cc-accent-light) 45%, transparent);
+}
+.link:hover {
+  text-decoration-color: var(--cc-accent-light);
+}
+.link--chrome {
+  color: var(--cc-accent-light);
+  text-decoration: none;
+}
+.link--chrome:hover,
+.link--chrome:focus-visible {
+  text-decoration: underline;
+}
+
 /* Truncation utility — collapses 3 declarations used 6+ times in the file. */
 .text-truncate {
   white-space: nowrap;

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -67,6 +67,7 @@
   --cc-accent-bg: color-mix(in oklch, var(--cc-accent) 18%, transparent);
   --cc-accent-bg-strong: color-mix(in oklch, var(--cc-accent) 30%, transparent);
   --cc-accent-border: color-mix(in oklch, var(--cc-accent) 45%, transparent);
+  --cc-accent-light-border: color-mix(in oklch, var(--cc-accent-light) 45%, transparent);
 
   /* ── COLORS — Semantic (success / warning / error) ────────────────────── */
   --cc-success: oklch(0.8 0.182 151.7);

--- a/app/src/views/InfoPane/InfoPane.css
+++ b/app/src/views/InfoPane/InfoPane.css
@@ -75,7 +75,7 @@
   color: var(--cc-accent-light);
   text-decoration: underline;
   text-underline-offset: 2px;
-  text-decoration-color: color-mix(in oklch, var(--cc-accent-light) 45%, transparent);
+  text-decoration-color: var(--cc-accent-light-border);
 }
 .info-markdown a:hover {
   text-decoration-color: var(--cc-accent-light);

--- a/app/src/views/InfoPane/InfoPane.css
+++ b/app/src/views/InfoPane/InfoPane.css
@@ -72,11 +72,13 @@
 }
 
 .info-markdown a {
-  color: var(--cc-accent);
-  text-decoration: none;
+  color: var(--cc-accent-light);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: color-mix(in oklch, var(--cc-accent-light) 45%, transparent);
 }
 .info-markdown a:hover {
-  text-decoration: underline;
+  text-decoration-color: var(--cc-accent-light);
 }
 
 .info-markdown strong {

--- a/app/src/views/InfoPane/InfoPane.tsx
+++ b/app/src/views/InfoPane/InfoPane.tsx
@@ -4,13 +4,16 @@
 
 import './InfoPane.css';
 import { useState } from 'preact/hooks';
+import { useSignalEffect } from '@preact/signals';
 import type { Signal } from '@preact/signals';
 import type { ComponentType } from 'preact';
 import { Globe, BookOpen } from 'lucide-preact';
 import type { LucideIcon } from 'lucide-preact';
 import type { DirNode, Manifest } from '@/types';
 import { Pane } from '@/components/Pane';
+import { PaneCloseButton } from '@/components/PaneHeader/PaneHeader';
 import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
+import { CURRENT_SOURCE } from '@/state/stores/source';
 import { OverviewPane } from './OverviewPane';
 import { ReadmePane } from './ReadmePane';
 
@@ -41,9 +44,23 @@ export interface InfoPaneProps {
 export function InfoPane({ manifest, onClose }: InfoPaneProps) {
   const [tab, setTab] = useState<InfoTab>(InfoTab.Overview);
   const active = INFO_TABS.find((t) => t.id === tab) ?? INFO_TABS[0];
+
+  // Reset to Overview when a new world commits — InfoPane stays mounted across
+  // world switches, so its subtab would otherwise persist. Keyed on
+  // CURRENT_SOURCE (not the manifest), so an in-place refresh keeps your subtab.
+  useSignalEffect(() => {
+    if (CURRENT_SOURCE.value) setTab(InfoTab.Overview);
+  });
   return (
-    <Pane paneClass="info-pane" title="Info" onClose={onClose}>
-      <PaneTabs tabs={INFO_TABS} active={tab} onSelect={(id) => setTab(id as InfoTab)} />
+    <Pane
+      paneClass="info-pane"
+      headerSlot={
+        <div class="pane-header pane-header--tabs">
+          <PaneTabs tabs={INFO_TABS} active={tab} onSelect={(id) => setTab(id as InfoTab)} />
+          {onClose && <PaneCloseButton onClose={onClose} />}
+        </div>
+      }
+    >
       <div class="pane-body info-body">
         <active.Component manifest={manifest} />
       </div>

--- a/app/src/views/InfoPane/OverviewPane.css
+++ b/app/src/views/InfoPane/OverviewPane.css
@@ -54,18 +54,8 @@
   white-space: nowrap;
 }
 
-.almanac-meta a {
-  color: var(--cc-accent-light);
-  text-decoration: none;
-}
-
-.almanac-meta a:hover {
-  text-decoration: underline;
-}
-
-/* The sha as plain text (no remote) vs. as the one link in the row (accent +
- * hover underline, matching the Remote link below). Both stay monospace and
- * never shrink. */
+/* The sha as plain text (no remote) vs. as the one link in the row. Both stay
+ * monospace and never shrink; link color/underline come from .link--chrome. */
 .almanac-sha,
 .almanac-sha-link {
   flex: 0 0 auto;
@@ -74,16 +64,6 @@
 
 .almanac-sha {
   color: var(--cc-text-primary);
-}
-
-.almanac-sha-link {
-  color: var(--cc-accent-light);
-  text-decoration: none;
-}
-
-.almanac-sha-link:hover,
-.almanac-sha-link:focus-visible {
-  text-decoration: underline;
 }
 
 /* Latest commit — an informational two-line row: sha + subject on top, relative

--- a/app/src/views/InfoPane/OverviewPane.tsx
+++ b/app/src/views/InfoPane/OverviewPane.tsx
@@ -249,7 +249,7 @@ export function OverviewPane({ manifest }: OverviewPaneProps) {
                   <span class="almanac-latest-head">
                     {latestUrl ? (
                       <a
-                        class="almanac-sha-link"
+                        class="almanac-sha-link link--chrome"
                         href={latestUrl}
                         target="_blank"
                         rel="noreferrer"
@@ -276,7 +276,7 @@ export function OverviewPane({ manifest }: OverviewPaneProps) {
             <div>
               <dt>Remote</dt>
               <dd>
-                <a href={repo.remote_url} target="_blank" rel="noreferrer">
+                <a class="link--chrome" href={repo.remote_url} target="_blank" rel="noreferrer">
                   {repo.remote_url}
                 </a>
               </dd>

--- a/app/src/views/SourcePicker/SourcePicker.css
+++ b/app/src/views/SourcePicker/SourcePicker.css
@@ -78,50 +78,6 @@
   flex: 1;
 }
 
-/* Tab strip — classic underline-tab pattern. The container draws the
-   horizontal rule under the row; each tab paints a 2px transparent
-   border-bottom that overlaps that rule (negative bottom margin) and
-   switches to the accent color on the active tab.
-
-   Layout:
-   - Negative inline margins pull the row out to the modal-card edges so
-     the underline spans the full card width.
-   - The row itself has padding that matches the modal body padding,
-     keeping the first/last tab aligned with the body content below.
-   - Individual tab buttons have no horizontal padding; the row's
-     gap property drives the spacing between tabs. */
-.modal-tabs {
-  display: flex;
-  gap: var(--cc-space-7); /* 16px between tabs */
-  margin-left: calc(-1 * var(--cc-space-6));
-  margin-right: calc(-1 * var(--cc-space-6));
-  margin-bottom: var(--cc-space-5);
-  padding: 0 var(--cc-space-6);
-  border-bottom: 1px solid var(--cc-border-subtle);
-}
-.modal-tabs button {
-  appearance: none;
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  color: var(--cc-text-muted);
-  padding: var(--cc-space-3) 0;
-  cursor: pointer;
-  font: inherit;
-  font-weight: var(--cc-fw-medium);
-  transition:
-    color var(--cc-t-base),
-    border-color var(--cc-t-base);
-}
-.modal-tabs button:hover {
-  color: var(--cc-text-primary);
-}
-.modal-tabs button.active {
-  color: var(--cc-text-primary);
-  border-bottom-color: var(--cc-accent);
-}
-
 .modal-field {
   display: flex;
   flex-direction: column;

--- a/app/src/views/SourcePicker/SourcePicker.tsx
+++ b/app/src/views/SourcePicker/SourcePicker.tsx
@@ -152,6 +152,7 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
         <div class="modal-body">
           {s.error && <div class="modal-error card-error">{s.error}</div>}
           <PaneTabs
+            class="pane-tabs--modal"
             tabs={[
               { id: SourceTab.Remote, label: 'Git URL' },
               { id: SourceTab.Local, label: 'Local path' },

--- a/app/src/views/SourcePicker/SourcePicker.tsx
+++ b/app/src/views/SourcePicker/SourcePicker.tsx
@@ -18,6 +18,7 @@ import { SERVER_CONFIG } from '@/state/stores/serverConfig';
 // ── Hosting-site SVG icons ───────────────────────────────────────────────────
 
 import { HostingIcon } from '@/components/HostingIcon';
+import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
 
 // ── Public types ────────────────────────────────────────────────────────────
 
@@ -150,24 +151,14 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
         </div>
         <div class="modal-body">
           {s.error && <div class="modal-error card-error">{s.error}</div>}
-          <div class="modal-tabs">
-            <button
-              type="button"
-              data-tab="remote"
-              class={activeTab === SourceTab.Remote ? 'active' : ''}
-              onClick={() => setActiveTab(SourceTab.Remote)}
-            >
-              Git URL
-            </button>
-            <button
-              type="button"
-              data-tab="local"
-              class={activeTab === SourceTab.Local ? 'active' : ''}
-              onClick={() => setActiveTab(SourceTab.Local)}
-            >
-              Local path
-            </button>
-          </div>
+          <PaneTabs
+            tabs={[
+              { id: SourceTab.Remote, label: 'Git URL' },
+              { id: SourceTab.Local, label: 'Local path' },
+            ]}
+            active={activeTab}
+            onSelect={(id) => setActiveTab(id as SourceTab)}
+          />
 
           <div
             data-pane="remote"

--- a/app/tests/views/sourcePicker.test.tsx
+++ b/app/tests/views/sourcePicker.test.tsx
@@ -69,6 +69,22 @@ describe('SourcePicker', () => {
     await flush();
   }
 
+  // PaneTabs renders `<button role="tab">` in the order tabs are passed:
+  // index 0 = Remote ("Git URL"), index 1 = Local ("Local path"). It exposes
+  // no data-* hooks, so address tabs by their PaneTabs position and read the
+  // active state off `aria-selected` / the `.pane-tab--active` class.
+  const TAB_INDEX: Record<SourceTab, number> = {
+    [SourceTab.Remote]: 0,
+    [SourceTab.Local]: 1,
+  };
+  function tabButton(tab: SourceTab): HTMLButtonElement {
+    const tabs = container.querySelectorAll('.pane-tab');
+    return tabs[TAB_INDEX[tab]] as HTMLButtonElement;
+  }
+  function isTabActive(tab: SourceTab): boolean {
+    return tabButton(tab).classList.contains('pane-tab--active');
+  }
+
   // Set a controlled input's value the way the component expects: write the
   // DOM value then dispatch an `input` event so the onInput handler updates
   // the backing useState. act() flushes that state update synchronously.
@@ -114,10 +130,10 @@ describe('SourcePicker', () => {
   it('switches tabs', async () => {
     createPicker({ allowLocalRepos: true });
     await open();
-    const gitTab = container.querySelector('[data-tab="remote"]') as HTMLButtonElement;
+    const gitTab = tabButton(SourceTab.Remote);
     act(() => gitTab.click());
     await flush();
-    expect(gitTab.classList.contains('active')).toBe(true);
+    expect(isTabActive(SourceTab.Remote)).toBe(true);
     // Git URL input visible
     expect(container.querySelector('[data-field="url"]')).toBeTruthy();
     // Branch input visible
@@ -128,7 +144,7 @@ describe('SourcePicker', () => {
     createPicker({ allowLocalRepos: true });
     await open();
     // Default tab is "git"; switch to local before setting the path field.
-    act(() => (container.querySelector('[data-tab="local"]') as HTMLButtonElement).click());
+    act(() => tabButton(SourceTab.Local).click());
     await flush();
     setInput('[data-field="path"]', '/Users/foo/bar');
     act(() => (container.querySelector('button.submit') as HTMLButtonElement).click());
@@ -145,7 +161,7 @@ describe('SourcePicker', () => {
   it('git-tab submit includes branch', async () => {
     createPicker({ allowLocalRepos: true });
     await open();
-    act(() => (container.querySelector('[data-tab="remote"]') as HTMLButtonElement).click());
+    act(() => tabButton(SourceTab.Remote).click());
     await flush();
     setInput('[data-field="url"]', 'https://github.com/o/r');
     setInput('[data-field="branch"]', 'main');
@@ -231,11 +247,7 @@ describe('SourcePicker', () => {
   it('prefill populates inputs', async () => {
     createPicker({ allowLocalRepos: true });
     await open({ prefill: { src: 'https://github.com/o/r', branch: 'develop' } });
-    expect(
-      (container.querySelector('[data-tab="remote"]') as HTMLButtonElement).classList.contains(
-        'active'
-      )
-    ).toBe(true);
+    expect(isTabActive(SourceTab.Remote)).toBe(true);
     expect((container.querySelector('[data-field="url"]') as HTMLInputElement).value).toBe(
       'https://github.com/o/r'
     );
@@ -269,7 +281,7 @@ describe('SourcePicker', () => {
   it('disabled: renders a warning card in the Local pane instead of the input', async () => {
     createPicker({ allowLocalRepos: false });
     await open();
-    act(() => (container.querySelector('[data-tab="local"]') as HTMLButtonElement).click());
+    act(() => tabButton(SourceTab.Local).click());
     await flush();
     // Path input is GONE.
     expect(container.querySelector('[data-field="path"]')).toBeNull();
@@ -284,8 +296,7 @@ describe('SourcePicker', () => {
   it('disabled: default tab is git even when prefill is a local path', async () => {
     createPicker({ allowLocalRepos: false });
     await open({ prefill: { src: '/Users/foo/bar' } });
-    const gitTab = container.querySelector('[data-tab="remote"]') as HTMLButtonElement;
-    expect(gitTab.classList.contains('active')).toBe(true);
+    expect(isTabActive(SourceTab.Remote)).toBe(true);
   });
 
   it('disabled: local recents render with warning badge + dimmed class', async () => {
@@ -333,7 +344,7 @@ describe('SourcePicker', () => {
     createPicker({ allowLocalRepos: false });
     await open();
     // Default opens on Git tab; switch to Local.
-    act(() => (container.querySelector('[data-tab="local"]') as HTMLButtonElement).click());
+    act(() => tabButton(SourceTab.Local).click());
     await flush();
     const formFields = container.querySelector('[data-form-fields]') as HTMLElement;
     expect(formFields).toBeTruthy();
@@ -343,9 +354,9 @@ describe('SourcePicker', () => {
   it('disabled: switching back to Git tab reveals the form fields again', async () => {
     createPicker({ allowLocalRepos: false });
     await open();
-    act(() => (container.querySelector('[data-tab="local"]') as HTMLButtonElement).click());
+    act(() => tabButton(SourceTab.Local).click());
     await flush();
-    act(() => (container.querySelector('[data-tab="remote"]') as HTMLButtonElement).click());
+    act(() => tabButton(SourceTab.Remote).click());
     await flush();
     const formFields = container.querySelector('[data-form-fields]') as HTMLElement;
     expect(formFields.style.display).not.toBe('none');
@@ -356,7 +367,7 @@ describe('SourcePicker', () => {
   it('enabled: form fields render on the Local pane (regression guard)', async () => {
     createPicker({ allowLocalRepos: true });
     await open();
-    act(() => (container.querySelector('[data-tab="local"]') as HTMLButtonElement).click());
+    act(() => tabButton(SourceTab.Local).click());
     await flush();
     const formFields = container.querySelector('[data-form-fields]') as HTMLElement;
     expect(formFields.style.display).not.toBe('none');

--- a/app/tests/views/sourcePicker.test.tsx
+++ b/app/tests/views/sourcePicker.test.tsx
@@ -72,7 +72,7 @@ describe('SourcePicker', () => {
   // PaneTabs renders `<button role="tab">` in the order tabs are passed:
   // index 0 = Remote ("Git URL"), index 1 = Local ("Local path"). It exposes
   // no data-* hooks, so address tabs by their PaneTabs position and read the
-  // active state off `aria-selected` / the `.pane-tab--active` class.
+  // active state off the contractual `aria-selected` attribute.
   const TAB_INDEX: Record<SourceTab, number> = {
     [SourceTab.Remote]: 0,
     [SourceTab.Local]: 1,
@@ -82,7 +82,7 @@ describe('SourcePicker', () => {
     return tabs[TAB_INDEX[tab]] as HTMLButtonElement;
   }
   function isTabActive(tab: SourceTab): boolean {
-    return tabButton(tab).classList.contains('pane-tab--active');
+    return tabButton(tab).getAttribute('aria-selected') === 'true';
   }
 
   // Set a controlled input's value the way the component expects: write the


### PR DESCRIPTION
Closes #78.

## #78 — interactive elements now read as interactive

A token-driven affordance vocabulary, applied through the existing `styles/` kit (no bespoke per-component styles):

- **Links** — `.link` (prose/markdown: accent + always underlined, AA-safe) and `.link--chrome` (repo URL / SHA: accent + underline on hover). The three hand-rolled baselines (`.almanac-meta a`, `.almanac-sha-link`, `.info-markdown a`) collapse onto these; the shared underline color is the new `--cc-accent-light-border` token.
- **Tabs** — `.pane-tab` becomes an underline strip; the duplicate `.modal-tabs` styling is deleted and the source picker reuses `PaneTabs`. One tab component, compatible with #69's Settings subtabs.
- **Focus** — one global `:focus-visible` ring (`styles/focus.css`) covering every button, link, tab, and row. Closes the keyboard gap (coordinates with #79).
- **Text buttons** — breadcrumb non-leaf segments underline on hover (leaf stays static).
- **Contrast (AA)** — verified every interactive resting color; the one real failure (inactive tab label = 4.45:1 on the modal surface) was fixed by bumping `.pane-tab` rest from `--cc-text-faint` to `--cc-text-muted` (6.08:1). Links land at 10:1+, the active-tab underline at 7:1.

## Beyond #78 — Info-pane header & world-switch UX (requested in review)

Grouped in their own commits so the affordance work stays separable:

- **Info pane header** — `Pane` gains a `headerSlot`; the close `×` is extracted to a shared `<PaneCloseButton>`. Info drops its "Info" title row and renders the Overview/Readme tabs as the header itself, reclaiming a row of vertical space. Tabs sit flush-left with internal label padding.
- **World-switch reactions** (keyed on `CURRENT_SOURCE`, so in-place refreshes don't trigger them): reset the picker → right sidebar closes + tree highlight clears (it previously carried a stale node into the new world); expand the left sidebar; reset the Info subtab to Overview.
- **Activity bar** — dropped the top padding so the first icon sits flush.

## Verification

Verified visually in the running app (`just dev`) with mouse + keyboard across every audited surface, plus `just lint` and `just test` (2373 passing).