### PR TITLE
feat: improve pane tab accessibility

### DIFF
--- a/app/src/components/PaneTabs/PaneTabs.tsx
+++ b/app/src/components/PaneTabs/PaneTabs.tsx
@@ -15,24 +15,57 @@ export interface PaneTabsProps {
   tabs: PaneTab[];
   active: string;
   onSelect: (id: string) => void;
+  idPrefix?: string;
   /** Extra class on the strip root for context-specific spacing (e.g. modal). */
   class?: string;
 }
 
-export function PaneTabs({ tabs, active, onSelect, class: className }: PaneTabsProps) {
+export function paneTabId(idPrefix: string, tabId: string) {
+  return `${idPrefix}-${tabId}-tab`;
+}
+
+export function panePanelId(idPrefix: string, tabId: string) {
+  return `${idPrefix}-${tabId}-panel`;
+}
+
+function nextTabId(tabs: PaneTab[], activeId: string, key: string) {
+  const index = tabs.findIndex((tab) => tab.id === activeId);
+  const current = index === -1 ? 0 : index;
+
+  if (key === 'Home') return tabs[0]?.id;
+  if (key === 'End') return tabs[tabs.length - 1]?.id;
+  if (key === 'ArrowRight' || key === 'ArrowDown') return tabs[(current + 1) % tabs.length]?.id;
+  if (key === 'ArrowLeft' || key === 'ArrowUp') {
+    return tabs[(current - 1 + tabs.length) % tabs.length]?.id;
+  }
+  return undefined;
+}
+
+export function PaneTabs({ tabs, active, onSelect, idPrefix, class: className }: PaneTabsProps) {
   return (
     <div class={className ? `pane-tabs ${className}` : 'pane-tabs'} role="tablist">
       {tabs.map((t) => {
         const Icon = t.icon;
         const selected = t.id === active;
+        const tabId = idPrefix ? paneTabId(idPrefix, t.id) : undefined;
+        const panelId = idPrefix ? panePanelId(idPrefix, t.id) : undefined;
         return (
           <button
             key={t.id}
+            id={tabId}
             type="button"
             role="tab"
             aria-selected={selected ? 'true' : 'false'}
+            aria-controls={panelId}
+            tabIndex={selected ? 0 : -1}
             class={selected ? 'pane-tab pane-tab--active' : 'pane-tab'}
             onClick={() => onSelect(t.id)}
+            onKeyDown={(e) => {
+              const targetId = nextTabId(tabs, t.id, e.key);
+              if (!targetId) return;
+              e.preventDefault();
+              onSelect(targetId);
+            }}
           >
             {Icon && <Icon class="lucide-icon" aria-hidden="true" />}
             <span>{t.label}</span>

--- a/app/src/views/InfoPane/InfoPane.tsx
+++ b/app/src/views/InfoPane/InfoPane.tsx
@@ -12,7 +12,7 @@ import type { LucideIcon } from 'lucide-preact';
 import type { DirNode, Manifest } from '@/types';
 import { Pane } from '@/components/Pane';
 import { PaneCloseButton } from '@/components/PaneHeader/PaneHeader';
-import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
+import { PaneTabs, panePanelId, paneTabId } from '@/components/PaneTabs/PaneTabs';
 import { CURRENT_SOURCE } from '@/state/stores/source';
 import { OverviewPane } from './OverviewPane';
 import { ReadmePane } from './ReadmePane';
@@ -35,6 +35,7 @@ const INFO_TABS: InfoTabDef[] = [
   { id: InfoTab.Overview, label: 'Overview', icon: Globe, Component: OverviewPane },
   { id: InfoTab.Readme, label: 'Readme', icon: BookOpen, Component: ReadmePane },
 ];
+const INFO_TABS_ID = 'info-pane';
 
 export interface InfoPaneProps {
   manifest: ManifestSignal;
@@ -56,12 +57,22 @@ export function InfoPane({ manifest, onClose }: InfoPaneProps) {
       paneClass="info-pane"
       headerSlot={
         <div class="pane-header pane-header--tabs">
-          <PaneTabs tabs={INFO_TABS} active={tab} onSelect={(id) => setTab(id as InfoTab)} />
+          <PaneTabs
+            idPrefix={INFO_TABS_ID}
+            tabs={INFO_TABS}
+            active={tab}
+            onSelect={(id) => setTab(id as InfoTab)}
+          />
           {onClose && <PaneCloseButton onClose={onClose} />}
         </div>
       }
     >
-      <div class="pane-body info-body">
+      <div
+        id={panePanelId(INFO_TABS_ID, active.id)}
+        class="pane-body info-body"
+        role="tabpanel"
+        aria-labelledby={paneTabId(INFO_TABS_ID, active.id)}
+      >
         <active.Component manifest={manifest} />
       </div>
     </Pane>

--- a/app/src/views/SourcePicker/SourcePicker.tsx
+++ b/app/src/views/SourcePicker/SourcePicker.tsx
@@ -18,7 +18,7 @@ import { SERVER_CONFIG } from '@/state/stores/serverConfig';
 // ── Hosting-site SVG icons ───────────────────────────────────────────────────
 
 import { HostingIcon } from '@/components/HostingIcon';
-import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
+import { PaneTabs, panePanelId, paneTabId } from '@/components/PaneTabs/PaneTabs';
 
 // ── Public types ────────────────────────────────────────────────────────────
 
@@ -27,6 +27,8 @@ export enum SourceTab {
   Remote = 'remote',
   Local = 'local',
 }
+
+const SOURCE_PICKER_TABS_ID = 'source-picker';
 
 /** Infer which tab a source string belongs to: git-like URLs / SCP syntax
  *  → Remote, anything else (filesystem paths) → Local. UX-only tab defaulting
@@ -152,6 +154,7 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
         <div class="modal-body">
           {s.error && <div class="modal-error card-error">{s.error}</div>}
           <PaneTabs
+            idPrefix={SOURCE_PICKER_TABS_ID}
             class="pane-tabs--modal"
             tabs={[
               { id: SourceTab.Remote, label: 'Git URL' },
@@ -162,6 +165,9 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
           />
 
           <div
+            id={panePanelId(SOURCE_PICKER_TABS_ID, SourceTab.Remote)}
+            role="tabpanel"
+            aria-labelledby={paneTabId(SOURCE_PICKER_TABS_ID, SourceTab.Remote)}
             data-pane="remote"
             style={{ display: activeTab === SourceTab.Remote ? 'block' : 'none' }}
           >
@@ -192,6 +198,9 @@ export function SourcePickerModal({ state, onSubmit, onClose }: SourcePickerModa
           </div>
 
           <div
+            id={panePanelId(SOURCE_PICKER_TABS_ID, SourceTab.Local)}
+            role="tabpanel"
+            aria-labelledby={paneTabId(SOURCE_PICKER_TABS_ID, SourceTab.Local)}
             data-pane="local"
             style={{ display: activeTab === SourceTab.Local ? 'block' : 'none' }}
           >

--- a/app/tests/components/paneTabs.test.tsx
+++ b/app/tests/components/paneTabs.test.tsx
@@ -27,10 +27,19 @@ describe('PaneTabs', () => {
     ) as HTMLButtonElement;
 
   it('renders a tab per entry and marks the active one', async () => {
-    render(<PaneTabs tabs={tabs} active="world" onSelect={() => {}} />, container);
+    render(
+      <PaneTabs idPrefix="info-pane" tabs={tabs} active="world" onSelect={() => {}} />,
+      container
+    );
     await flush();
-    expect(tabByLabel('World').getAttribute('aria-selected')).toBe('true');
-    expect(tabByLabel('Readme').getAttribute('aria-selected')).toBe('false');
+    const world = tabByLabel('World');
+    const readme = tabByLabel('Readme');
+    expect(world.getAttribute('aria-selected')).toBe('true');
+    expect(world.getAttribute('aria-controls')).toBe('info-pane-world-panel');
+    expect(world.id).toBe('info-pane-world-tab');
+    expect(world.tabIndex).toBe(0);
+    expect(readme.getAttribute('aria-selected')).toBe('false');
+    expect(readme.tabIndex).toBe(-1);
   });
 
   it('calls onSelect with the clicked tab id', async () => {
@@ -39,5 +48,20 @@ describe('PaneTabs', () => {
     await flush();
     tabByLabel('Readme').click();
     expect(onSelect).toHaveBeenCalledWith('readme');
+  });
+
+  it('moves selection with tablist keyboard shortcuts', async () => {
+    const onSelect = vi.fn();
+    render(<PaneTabs tabs={tabs} active="world" onSelect={onSelect} />, container);
+    await flush();
+
+    tabByLabel('World').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    expect(onSelect).toHaveBeenLastCalledWith('readme');
+
+    tabByLabel('World').dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+    expect(onSelect).toHaveBeenLastCalledWith('readme');
+
+    tabByLabel('Readme').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    expect(onSelect).toHaveBeenLastCalledWith('world');
   });
 });

--- a/app/tests/views/InfoPane/infoPane.test.tsx
+++ b/app/tests/views/InfoPane/infoPane.test.tsx
@@ -26,6 +26,9 @@ describe('InfoPane shell', () => {
     await flush();
     expect(tabByLabel('Overview').getAttribute('aria-selected')).toBe('true');
     expect(tabByLabel('Readme').getAttribute('aria-selected')).toBe('false');
+    const panel = container.querySelector('[role="tabpanel"]') as HTMLElement;
+    expect(panel.id).toBe('info-pane-overview-panel');
+    expect(panel.getAttribute('aria-labelledby')).toBe('info-pane-overview-tab');
   });
 
   it('switches to Readme when its tab is clicked', async () => {
@@ -35,5 +38,8 @@ describe('InfoPane shell', () => {
     tabByLabel('Readme').click();
     await flush();
     expect(tabByLabel('Readme').getAttribute('aria-selected')).toBe('true');
+    const panel = container.querySelector('[role="tabpanel"]') as HTMLElement;
+    expect(panel.id).toBe('info-pane-readme-panel');
+    expect(panel.getAttribute('aria-labelledby')).toBe('info-pane-readme-tab');
   });
 });

--- a/app/tests/views/sourcePicker.test.tsx
+++ b/app/tests/views/sourcePicker.test.tsx
@@ -70,9 +70,7 @@ describe('SourcePicker', () => {
   }
 
   // PaneTabs renders `<button role="tab">` in the order tabs are passed:
-  // index 0 = Remote ("Git URL"), index 1 = Local ("Local path"). It exposes
-  // no data-* hooks, so address tabs by their PaneTabs position and read the
-  // active state off the contractual `aria-selected` attribute.
+  // index 0 = Remote ("Git URL"), index 1 = Local ("Local path").
   const TAB_INDEX: Record<SourceTab, number> = {
     [SourceTab.Remote]: 0,
     [SourceTab.Local]: 1,
@@ -138,6 +136,24 @@ describe('SourcePicker', () => {
     expect(container.querySelector('[data-field="url"]')).toBeTruthy();
     // Branch input visible
     expect(container.querySelector('[data-field="branch"]')).toBeTruthy();
+  });
+
+  it('links source tabs to their panels', async () => {
+    createPicker({ allowLocalRepos: true });
+    await open();
+    const remoteTab = tabButton(SourceTab.Remote);
+    const remotePanel = container.querySelector('[data-pane="remote"]') as HTMLElement;
+    const localTab = tabButton(SourceTab.Local);
+    const localPanel = container.querySelector('[data-pane="local"]') as HTMLElement;
+
+    expect(remoteTab.id).toBe('source-picker-remote-tab');
+    expect(remoteTab.getAttribute('aria-controls')).toBe('source-picker-remote-panel');
+    expect(remotePanel.getAttribute('role')).toBe('tabpanel');
+    expect(remotePanel.getAttribute('aria-labelledby')).toBe('source-picker-remote-tab');
+    expect(localTab.id).toBe('source-picker-local-tab');
+    expect(localTab.getAttribute('aria-controls')).toBe('source-picker-local-panel');
+    expect(localPanel.getAttribute('role')).toBe('tabpanel');
+    expect(localPanel.getAttribute('aria-labelledby')).toBe('source-picker-local-tab');
   });
 
   it('submit fires onSubmit with the typed src', async () => {


### PR DESCRIPTION
## Summary
- link pane tabs to their active tab panels with stable ids and aria-controls
- add roving tabIndex plus arrow/Home/End keyboard handling for pane tab strips
- wire the semantics through InfoPane and SourcePicker modal panels

Refs #79

## Verification
- npm run test -- paneTabs infoPane sourcePicker
- npm run typecheck
- npm run format:check -- src/components/PaneTabs/PaneTabs.tsx src/views/InfoPane/InfoPane.tsx src/views/SourcePicker/SourcePicker.tsx tests/components/paneTabs.test.tsx tests/views/InfoPane/infoPane.test.tsx tests/views/sourcePicker.test.tsx
- npm run lint -- src/components/PaneTabs/PaneTabs.tsx src/views/InfoPane/InfoPane.tsx src/views/SourcePicker/SourcePicker.tsx tests/components/paneTabs.test.tsx tests/views/InfoPane/infoPane.test.tsx tests/views/sourcePicker.test.tsx