### PR TITLE
Info pane: Legend + Explore split, plus a view & chrome polish pass

### DIFF
--- a/app/src/city/render/cameraRig.ts
+++ b/app/src/city/render/cameraRig.ts
@@ -44,6 +44,8 @@ import {
 import { NodeKind, StreetAxis } from '@/types';
 import type { Building, PickTarget, Street } from '@/types';
 import type { CityState } from '@/city/state';
+import { computeFramingDir } from './framingDir';
+import { CAMERA } from '@/state/stores/settings/camera';
 
 /** Narrow accessor surface the rig needs from the composer for component
  *  geometry (repoLabel/trees). World framing inputs (bbox, gem, root street,
@@ -86,18 +88,6 @@ const STREET_FOCUS_RATIO = 1.2;
 // controls.maxPolarAngle.
 const TOP_DOWN_ELEVATION_DEG = 80;
 const TOP_DOWN_PADDING_MULT = 2.8;
-
-// y-component of the start framing direction vector (before normalization).
-// Combined with FRAMING_DIR_LATERAL below: with lateral=0.3, y=1.0 gives
-// ~43.7° elevation.
-const FRAMING_DIR_Y = 1.0;
-
-// Lateral component on the framing direction vector — perpendicular to
-// the root street's long axis. Adds an isometric-style off-axis tilt so
-// the camera doesn't look straight down the road; both sides of the
-// street read in 3D instead of stacking face-on. 0.3 → ~15° lateral
-// angle from the street axis.
-const FRAMING_DIR_LATERAL = 0.3;
 
 // Headroom above the tallest building's roof when fitting the start
 // framing. 1.0 = spire flush at the top edge of the vertical FOV
@@ -224,23 +214,17 @@ export function createCameraRig({
     // screen" framing. INITIAL_DISTANCE_MULT (<1) tightens the sphere fit
     // intentionally; tuned for the typical city shape.
     const widthDist = (framingRadius / Math.sin(halfFov)) * CAMERA_INITIAL_DISTANCE_MULT;
-    // Default framing direction: place the camera BEHIND the gem along
-    // the root street's long axis (the street extends in +X for X-oriented
-    // or +Z for Y-oriented; the gem sits at the low end — see
-    // city/components/gem/mesh.ts:createRootGem) at a moderate elevation with a slight
-    // lateral offset so the view reads as 3D oblique rather than face-on
-    // down the road. FRAMING_DIR_Y (1.0) → ~44° elevation after the
-    // lateral mix; FRAMING_DIR_LATERAL (0.3) → ~15° azimuth off the
-    // street axis. Fallback (no gem) uses a high-oblique direction.
-    let dir: THREE.Vector3;
-    if (rootStreet) {
-      dir =
-        rootStreet.orientation === StreetAxis.X
-          ? new THREE.Vector3(-1, FRAMING_DIR_Y, FRAMING_DIR_LATERAL).normalize()
-          : new THREE.Vector3(FRAMING_DIR_LATERAL, FRAMING_DIR_Y, -1).normalize();
-    } else {
-      dir = new THREE.Vector3(-1, 1, 1).normalize();
-    }
+    // Default framing direction: place the camera BEHIND the gem along the root
+    // street's long axis (the street extends in +X for X-oriented or +Z for
+    // Y-oriented; the gem sits at the low end — see gem/mesh.ts:createRootGem),
+    // lifted + swung by the user's elevation/azimuth (CAMERA store). Read
+    // untracked here — the reframe effect this runs inside tracks bbox only; a
+    // dedicated CAMERA effect re-frames on angle changes.
+    const dir = computeFramingDir(
+      CAMERA.value.ELEVATION,
+      CAMERA.value.AZIMUTH,
+      rootStreet ? rootStreet.orientation : null
+    );
 
     // Height fit: project the tallest building's 4 roof corners through
     // the camera math and find the minimum D such that they all sit
@@ -353,6 +337,15 @@ export function createCameraRig({
     // change in lockstep with bbox anyway, but tracking just bbox keeps the
     // dependency set exactly what it claims to be.
     untracked(_captureFraming);
+  });
+
+  // Re-frame live when the user drags the default camera angle. CAMERA is an
+  // autosave store, so the slider writes through immediately; reset() reads the
+  // fresh angle (via _captureFraming) and hard-snaps to the new pose. Subscribes
+  // to CAMERA only; on construction bbox is empty so reset() no-ops.
+  const _disposeCameraAngleEffect = effect(() => {
+    void CAMERA.value;
+    untracked(reset);
   });
 
   function update(_dtMs: number): void {
@@ -525,6 +518,7 @@ export function createCameraRig({
 
   function dispose() {
     _disposeReframeEffect();
+    _disposeCameraAngleEffect();
     if (typeof controls.dispose === 'function') controls.dispose();
   }
 

--- a/app/src/city/render/framingDir.ts
+++ b/app/src/city/render/framingDir.ts
@@ -1,0 +1,37 @@
+// city/render/framingDir.ts — the default camera's offset direction (camera =
+// target + dir·distance), derived from a user-tunable elevation + azimuth. The
+// target is always the root gem; only this direction changes. Pure math so it's
+// unit-testable without the rig/canvas.
+
+import * as THREE from 'three';
+import { StreetAxis } from '@/types';
+
+const DEG2RAD = Math.PI / 180;
+
+/**
+ * Unit camera-offset direction for the start framing. `elevationDeg` lifts the
+ * camera above the horizon (90° = straight overhead); `azimuthDeg` swings it
+ * around the gem, measured off the root street's long axis (0° = looking
+ * straight down the street from behind the gem). `axis` is the root street's
+ * orientation, or null when there's no gem (a high-oblique fallback).
+ */
+export function computeFramingDir(
+  elevationDeg: number,
+  azimuthDeg: number,
+  axis: StreetAxis | null
+): THREE.Vector3 {
+  const e = elevationDeg * DEG2RAD;
+  const a = azimuthDeg * DEG2RAD;
+  const cosE = Math.cos(e);
+  const sinE = Math.sin(e);
+  // Behind the gem along the street's long axis; azimuth mixes in the
+  // perpendicular (lateral) horizontal axis; elevation lifts it toward +Y.
+  if (axis === StreetAxis.X) {
+    return new THREE.Vector3(-cosE * Math.cos(a), sinE, cosE * Math.sin(a)).normalize();
+  }
+  if (axis === StreetAxis.Y) {
+    return new THREE.Vector3(cosE * Math.sin(a), sinE, -cosE * Math.cos(a)).normalize();
+  }
+  // No root street (no gem): honor the angles against a default X-axis frame.
+  return new THREE.Vector3(-cosE * Math.cos(a), sinE, cosE * Math.sin(a)).normalize();
+}

--- a/app/src/components/Pane.tsx
+++ b/app/src/components/Pane.tsx
@@ -14,7 +14,7 @@ import type { LucideIcon } from 'lucide-preact';
 import { PaneHeader } from './PaneHeader/PaneHeader';
 
 export interface PaneProps {
-  /** Extra class on the outer `.pane` (e.g. 'commit-pane', 'tree-pane'). */
+  /** Extra class on the outer `.pane` (e.g. 'commit-pane', 'explore-pane'). */
   paneClass?: string;
   /** Replaces the entire default <PaneHeader> — for panes whose header isn't a
    *  title bar (e.g. a tabbed pane whose tab strip IS the header). When set,

--- a/app/src/components/PaneHeader/PaneHeader.css
+++ b/app/src/components/PaneHeader/PaneHeader.css
@@ -31,11 +31,12 @@
   flex: 1 1 auto;
   border-bottom: 0;
 }
-.pane-header--tabs > .btn-icon--text {
+.pane-header--tabs > .btn-icon {
   align-self: center;
 }
 
-/* Pane-header close + action buttons use .btn-icon + .btn-icon--text. */
+/* Pane-header action buttons (e.g. focus) use .btn-icon--text; the close button
+ * is a plain .btn-icon so it matches the app-header icons. */
 .pane-header .btn-icon--text {
   line-height: 1;
 }

--- a/app/src/components/PaneHeader/PaneHeader.tsx
+++ b/app/src/components/PaneHeader/PaneHeader.tsx
@@ -78,12 +78,13 @@ export interface PaneCloseButtonProps {
 }
 
 /** The pane's × close button. Shared by the default header and by panes that
- *  compose their own header (e.g. InfoPane's tab strip). */
+ *  compose their own header (e.g. InfoPane's tab strip). Plain .btn-icon so it
+ *  matches the icon-only buttons in the app header. */
 export function PaneCloseButton({ onClose, title = 'Hide sidebar' }: PaneCloseButtonProps) {
   return (
     <button
       type="button"
-      class="btn-icon btn-icon--text"
+      class="btn-icon"
       title={title}
       aria-label={title}
       onClick={() => onClose()}

--- a/app/src/components/ProjectSwitcher/ProjectSwitcher.tsx
+++ b/app/src/components/ProjectSwitcher/ProjectSwitcher.tsx
@@ -1,11 +1,11 @@
-// components/ProjectSwitcher.tsx — The project chip: icon + label + optional
-// @branch pill + a switch cue. Click opens the project switcher. The trailing
-// glyph is ChevronsUpDown (a "switchable value" cue), not a down-caret, since
-// clicking opens a full switcher screen rather than a dropdown menu.
+// components/ProjectSwitcher.tsx — The project chip: label + optional @branch
+// pill + a switch cue. Click opens the project switcher. The trailing glyph is
+// ChevronsUpDown (a "switchable value" cue), not a down-caret, since clicking
+// opens a full switcher screen rather than a dropdown menu.
 // Renders nothing until a project is loaded (no label).
 
 import './ProjectSwitcher.css';
-import { ChevronsUpDown, Map } from 'lucide-preact';
+import { ChevronsUpDown } from 'lucide-preact';
 
 export interface ProjectSwitcherProps {
   rootLabel: string;
@@ -26,7 +26,6 @@ export function ProjectSwitcher({ rootLabel, branch, onSwitchSource }: ProjectSw
         if (onSwitchSource) onSwitchSource();
       }}
     >
-      <Map class="lucide-icon" />
       <span class="btn-chip-label">{rootLabel}</span>
       {branch && <span class="app-header-branch-pill">@{branch}</span>}
       <ChevronsUpDown class="lucide-icon btn-chip-affordance" />

--- a/app/src/constants/storage.ts
+++ b/app/src/constants/storage.ts
@@ -19,6 +19,4 @@ export const PERSISTED_KEYS = {
   LEFT_SIDEBAR_WIDTH: 'leftSidebarWidth',
   /** Right (file/commit/street pane) sidebar drag-handle width in px. */
   RIGHT_SIDEBAR_WIDTH: 'rightSidebarWidth',
-  /** Left sidebar collapsed state. */
-  LEFT_SIDEBAR_COLLAPSED: 'leftSidebarCollapsed',
 } as const;

--- a/app/src/constants/ui.ts
+++ b/app/src/constants/ui.ts
@@ -1,6 +1,6 @@
 // constants/ui.ts — UI metadata that isn't user-tunable.
 
-import { FolderTree, Search, Info, Settings2, type LucideIcon } from 'lucide-preact';
+import { Compass, Search, Info, Settings2, type LucideIcon } from 'lucide-preact';
 import { SidebarTab } from '@/types/ui';
 
 /** Max number of recently-opened sources kept in the source-picker MRU list
@@ -32,7 +32,7 @@ export const ACTIVITY_BAR_TABS: readonly ActivityBarTab[] = [
   // Info leads: the almanac is the first thing a freshly-loaded world greets you
   // with (see DEFAULT_SIDEBAR_TAB + LeftSidebar's on-load switch).
   { id: SidebarTab.Info, icon: Info, title: 'Info' },
-  { id: SidebarTab.Tree, icon: FolderTree, title: 'Tree' },
+  { id: SidebarTab.Explore, icon: Compass, title: 'Explore' },
   { id: SidebarTab.Search, icon: Search, title: 'Search' },
   { id: SidebarTab.Controls, icon: Settings2, title: 'Settings', placement: TabPlacement.Bottom },
 ] as const;

--- a/app/src/layout/LeftSidebar/LeftSidebar.tsx
+++ b/app/src/layout/LeftSidebar/LeftSidebar.tsx
@@ -26,7 +26,7 @@ import { SCENE_HANDLE, selectPath, focusPath, hoverPath, clearHover } from '@/st
 import { MANIFEST } from '@/state/stores/manifest';
 import { CURRENT_SOURCE } from '@/state/stores/source';
 import { isEmptyManifest } from '@/utils/manifest';
-import { TreePane } from '@/views/TreePane/TreePane';
+import { ExplorePane } from '@/views/ExplorePane/ExplorePane';
 import { InfoPane } from '@/views/InfoPane/InfoPane';
 import { SearchPane } from '@/views/SearchPane/SearchPane';
 import { ControlsPane } from '@/views/ControlsPane/ControlsPane';
@@ -181,8 +181,8 @@ export function LeftSidebar() {
     >
       <ActivityBar activeTab={tab} collapsed={effectiveCollapsed} onIconClick={onIconClick} />
       <div class="pane">
-        {tab === SidebarTab.Tree && (
-          <TreePane
+        {tab === SidebarTab.Explore && (
+          <ExplorePane
             manifest={MANIFEST}
             selectedPath={selectedPath}
             hoveredPath={hoveredPath}

--- a/app/src/layout/LeftSidebar/LeftSidebar.tsx
+++ b/app/src/layout/LeftSidebar/LeftSidebar.tsx
@@ -22,7 +22,7 @@ import { PERSISTED_KEYS } from '@/constants/storage';
 import { SidebarTab, NodeKind } from '@/types';
 import type { PickTarget, TreeNode } from '@/types';
 import { persistedSignal } from '@/state/persist';
-import { SCENE_HANDLE, selectPath, focusPath, hoverPath, clearHover } from '@/state/stores/scene';
+import { SCENE_HANDLE, selectPath, hoverPath, clearHover } from '@/state/stores/scene';
 import { MANIFEST } from '@/state/stores/manifest';
 import { CURRENT_SOURCE } from '@/state/stores/source';
 import { isEmptyManifest } from '@/utils/manifest';
@@ -195,12 +195,7 @@ export function LeftSidebar() {
           />
         )}
         {tab === SidebarTab.Search && (
-          <SearchPane
-            manifest={MANIFEST}
-            onClose={onPaneClose}
-            onSelect={selectPath}
-            onFocus={focusPath}
-          />
+          <SearchPane manifest={MANIFEST} onClose={onPaneClose} onSelect={selectPath} />
         )}
         {tab === SidebarTab.Info && <InfoPane manifest={MANIFEST} onClose={onPaneClose} />}
         {tab === SidebarTab.Controls && (

--- a/app/src/layout/LeftSidebar/LeftSidebar.tsx
+++ b/app/src/layout/LeftSidebar/LeftSidebar.tsx
@@ -36,10 +36,6 @@ import { Sidebar, SidebarSide } from '@/components/Sidebar/Sidebar';
 // abstraction) so persistence/hydration is handled for us — no hand-rolled
 // localStorage. Width is null until the user first drags the resize handle
 // (null ⇒ fall back to the CSS default width).
-const LEFT_SIDEBAR_COLLAPSED = persistedSignal<boolean>(
-  PERSISTED_KEYS.LEFT_SIDEBAR_COLLAPSED,
-  false
-);
 const LEFT_SIDEBAR_WIDTH = persistedSignal<number | null>(PERSISTED_KEYS.LEFT_SIDEBAR_WIDTH, null);
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -94,7 +90,9 @@ function ActivityBar({ activeTab, collapsed, onIconClick }: ActivityBarProps) {
 
 export function LeftSidebar() {
   const activeTab = useSignal<SidebarTab>(DEFAULT_SIDEBAR_TAB);
-  const collapsed = useSignal<boolean>(LEFT_SIDEBAR_COLLAPSED.value);
+  // Always starts closed and is force-closed on every world load; the open
+  // state is intentionally not persisted or remembered across worlds.
+  const collapsed = useSignal<boolean>(true);
 
   // Tree selection + hover paths, derived from picker signals.
   const selectedPath = useSignal<string | null>(null);
@@ -124,19 +122,15 @@ export function LeftSidebar() {
     hoveredPath.value = _pathOf(handle.picker.hover.value);
   });
 
-  // Persist collapsed → localStorage via the persistedSignal.
-  useSignalEffect(() => {
-    LEFT_SIDEBAR_COLLAPSED.value = collapsed.value;
-  });
-
-  // Open to Info AND expand the panel whenever a world commits — cold-boot
-  // ?src= and a user source switch both write CURRENT_SOURCE; live-reloads
-  // don't, so this fires once per real load and won't fight a manual tab/
-  // collapse change between loads.
+  // Force the sidebar closed and reset to Info on every world commit, so a new
+  // world always opens with the city unobscured (the open state is never
+  // remembered across worlds). Cold-boot ?src= and a user source switch both
+  // write CURRENT_SOURCE; live-reloads don't, so this fires once per real load
+  // and won't fight a manual tab/collapse change between loads.
   useSignalEffect(() => {
     if (CURRENT_SOURCE.value) {
       activeTab.value = DEFAULT_SIDEBAR_TAB;
-      collapsed.value = false;
+      collapsed.value = true;
     }
   });
 

--- a/app/src/layout/RightSidebar/RightSidebar.css
+++ b/app/src/layout/RightSidebar/RightSidebar.css
@@ -18,7 +18,9 @@
 }
 
 #right-sidebar.open {
-  width: var(--sidebar-width, 360px);
+  /* Default to a third of the viewport until the user drags a width; min/max
+     below clamp it on narrow/wide screens. */
+  width: var(--sidebar-width, calc(100vw / 3));
   min-width: 280px;
   max-width: 70vw;
 }

--- a/app/src/state/stores/settings/camera.ts
+++ b/app/src/state/stores/settings/camera.ts
@@ -18,7 +18,7 @@ const CAMERA_FIELDS = {
   ELEVATION: {
     route: ChangeRoute.Live,
     kind: FieldKind.Slider,
-    default: 44,
+    default: 5,
     min: 0,
     max: 90,
     step: 1,
@@ -28,7 +28,7 @@ const CAMERA_FIELDS = {
   AZIMUTH: {
     route: ChangeRoute.Live,
     kind: FieldKind.Slider,
-    default: 17,
+    default: 0,
     min: -180,
     max: 180,
     step: 1,

--- a/app/src/state/stores/settings/camera.ts
+++ b/app/src/state/stores/settings/camera.ts
@@ -1,0 +1,42 @@
+// state/stores/settings/camera.ts — the default camera framing angle. The
+// camera always looks at the root gem; these two angles set the direction it
+// views from. Autosave (write-through) so dragging a slider re-frames live —
+// the cameraRig subscribes to this store and snaps to the new pose.
+//
+// ChangeRoute.Live: no rebuild/refresh reaction; the rig drives the update.
+
+import {
+  settingSignal,
+  markAutosave,
+  FieldKind,
+  ChangeRoute,
+  type ConfigOf,
+  type FieldMap,
+} from '@/state/settingsSchema';
+
+const CAMERA_FIELDS = {
+  ELEVATION: {
+    route: ChangeRoute.Live,
+    kind: FieldKind.Slider,
+    default: 44,
+    min: 0,
+    max: 90,
+    step: 1,
+    label: 'Elevation',
+    tip: 'Angle of the default camera above the horizon, always looking at the root gem. 90° is straight overhead.',
+  },
+  AZIMUTH: {
+    route: ChangeRoute.Live,
+    kind: FieldKind.Slider,
+    default: 17,
+    min: -180,
+    max: 180,
+    step: 1,
+    label: 'Azimuth',
+    tip: 'How far the default camera swings around the gem, off the main street axis. 0° looks straight down the street.',
+  },
+} satisfies FieldMap;
+
+export const CAMERA = settingSignal('CAMERA', CAMERA_FIELDS);
+markAutosave(CAMERA);
+export type CameraConfig = ConfigOf<typeof CAMERA_FIELDS>;

--- a/app/src/styles/buttons.css
+++ b/app/src/styles/buttons.css
@@ -84,7 +84,7 @@
 .btn-icon--lg {
   width: auto;
   height: auto;
-  padding: var(--cc-space-2) var(--cc-space-4);
+  padding: var(--cc-space-2);
   border-radius: var(--cc-radius-md);
   font-size: var(--cc-font-2xl);
   color: inherit;

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -70,12 +70,22 @@
   --cc-accent-light-border: color-mix(in oklch, var(--cc-accent-light) 45%, transparent);
 
   /* ── COLORS — Gem palette (the codecity mark's four faces) ─────────────
-     Single source for the brand gem: drives the GemIcon SVG fills, the landing
-     backdrop wash, and the "what it does" cue icons. */
+     Single source for the brand gem: drives the GemIcon SVG fills and the
+     landing backdrop wash. */
   --cc-gem-lime: #bfff33;
   --cc-gem-cyan: #26e5ff;
   --cc-gem-purple: #9940ff;
   --cc-gem-magenta: #ff338c;
+
+  /* ── COLORS — World-layer accents ─────────────────────────────────────
+     One hue per city layer. Single source for the Info tab's Legend + Overview
+     section accents and the landing "what it does" cue icons, so both screens
+     read the same key. */
+  --cc-layer-buildings: #7aa2f7;
+  --cc-layer-media: #d98fd0;
+  --cc-layer-streets: #4fb8c9;
+  --cc-layer-forest: #84c98a;
+  --cc-layer-fireflies: #efc560;
 
   /* ── COLORS — Semantic (success / warning / error) ────────────────────── */
   --cc-success: oklch(0.8 0.182 151.7);

--- a/app/src/types/ui.ts
+++ b/app/src/types/ui.ts
@@ -2,7 +2,7 @@
 
 /** Left-sidebar tab IDs. Discriminator on the activity bar's mounted pane. */
 export enum SidebarTab {
-  Tree = 'tree',
+  Explore = 'explore',
   Search = 'search',
   Info = 'info',
   Controls = 'controls',

--- a/app/src/views/ControlsPane/ControlsPane.tsx
+++ b/app/src/views/ControlsPane/ControlsPane.tsx
@@ -73,7 +73,7 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
     },
     {
       id: 'updates',
-      label: 'Updates',
+      label: 'Live updates',
       icon: RefreshCw,
       draftable: false,
       sections: [{ ...UPDATES_SECTION, inline: true }],

--- a/app/src/views/ControlsPane/ControlsPane.tsx
+++ b/app/src/views/ControlsPane/ControlsPane.tsx
@@ -17,6 +17,7 @@ import { Boxes, RefreshCw, Eye } from 'lucide-preact';
 import type { LucideIcon } from 'lucide-preact';
 import { FilePreviewSection } from './partials/FilePreviewSection';
 import { DynamicSection, type SectionNode } from './partials';
+import { CAMERA_SECTION } from './partials/Camera';
 import { SCENE_SECTION } from './partials/Scene';
 import { ISLAND_SECTION } from './partials/Island';
 import { BUILDINGS_SECTION } from './partials/Buildings';
@@ -60,6 +61,7 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
       icon: Boxes,
       draftable: true,
       sections: [
+        CAMERA_SECTION,
         SCENE_SECTION,
         ISLAND_SECTION,
         BUILDINGS_SECTION,

--- a/app/src/views/ControlsPane/partials/Camera.ts
+++ b/app/src/views/ControlsPane/partials/Camera.ts
@@ -1,0 +1,13 @@
+// views/ControlsPane/partials/Camera.ts — Camera section: the default framing
+// angle. CAMERA is autosave, so the sliders re-frame the view live as you drag
+// (the cameraRig subscribes and snaps to the new pose).
+import { field, type SectionNode } from '.';
+import { CAMERA } from '@/state/stores/settings/camera';
+
+export const CAMERA_SECTION: SectionNode = {
+  key: 'camera',
+  label: 'Camera',
+  description:
+    'The angle the default view frames the city from, always looking at the root gem. Drag to preview it live.',
+  children: [field(CAMERA, 'ELEVATION'), field(CAMERA, 'AZIMUTH')],
+};

--- a/app/src/views/ExplorePane/ExplorePane.css
+++ b/app/src/views/ExplorePane/ExplorePane.css
@@ -1,0 +1,5 @@
+/* The Readme subtab body scrolls in its own .pane-body; let its empty states
+ * fill the pane like the tree's do (mirrors .info-body > .empty-state). */
+.explore-pane .pane-body > .empty-state {
+  flex: 1 1 auto;
+}

--- a/app/src/views/ExplorePane/ExplorePane.tsx
+++ b/app/src/views/ExplorePane/ExplorePane.tsx
@@ -1,0 +1,91 @@
+// views/ExplorePane/ExplorePane.tsx — the "Explore" sidebar section: browse the
+// repo's actual content. Hosts two subtabs — File tree (default) and Readme —
+// owning the Pane chrome + tab strip while the subtab bodies render themselves.
+// The interpretive counterpart is InfoPane (Overview + Legend).
+
+import './ExplorePane.css';
+import { useState } from 'preact/hooks';
+import { useSignalEffect } from '@preact/signals';
+import type { Signal, ReadonlySignal } from '@preact/signals';
+import { FolderTree, BookOpen } from 'lucide-preact';
+import type { DirNode, Manifest, TreeNode } from '@/types';
+import { Pane } from '@/components/Pane';
+import { PaneCloseButton } from '@/components/PaneHeader/PaneHeader';
+import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
+import { CURRENT_SOURCE } from '@/state/stores/source';
+import { TreePane } from '@/views/TreePane/TreePane';
+import { ReadmePane } from '@/views/InfoPane/ReadmePane';
+
+type ManifestSignal = Signal<Manifest | DirNode | { tree?: unknown; [k: string]: unknown } | null>;
+
+export enum ExploreTab {
+  Tree = 'tree',
+  Readme = 'readme',
+}
+
+const EXPLORE_TABS = [
+  { id: ExploreTab.Tree, label: 'File tree', icon: FolderTree },
+  { id: ExploreTab.Readme, label: 'Readme', icon: BookOpen },
+];
+
+export interface ExplorePaneProps {
+  manifest: ManifestSignal;
+  selectedPath: ReadonlySignal<string | null>;
+  hoveredPath: ReadonlySignal<string | null>;
+  expanded: Signal<Set<string>>;
+  rootPath: string;
+  onClose?: () => void;
+  onSelect?: (node: TreeNode) => void;
+  onHover?: (node: TreeNode) => void;
+  onHoverEnd?: (node: TreeNode) => void;
+}
+
+export function ExplorePane({
+  manifest,
+  selectedPath,
+  hoveredPath,
+  expanded,
+  rootPath,
+  onClose,
+  onSelect,
+  onHover,
+  onHoverEnd,
+}: ExplorePaneProps) {
+  const [tab, setTab] = useState<ExploreTab>(ExploreTab.Tree);
+
+  // Reset to the File tree when a new world commits — ExplorePane stays mounted
+  // across world switches. Keyed on CURRENT_SOURCE (not the manifest), so an
+  // in-place refresh keeps your subtab.
+  useSignalEffect(() => {
+    if (CURRENT_SOURCE.value) setTab(ExploreTab.Tree);
+  });
+
+  return (
+    <Pane
+      paneClass="explore-pane"
+      headerSlot={
+        <div class="pane-header pane-header--tabs">
+          <PaneTabs tabs={EXPLORE_TABS} active={tab} onSelect={(id) => setTab(id as ExploreTab)} />
+          {onClose && <PaneCloseButton onClose={onClose} />}
+        </div>
+      }
+    >
+      {tab === ExploreTab.Tree ? (
+        <TreePane
+          manifest={manifest}
+          selectedPath={selectedPath}
+          hoveredPath={hoveredPath}
+          expanded={expanded}
+          rootPath={rootPath}
+          onSelect={onSelect}
+          onHover={onHover}
+          onHoverEnd={onHoverEnd}
+        />
+      ) : (
+        <div class="pane-body">
+          <ReadmePane manifest={manifest} />
+        </div>
+      )}
+    </Pane>
+  );
+}

--- a/app/src/views/InfoPane/InfoPane.css
+++ b/app/src/views/InfoPane/InfoPane.css
@@ -1,5 +1,27 @@
 /* ── Info pane ── */
 
+/* World-layer accents — one --sec-accent per data-section, shared by the
+ * Overview sections and the Legend rows (both live in .info-body) so the color
+ * cue reads from a single source. */
+.info-body [data-section] {
+  --sec-accent: var(--cc-text-secondary);
+}
+.info-body [data-section='buildings'] {
+  --sec-accent: #7aa2f7;
+}
+.info-body [data-section='media'] {
+  --sec-accent: #d98fd0;
+}
+.info-body [data-section='streets'] {
+  --sec-accent: #d3a85f;
+}
+.info-body [data-section='forest'] {
+  --sec-accent: #84c98a;
+}
+.info-body [data-section='fireflies'] {
+  --sec-accent: #efc560;
+}
+
 .info-markdown code {
   display: inline-block;
   background: var(--cc-accent-bg-soft);

--- a/app/src/views/InfoPane/InfoPane.css
+++ b/app/src/views/InfoPane/InfoPane.css
@@ -7,19 +7,19 @@
   --sec-accent: var(--cc-text-secondary);
 }
 .info-body [data-section='buildings'] {
-  --sec-accent: #7aa2f7;
+  --sec-accent: var(--cc-layer-buildings);
 }
 .info-body [data-section='media'] {
-  --sec-accent: #d98fd0;
+  --sec-accent: var(--cc-layer-media);
 }
 .info-body [data-section='streets'] {
-  --sec-accent: #d3a85f;
+  --sec-accent: var(--cc-layer-streets);
 }
 .info-body [data-section='forest'] {
-  --sec-accent: #84c98a;
+  --sec-accent: var(--cc-layer-forest);
 }
 .info-body [data-section='fireflies'] {
-  --sec-accent: #efc560;
+  --sec-accent: var(--cc-layer-fireflies);
 }
 
 .info-markdown code {

--- a/app/src/views/InfoPane/InfoPane.tsx
+++ b/app/src/views/InfoPane/InfoPane.tsx
@@ -1,13 +1,14 @@
 // views/InfoPane/InfoPane.tsx — the "Info" tab shell. Hosts two subtabs:
-// Overview (the almanac, default) and Readme (the rendered root README). Owns
-// the Pane chrome + active-subtab state; the subtab bodies render themselves.
+// Overview (the almanac, default) and Legend (how the city reads). Owns the
+// Pane chrome + active-subtab state; the subtab bodies render themselves. The
+// repo's own content (file tree, README) lives in the Explore pane.
 
 import './InfoPane.css';
 import { useState } from 'preact/hooks';
 import { useSignalEffect } from '@preact/signals';
 import type { Signal } from '@preact/signals';
 import type { ComponentType } from 'preact';
-import { Globe, Map, BookOpen } from 'lucide-preact';
+import { Globe, Map } from 'lucide-preact';
 import type { LucideIcon } from 'lucide-preact';
 import type { DirNode, Manifest } from '@/types';
 import { Pane } from '@/components/Pane';
@@ -16,14 +17,12 @@ import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
 import { CURRENT_SOURCE } from '@/state/stores/source';
 import { OverviewPane } from './OverviewPane';
 import { LegendPane } from './LegendPane';
-import { ReadmePane } from './ReadmePane';
 
 type ManifestSignal = Signal<Manifest | DirNode | { tree?: unknown; [k: string]: unknown } | null>;
 
 export enum InfoTab {
   Overview = 'overview',
   Legend = 'legend',
-  Readme = 'readme',
 }
 
 interface InfoTabDef {
@@ -38,7 +37,6 @@ interface InfoTabDef {
 const INFO_TABS: InfoTabDef[] = [
   { id: InfoTab.Overview, label: 'Overview', icon: Globe, Component: OverviewPane },
   { id: InfoTab.Legend, label: 'Legend', icon: Map, Component: LegendPane },
-  { id: InfoTab.Readme, label: 'Readme', icon: BookOpen, Component: ReadmePane },
 ];
 
 export interface InfoPaneProps {

--- a/app/src/views/InfoPane/InfoPane.tsx
+++ b/app/src/views/InfoPane/InfoPane.tsx
@@ -7,7 +7,7 @@ import { useState } from 'preact/hooks';
 import { useSignalEffect } from '@preact/signals';
 import type { Signal } from '@preact/signals';
 import type { ComponentType } from 'preact';
-import { Globe, BookOpen } from 'lucide-preact';
+import { Globe, Map, BookOpen } from 'lucide-preact';
 import type { LucideIcon } from 'lucide-preact';
 import type { DirNode, Manifest } from '@/types';
 import { Pane } from '@/components/Pane';
@@ -15,12 +15,14 @@ import { PaneCloseButton } from '@/components/PaneHeader/PaneHeader';
 import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
 import { CURRENT_SOURCE } from '@/state/stores/source';
 import { OverviewPane } from './OverviewPane';
+import { LegendPane } from './LegendPane';
 import { ReadmePane } from './ReadmePane';
 
 type ManifestSignal = Signal<Manifest | DirNode | { tree?: unknown; [k: string]: unknown } | null>;
 
 export enum InfoTab {
   Overview = 'overview',
+  Legend = 'legend',
   Readme = 'readme',
 }
 
@@ -31,8 +33,11 @@ interface InfoTabDef {
   Component: ComponentType<{ manifest: ManifestSignal }>;
 }
 
+// Legend is static (no manifest) but keeps the shared signature so INFO_TABS
+// stays uniform; it simply ignores the prop.
 const INFO_TABS: InfoTabDef[] = [
   { id: InfoTab.Overview, label: 'Overview', icon: Globe, Component: OverviewPane },
+  { id: InfoTab.Legend, label: 'Legend', icon: Map, Component: LegendPane },
   { id: InfoTab.Readme, label: 'Readme', icon: BookOpen, Component: ReadmePane },
 ];
 

--- a/app/src/views/InfoPane/LegendPane.css
+++ b/app/src/views/InfoPane/LegendPane.css
@@ -2,8 +2,8 @@
   padding: var(--cc-space-7); /* shared pane content inset, all sides */
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  /* Default accent for cue rows (no data-section); layer rows override it via
+  gap: 12px;
+  /* Default accent for cue rows (no data-section); layer blocks override it via
    * the shared .info-body [data-section] map. */
   --sec-accent: var(--cc-text-secondary);
 }
@@ -15,8 +15,70 @@
   font-size: var(--cc-font-xl);
 }
 
-/* A group heading in the almanac section-title idiom (uppercase, tracked) so the
- * Legend and Overview read as the same family. */
+/* One world layer: header + lead + its cue rows, separated by a hairline like
+ * the Overview sections so the two tabs read as one family. */
+.legend-layer {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--cc-border-subtle);
+  padding-top: 12px;
+}
+
+.legend-layer-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 0 6px;
+  font-size: var(--cc-font-md);
+  font-weight: var(--cc-fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--cc-track-label);
+  color: var(--cc-text-secondary);
+}
+
+.legend-layer-icon {
+  width: 15px;
+  height: 15px;
+  color: var(--sec-accent);
+}
+
+.legend-layer-lead {
+  margin: 0 0 8px;
+  color: var(--cc-text-secondary);
+  font-size: var(--cc-font-lg);
+  line-height: 1.45;
+}
+
+/* The cue → meaning key: a fixed label rail so every "meaning" starts on the
+ * same column. */
+.legend-cues {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.legend-cue {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  min-width: 0;
+  font-size: var(--cc-font-lg);
+}
+
+.legend-cue-label {
+  flex: 0 0 128px;
+  font-weight: var(--cc-fw-semibold);
+  color: var(--cc-text-primary);
+}
+
+.legend-cue-detail {
+  margin: 0;
+  min-width: 0;
+  color: var(--cc-text-secondary);
+}
+
+/* "Reading the city" group heading, in the layer-title idiom. */
 .legend-group-title {
   display: flex;
   align-items: center;
@@ -30,8 +92,8 @@
   color: var(--cc-text-secondary);
 }
 
-.legend-list {
-  margin: 0;
+.legend-cue-list {
+  margin: 8px 0 0;
   padding: 0;
   list-style: none;
   display: flex;
@@ -39,8 +101,7 @@
   gap: 12px;
 }
 
-/* One key row: accented layer glyph on its own rail, name + rule stacked beside
- * it so the eye scans icon → name → meaning. */
+/* A non-layer cue row: glyph on its own rail, name + description stacked. */
 .legend-row {
   display: flex;
   gap: 10px;

--- a/app/src/views/InfoPane/LegendPane.css
+++ b/app/src/views/InfoPane/LegendPane.css
@@ -1,0 +1,75 @@
+.legend {
+  padding: var(--cc-space-7); /* shared pane content inset, all sides */
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  /* Default accent for cue rows (no data-section); layer rows override it via
+   * the shared .info-body [data-section] map. */
+  --sec-accent: var(--cc-text-secondary);
+}
+
+.legend-intro {
+  margin: 0 0 2px;
+  color: var(--cc-text-secondary);
+  line-height: 1.5;
+  font-size: var(--cc-font-xl);
+}
+
+/* A group heading in the almanac section-title idiom (uppercase, tracked) so the
+ * Legend and Overview read as the same family. */
+.legend-group-title {
+  display: flex;
+  align-items: center;
+  margin: 6px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--cc-border-subtle);
+  font-size: var(--cc-font-md);
+  font-weight: var(--cc-fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--cc-track-label);
+  color: var(--cc-text-secondary);
+}
+
+.legend-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* One key row: accented layer glyph on its own rail, name + rule stacked beside
+ * it so the eye scans icon → name → meaning. */
+.legend-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.legend-row-icon {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px; /* optical align with the title cap-height */
+  color: var(--sec-accent);
+}
+
+.legend-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.legend-row-title {
+  font-size: var(--cc-font-lg);
+  font-weight: var(--cc-fw-semibold);
+  color: var(--cc-text-primary);
+}
+
+.legend-row-rule {
+  font-size: var(--cc-font-lg);
+  line-height: 1.45;
+  color: var(--cc-text-secondary);
+}

--- a/app/src/views/InfoPane/LegendPane.tsx
+++ b/app/src/views/InfoPane/LegendPane.tsx
@@ -1,13 +1,15 @@
 // views/InfoPane/LegendPane.tsx — the "Legend" subtab: a static map-key for how
-// a repo's structure and history become the 3D city. Each world layer's rule is
-// read from LAYER_LEGEND (single-sourced with the Overview section tooltips); a
-// trailing "Reading the city" group covers the two non-layer cues. No manifest:
-// the encodings are identical for every project. Body-only; InfoPane owns chrome.
+// a repo's structure and history become the 3D city. Each world layer renders
+// as an accented header + a list of cue → meaning rows, read from LAYER_LEGEND
+// (single-sourced with the Overview section tooltips). A trailing "Reading the
+// city" group covers the non-layer cues. No manifest: the encodings are
+// identical for every project. Body-only; InfoPane owns chrome.
 
 import './LegendPane.css';
 import { Gem, Contrast } from 'lucide-preact';
 import type { LucideIcon } from 'lucide-preact';
 import { LAYER_LEGEND } from './almanac';
+import type { LayerCue } from './almanac';
 import { SECTION_ICON } from './sectionIcons';
 
 // The non-layer cues — a landmark and an interaction affordance with no
@@ -32,26 +34,27 @@ const WORLD_CUES: WorldCue[] = [
   },
 ];
 
-function LegendRow({
-  icon: Icon,
-  title,
-  rule,
-  section,
-}: {
-  icon: LucideIcon;
-  title: string;
-  rule: string;
-  /** An AlmanacSectionKey drives the row's --sec-accent; absent → neutral. */
-  section?: string;
-}) {
+/** One world layer: accented glyph + name, a lead line, then its cue → meaning
+ *  rows. `data-section` drives the row's --sec-accent from the shared map. */
+function LayerBlock({ layerKey }: { layerKey: (typeof LAYER_LEGEND)[number]['key'] }) {
+  const layer = LAYER_LEGEND.find((l) => l.key === layerKey)!;
+  const Icon = SECTION_ICON[layer.key];
   return (
-    <li class="legend-row" data-section={section}>
-      <Icon class="lucide-icon legend-row-icon" aria-hidden="true" />
-      <div class="legend-row-text">
-        <span class="legend-row-title">{title}</span>
-        <span class="legend-row-rule">{rule}</span>
-      </div>
-    </li>
+    <section class="legend-layer" data-section={layer.key}>
+      <h3 class="legend-layer-title">
+        <Icon class="lucide-icon legend-layer-icon" aria-hidden="true" />
+        {layer.title}
+      </h3>
+      <p class="legend-layer-lead">{layer.lead}</p>
+      <dl class="legend-cues">
+        {layer.cues.map((c: LayerCue) => (
+          <div key={c.label} class="legend-cue">
+            <dt class="legend-cue-label">{c.label}</dt>
+            <dd class="legend-cue-detail">{c.detail}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
   );
 }
 
@@ -59,21 +62,19 @@ export function LegendPane() {
   return (
     <div class="legend">
       <p class="legend-intro">How a repo's structure and history become this city.</p>
-      <ul class="legend-list">
-        {LAYER_LEGEND.map((l) => (
-          <LegendRow
-            key={l.key}
-            icon={SECTION_ICON[l.key]}
-            title={l.title}
-            rule={l.rule}
-            section={l.key}
-          />
-        ))}
-      </ul>
+      {LAYER_LEGEND.map((l) => (
+        <LayerBlock key={l.key} layerKey={l.key} />
+      ))}
       <h3 class="legend-group-title">Reading the city</h3>
-      <ul class="legend-list">
+      <ul class="legend-cue-list">
         {WORLD_CUES.map((c) => (
-          <LegendRow key={c.title} icon={c.icon} title={c.title} rule={c.rule} />
+          <li key={c.title} class="legend-row">
+            <c.icon class="lucide-icon legend-row-icon" aria-hidden="true" />
+            <div class="legend-row-text">
+              <span class="legend-row-title">{c.title}</span>
+              <span class="legend-row-rule">{c.rule}</span>
+            </div>
+          </li>
         ))}
       </ul>
     </div>

--- a/app/src/views/InfoPane/LegendPane.tsx
+++ b/app/src/views/InfoPane/LegendPane.tsx
@@ -1,0 +1,81 @@
+// views/InfoPane/LegendPane.tsx — the "Legend" subtab: a static map-key for how
+// a repo's structure and history become the 3D city. Each world layer's rule is
+// read from LAYER_LEGEND (single-sourced with the Overview section tooltips); a
+// trailing "Reading the city" group covers the two non-layer cues. No manifest:
+// the encodings are identical for every project. Body-only; InfoPane owns chrome.
+
+import './LegendPane.css';
+import { Gem, Contrast } from 'lucide-preact';
+import type { LucideIcon } from 'lucide-preact';
+import { LAYER_LEGEND } from './almanac';
+import { SECTION_ICON } from './sectionIcons';
+
+// The non-layer cues — a landmark and an interaction affordance with no
+// manifest-derived source, so their copy lives here (the Legend is their only
+// consumer). Verified against the gem + building-fader render behavior.
+interface WorldCue {
+  icon: LucideIcon;
+  title: string;
+  rule: string;
+}
+
+const WORLD_CUES: WorldCue[] = [
+  {
+    icon: Gem,
+    title: 'Root gem',
+    rule: "A gem marks the project root at the city's origin: click it to clear your selection and recenter the camera.",
+  },
+  {
+    icon: Contrast,
+    title: 'Hover fade',
+    rule: 'Hovering or selecting a building fades the rest by how far they sit in the folder tree: near neighbors stay bright, distant ones dim to ghosts.',
+  },
+];
+
+function LegendRow({
+  icon: Icon,
+  title,
+  rule,
+  section,
+}: {
+  icon: LucideIcon;
+  title: string;
+  rule: string;
+  /** An AlmanacSectionKey drives the row's --sec-accent; absent → neutral. */
+  section?: string;
+}) {
+  return (
+    <li class="legend-row" data-section={section}>
+      <Icon class="lucide-icon legend-row-icon" aria-hidden="true" />
+      <div class="legend-row-text">
+        <span class="legend-row-title">{title}</span>
+        <span class="legend-row-rule">{rule}</span>
+      </div>
+    </li>
+  );
+}
+
+export function LegendPane() {
+  return (
+    <div class="legend">
+      <p class="legend-intro">How a repo's structure and history become this city.</p>
+      <ul class="legend-list">
+        {LAYER_LEGEND.map((l) => (
+          <LegendRow
+            key={l.key}
+            icon={SECTION_ICON[l.key]}
+            title={l.title}
+            rule={l.rule}
+            section={l.key}
+          />
+        ))}
+      </ul>
+      <h3 class="legend-group-title">Reading the city</h3>
+      <ul class="legend-list">
+        {WORLD_CUES.map((c) => (
+          <LegendRow key={c.title} icon={c.icon} title={c.title} rule={c.rule} />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/src/views/InfoPane/OverviewPane.css
+++ b/app/src/views/InfoPane/OverviewPane.css
@@ -149,25 +149,8 @@
   cursor: default;
 }
 
-/* Each section carries its world-layer accent (icon + dimension labels). */
-.almanac-section {
-  --sec-accent: var(--cc-text-secondary);
-}
-.almanac-section[data-section='buildings'] {
-  --sec-accent: #7aa2f7;
-}
-.almanac-section[data-section='media'] {
-  --sec-accent: #d98fd0;
-}
-.almanac-section[data-section='streets'] {
-  --sec-accent: #d3a85f;
-}
-.almanac-section[data-section='forest'] {
-  --sec-accent: #84c98a;
-}
-.almanac-section[data-section='fireflies'] {
-  --sec-accent: #efc560;
-}
+/* Section accents (--sec-accent per data-section) are shared with the Legend
+ * subtab, so they live in InfoPane.css scoped to .info-body. */
 
 /* Hairline divider above every section — including the first, so the intro
  * title-card is separated from the data sections the same way they're separated

--- a/app/src/views/InfoPane/OverviewPane.tsx
+++ b/app/src/views/InfoPane/OverviewPane.tsx
@@ -7,8 +7,7 @@
 import './OverviewPane.css';
 import { useMemo } from 'preact/hooks';
 import type { Signal } from '@preact/signals';
-import { FolderOpen, Focus, Building2, Image, Signpost, TreePine, Sparkles } from 'lucide-preact';
-import type { LucideIcon } from 'lucide-preact';
+import { FolderOpen, Focus } from 'lucide-preact';
 import { NodeKind } from '@/types';
 import type { DirNode, Manifest } from '@/types';
 import { PaneEmpty } from '@/components/Pane';
@@ -22,18 +21,8 @@ import { commitUrl } from '@/utils/commit';
 import { languageLabelForExt } from '@/utils/syntaxLanguages';
 import { formatCount, pluralize } from '@/utils/format';
 import { computeAlmanac } from './almanac';
-import type { AlmanacFact, AlmanacSectionKey, LandmarkRef, LanguageStat } from './almanac';
-
-// Each section gets its world layer's icon — the panel reads as a legend for
-// the city, not a generic stats list. The accent color is keyed off
-// data-section in the CSS so it stays a single source of truth.
-const SECTION_ICON: Record<AlmanacSectionKey, LucideIcon> = {
-  buildings: Building2,
-  media: Image,
-  streets: Signpost,
-  forest: TreePine,
-  fireflies: Sparkles,
-};
+import type { AlmanacFact, LandmarkRef, LanguageStat } from './almanac';
+import { SECTION_ICON } from './sectionIcons';
 
 function visit(landmark: LandmarkRef): void {
   if (landmark.kind === NodeKind.Commit) {

--- a/app/src/views/InfoPane/ReadmePane.tsx
+++ b/app/src/views/InfoPane/ReadmePane.tsx
@@ -1,6 +1,7 @@
 // views/InfoPane/ReadmePane.tsx — renders the body of the README panel:
 // finds the root README in the manifest, fetches + renders it as markdown,
-// and shows appropriate empty states. No <Pane> wrapper — InfoPane owns the chrome.
+// and shows appropriate empty states. No <Pane> wrapper — the Explore pane
+// owns the chrome.
 
 import './InfoPane.css';
 import { useState, useEffect } from 'preact/hooks';

--- a/app/src/views/InfoPane/almanac.ts
+++ b/app/src/views/InfoPane/almanac.ts
@@ -91,42 +91,78 @@ export interface Almanac {
 
 const MAX_LANGUAGES = 6;
 
+export interface LayerCue {
+  /** The visual property, e.g. "Height". */
+  label: string;
+  /** The repo-data factor that drives it, e.g. "line count". */
+  detail: string;
+}
+
 export interface LayerLegend {
   key: AlmanacSectionKey;
   title: string;
-  /** The layer's one-line encoding rule. Single source for both the section
-   *  header tooltip (Overview) and the Legend subtab's rows. */
-  rule: string;
+  /** One-line "what this layer is". */
+  lead: string;
+  /** The cue → meaning rows that make up the map key. */
+  cues: LayerCue[];
 }
 
 // What each world layer encodes, in world-build order. The single source for
-// the Overview section-header tooltips and the Legend subtab, so the two can't
-// drift.
+// the Legend subtab and the Overview section-header tooltips (composed via
+// layerTip), so the two can't drift. Kept to the salient, viewer-noticeable
+// encodings, not every downstream shader detail.
 export const LAYER_LEGEND: LayerLegend[] = [
   {
     key: 'buildings',
     title: 'Buildings',
-    rule: 'Every code file is a building: height from line count, footprint from byte size, brightness from how recently it changed.',
+    lead: 'Every code file is a building.',
+    cues: [
+      { label: 'Height', detail: 'line count' },
+      { label: 'Footprint', detail: 'file size' },
+      { label: 'Color & roof icon', detail: 'file type' },
+      { label: 'Brightness', detail: 'how recently it changed' },
+      { label: 'Grime & lean', detail: "how long it's existed" },
+    ],
   },
   {
     key: 'media',
     title: 'Billboards',
-    rule: 'Image & video files render as billboard panels, sized by aspect ratio instead of lines.',
+    lead: 'Image & video files render as billboard panels showing the file itself.',
+    cues: [
+      { label: 'Shape', detail: "the file's aspect ratio" },
+      { label: 'Width', detail: 'file size' },
+      { label: 'Video', detail: 'adds a play button' },
+    ],
   },
   {
     key: 'streets',
     title: 'Streets',
-    rule: 'Directories are streets; the more files a directory holds, the wider its road.',
+    lead: 'Directories are streets.',
+    cues: [
+      { label: 'Width', detail: 'how many files it holds' },
+      { label: 'Length', detail: 'how much it contains' },
+      { label: 'Label', detail: 'the directory name' },
+    ],
   },
   {
     key: 'forest',
     title: 'Forest',
-    rule: 'Each commit plants a tree: older commits grow taller, bigger commits grow wider canopies.',
+    lead: 'Each commit plants a tree.',
+    cues: [
+      { label: 'Height', detail: 'older commits grow taller' },
+      { label: 'Canopy', detail: 'wider for bigger commits' },
+      { label: 'Color', detail: "how busy the commit's day was" },
+      { label: 'Position', detail: 'older commits sit nearer the center' },
+    ],
   },
   {
     key: 'fireflies',
     title: 'Fireflies',
-    rule: 'Each distinct commit author is a uniquely colored firefly orbiting the trees they touched.',
+    lead: 'Each commit author is a firefly, orbiting the trees they touched.',
+    cues: [
+      { label: 'Color', detail: 'unique per author' },
+      { label: 'Size', detail: 'how many commits they made' },
+    ],
   },
 ];
 
@@ -135,15 +171,21 @@ const LAYER_BY_KEY = Object.fromEntries(LAYER_LEGEND.map((l) => [l.key, l])) as 
   LayerLegend
 >;
 
-/** A section's shared header — key, display title, and encoding rule (its
- *  tooltip) — all read from LAYER_LEGEND. */
+/** The layer's encodings as one tooltip string: the lead sentence followed by
+ *  its cue → meaning pairs. */
+function layerTip(l: LayerLegend): string {
+  return `${l.lead} ${l.cues.map((c) => `${c.label}: ${c.detail}`).join('; ')}.`;
+}
+
+/** A section's shared header — key, display title, and composed encoding tip —
+ *  all read from LAYER_LEGEND. */
 function layerHeader(key: AlmanacSectionKey): {
   key: AlmanacSectionKey;
   title: string;
   tip: string;
 } {
   const l = LAYER_BY_KEY[key];
-  return { key, title: l.title, tip: l.rule };
+  return { key, title: l.title, tip: layerTip(l) };
 }
 
 function isManifest(m: unknown): m is Manifest {

--- a/app/src/views/InfoPane/almanac.ts
+++ b/app/src/views/InfoPane/almanac.ts
@@ -91,17 +91,60 @@ export interface Almanac {
 
 const MAX_LANGUAGES = 6;
 
-// What each world layer encodes — surfaced as the section header tooltips.
-const SECTION_TIPS: Record<AlmanacSectionKey, string> = {
-  buildings:
-    'Every code file is a building — height from line count, footprint from byte size, brightness from how recently it changed.',
-  media: 'Image & video files render as billboard panels, sized by aspect ratio instead of lines.',
-  streets: 'Directories are streets; the more files a directory holds, the wider its road.',
-  forest:
-    'Each commit plants a tree — older commits grow taller, bigger commits grow wider canopies.',
-  fireflies:
-    'Each distinct commit author is a uniquely colored firefly orbiting the trees they touched.',
-};
+export interface LayerLegend {
+  key: AlmanacSectionKey;
+  title: string;
+  /** The layer's one-line encoding rule. Single source for both the section
+   *  header tooltip (Overview) and the Legend subtab's rows. */
+  rule: string;
+}
+
+// What each world layer encodes, in world-build order. The single source for
+// the Overview section-header tooltips and the Legend subtab, so the two can't
+// drift.
+export const LAYER_LEGEND: LayerLegend[] = [
+  {
+    key: 'buildings',
+    title: 'Buildings',
+    rule: 'Every code file is a building: height from line count, footprint from byte size, brightness from how recently it changed.',
+  },
+  {
+    key: 'media',
+    title: 'Billboards',
+    rule: 'Image & video files render as billboard panels, sized by aspect ratio instead of lines.',
+  },
+  {
+    key: 'streets',
+    title: 'Streets',
+    rule: 'Directories are streets; the more files a directory holds, the wider its road.',
+  },
+  {
+    key: 'forest',
+    title: 'Forest',
+    rule: 'Each commit plants a tree: older commits grow taller, bigger commits grow wider canopies.',
+  },
+  {
+    key: 'fireflies',
+    title: 'Fireflies',
+    rule: 'Each distinct commit author is a uniquely colored firefly orbiting the trees they touched.',
+  },
+];
+
+const LAYER_BY_KEY = Object.fromEntries(LAYER_LEGEND.map((l) => [l.key, l])) as Record<
+  AlmanacSectionKey,
+  LayerLegend
+>;
+
+/** A section's shared header — key, display title, and encoding rule (its
+ *  tooltip) — all read from LAYER_LEGEND. */
+function layerHeader(key: AlmanacSectionKey): {
+  key: AlmanacSectionKey;
+  title: string;
+  tip: string;
+} {
+  const l = LAYER_BY_KEY[key];
+  return { key, title: l.title, tip: l.rule };
+}
 
 function isManifest(m: unknown): m is Manifest {
   return !!m && typeof m === 'object' && 'tree' in (m as object) && (m as Manifest).tree != null;
@@ -292,9 +335,7 @@ function buildingsSection(m: Manifest): AlmanacSection {
     pluralize(count, 'building') +
     (avgLines !== null ? ` · ~${formatCount(avgLines)} lines each` : '');
   return {
-    key: 'buildings',
-    title: 'Buildings',
-    tip: SECTION_TIPS.buildings,
+    ...layerHeader('buildings'),
     overview,
     facts,
     note: facts.length ? undefined : 'No code files yet.',
@@ -308,9 +349,7 @@ function mediaSection(m: Manifest): AlmanacSection {
   const overview = pluralize(s.mediaCount, 'billboard');
   if (s.mediaCount === 0) {
     return {
-      key: 'media',
-      title: 'Billboards',
-      tip: SECTION_TIPS.media,
+      ...layerHeader('media'),
       overview,
       facts: [],
       note: 'No images or videos.',
@@ -334,9 +373,7 @@ function mediaSection(m: Manifest): AlmanacSection {
   if (!sizePair && !resPair && hi) {
     const dims = hasRes(hiRes) ? ` · ${resFmt(hiRes)}` : '';
     return {
-      key: 'media',
-      title: 'Billboards',
-      tip: SECTION_TIPS.media,
+      ...layerHeader('media'),
       overview,
       facts: compact([
         fileFact({
@@ -385,7 +422,7 @@ function mediaSection(m: Manifest): AlmanacSection {
         })
       : null,
   ]);
-  return { key: 'media', title: 'Billboards', tip: SECTION_TIPS.media, overview, facts };
+  return { ...layerHeader('media'), overview, facts };
 }
 
 function streetsSection(m: Manifest): AlmanacSection {
@@ -423,9 +460,7 @@ function streetsSection(m: Manifest): AlmanacSection {
     }),
   ]);
   return {
-    key: 'streets',
-    title: 'Streets',
-    tip: SECTION_TIPS.streets,
+    ...layerHeader('streets'),
     overview,
     facts,
     note: facts.length ? undefined : 'Everything lives at the root — no sub-directories.',
@@ -437,7 +472,7 @@ function forestSection(m: Manifest, treesEnabled: boolean): AlmanacSection {
   const cd = m.stats.commitDates;
   const span = cd.oldest && cd.newest ? humanSpan(cd.oldest, cd.newest) : '';
   const overview = `${pluralize(trees, 'tree')}${span ? ` · ${span} of history` : ''}`;
-  const base = { key: 'forest', title: 'Forest', tip: SECTION_TIPS.forest, overview } as const;
+  const base = { ...layerHeader('forest'), overview };
   // Canopies fly the camera to a tree; with the Trees layer off those targets
   // don't exist, so the notice lives here (not the view) like any empty state.
   if (!treesEnabled) {
@@ -491,12 +526,7 @@ function firefliesSection(m: Manifest): AlmanacSection {
   const noun = count === 1 ? 'firefly' : 'fireflies';
   const each = avgCommits !== null ? ` · ~${formatCount(avgCommits)} commits each` : '';
   const overview = `${formatCount(count)} ${noun}${each}`;
-  const base = {
-    key: 'fireflies',
-    title: 'Fireflies',
-    tip: SECTION_TIPS.fireflies,
-    overview,
-  } as const;
+  const base = { ...layerHeader('fireflies'), overview };
   if (count === 0) {
     return { ...base, facts: [], note: 'No commits yet — no fireflies.' };
   }

--- a/app/src/views/InfoPane/sectionIcons.ts
+++ b/app/src/views/InfoPane/sectionIcons.ts
@@ -1,0 +1,15 @@
+// views/InfoPane/sectionIcons.ts — the world-layer icon for each almanac
+// section. Shared by the Overview sections and the Legend rows so both read one
+// key→icon source; the layer copy lives alongside in almanac.ts (LAYER_LEGEND).
+
+import { Building2, Image, Signpost, TreePine, Sparkles } from 'lucide-preact';
+import type { LucideIcon } from 'lucide-preact';
+import type { AlmanacSectionKey } from './almanac';
+
+export const SECTION_ICON: Record<AlmanacSectionKey, LucideIcon> = {
+  buildings: Building2,
+  media: Image,
+  streets: Signpost,
+  forest: TreePine,
+  fireflies: Sparkles,
+};

--- a/app/src/views/ProjectsView/ProjectsView.css
+++ b/app/src/views/ProjectsView/ProjectsView.css
@@ -148,16 +148,16 @@
   flex: 0 0 auto;
 }
 .landing-delight--streets > svg {
-  color: var(--cc-gem-cyan);
+  color: var(--cc-layer-streets);
 }
 .landing-delight--buildings > svg {
-  color: var(--cc-gem-purple);
+  color: var(--cc-layer-buildings);
 }
 .landing-delight--trees > svg {
-  color: var(--cc-gem-lime);
+  color: var(--cc-layer-forest);
 }
 .landing-delight--authors > svg {
-  color: var(--cc-gem-magenta);
+  color: var(--cc-layer-fireflies);
 }
 
 /* ── Action column ── stacked cards (open project, then recents). */

--- a/app/src/views/SearchPane/SearchPane.css
+++ b/app/src/views/SearchPane/SearchPane.css
@@ -5,11 +5,11 @@
    fills the row with the × close button pinned right, and the result list
    scrolls below. Matched query characters in each result are wrapped in <mark>. */
 
-/* The input takes the place of a title, so the row hugs the field instead of
-   the taller default header padding. */
+/* The input takes the place of a title, so the row hugs the field: shorter than
+   the default header, and flush to the left edge (no title inset) so the search
+   glyph starts at the pane edge. */
 .pane-header--search {
-  padding-top: var(--cc-space-4);
-  padding-bottom: var(--cc-space-4);
+  padding: var(--cc-space-4) var(--cc-space-6) var(--cc-space-4) 0;
 }
 
 .search-input-wrap {

--- a/app/src/views/SearchPane/SearchPane.css
+++ b/app/src/views/SearchPane/SearchPane.css
@@ -5,11 +5,11 @@
    fills the row with the × close button pinned right, and the result list
    scrolls below. Matched query characters in each result are wrapped in <mark>. */
 
-/* The input takes the place of a title, so the row hugs the field: shorter than
-   the default header, and the left inset matches the icon→input gap so the
-   search glyph sits with equal space on both sides. */
+/* The input takes the place of a title, so the row hugs the field: a uniform
+   inset all round, and the icon→input gap matches it so the search glyph sits
+   with equal space on both sides. */
 .pane-header--search {
-  padding: var(--cc-space-4) var(--cc-space-6) var(--cc-space-4) var(--cc-space-3);
+  padding: var(--cc-space-4);
 }
 
 .search-input-wrap {
@@ -17,7 +17,7 @@
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: var(--cc-space-3);
+  gap: var(--cc-space-4);
 }
 
 .search-input-icon {

--- a/app/src/views/SearchPane/SearchPane.css
+++ b/app/src/views/SearchPane/SearchPane.css
@@ -1,16 +1,23 @@
 /* ── Search pane ── */
 
 /* ── Search pane (Search tab in left sidebar) ───────────────────────────
-   Header (shared .pane-header) + input row + scrollable result list.
-   Matched query characters in each result are wrapped in <mark>. */
+   The search field IS the header row (no separate title bar): the input
+   fills the row with the × close button pinned right, and the result list
+   scrolls below. Matched query characters in each result are wrapped in <mark>. */
+
+/* The input takes the place of a title, so the row hugs the field instead of
+   the taller default header padding. */
+.pane-header--search {
+  padding-top: var(--cc-space-4);
+  padding-bottom: var(--cc-space-4);
+}
 
 .search-input-wrap {
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: var(--cc-space-3);
-  padding: var(--cc-space-7); /* shared pane content inset, all sides */
-  border-bottom: 1px solid var(--cc-border-subtle);
 }
 
 .search-input-icon {

--- a/app/src/views/SearchPane/SearchPane.css
+++ b/app/src/views/SearchPane/SearchPane.css
@@ -6,10 +6,10 @@
    scrolls below. Matched query characters in each result are wrapped in <mark>. */
 
 /* The input takes the place of a title, so the row hugs the field: shorter than
-   the default header, and flush to the left edge (no title inset) so the search
-   glyph starts at the pane edge. */
+   the default header, and the left inset matches the icon→input gap so the
+   search glyph sits with equal space on both sides. */
 .pane-header--search {
-  padding: var(--cc-space-4) var(--cc-space-6) var(--cc-space-4) 0;
+  padding: var(--cc-space-4) var(--cc-space-6) var(--cc-space-4) var(--cc-space-3);
 }
 
 .search-input-wrap {

--- a/app/src/views/SearchPane/SearchPane.tsx
+++ b/app/src/views/SearchPane/SearchPane.tsx
@@ -23,6 +23,7 @@ import { NodeKind } from '@/types';
 import type { DirNode, FileNode, Manifest, TreeNode } from '@/types';
 import { Search, SearchX } from 'lucide-preact';
 import { Pane, PaneEmpty } from '@/components/Pane';
+import { PaneCloseButton } from '@/components/PaneHeader/PaneHeader';
 
 const MAX_RESULTS = 50;
 const WORD_BOUNDARY_RE = /[/_\-.]/;
@@ -52,17 +53,25 @@ export function SearchPane({ manifest, onClose, onSelect, onFocus }: SearchPaneP
   const results = trimmed ? _searchFiles(trimmed, files) : null;
 
   return (
-    <Pane paneClass="search-pane" title="Search" onClose={onClose}>
-      <div class="search-input-wrap">
-        <Search class="lucide-icon search-input-icon" />
-        <input
-          type="search"
-          class="form-input search-input"
-          placeholder="Search files by path"
-          value={query}
-          onInput={(e) => setQuery((e.target as HTMLInputElement).value)}
-        />
-      </div>
+    <Pane
+      paneClass="search-pane"
+      headerSlot={
+        <div class="pane-header pane-header--search">
+          <div class="search-input-wrap">
+            <Search class="lucide-icon search-input-icon" aria-hidden="true" />
+            <input
+              type="search"
+              class="form-input search-input"
+              placeholder="Search files by path"
+              aria-label="Search files by path"
+              value={query}
+              onInput={(e) => setQuery((e.target as HTMLInputElement).value)}
+            />
+          </div>
+          {onClose && <PaneCloseButton onClose={onClose} />}
+        </div>
+      }
+    >
       <div class="pane-body">
         {!trimmed && (
           <PaneEmpty

--- a/app/src/views/SearchPane/SearchPane.tsx
+++ b/app/src/views/SearchPane/SearchPane.tsx
@@ -41,10 +41,9 @@ export interface SearchPaneProps {
   manifest: Signal<Manifest | DirNode | { tree?: unknown; [k: string]: unknown } | null>;
   onClose?: () => void;
   onSelect?: (path: string) => void;
-  onFocus?: (path: string) => void;
 }
 
-export function SearchPane({ manifest, onClose, onSelect, onFocus }: SearchPaneProps) {
+export function SearchPane({ manifest, onClose, onSelect }: SearchPaneProps) {
   const [query, setQuery] = useState('');
   // Flatten once per manifest, not per keystroke — _flattenFiles is an O(N)
   // tree walk and setQuery re-renders on every character typed.
@@ -98,9 +97,6 @@ export function SearchPane({ manifest, onClose, onSelect, onFocus }: SearchPaneP
                 tabIndex={0}
                 onClick={() => {
                   if (onSelect && file.path) onSelect(file.path);
-                }}
-                onDblClick={() => {
-                  if (onFocus && file.path) onFocus(file.path);
                 }}
                 onKeyDown={(e: KeyboardEvent) => {
                   if (e.key === 'Enter' && onSelect && file.path) onSelect(file.path);

--- a/app/src/views/ShortcutsModal/ShortcutsModal.css
+++ b/app/src/views/ShortcutsModal/ShortcutsModal.css
@@ -21,10 +21,8 @@
   font-style: normal;
 }
 
-/* Keyboard / mouse shortcuts table. Two-column grid:
- *   [keys / mouse]   [action]
- * Section breaks (null entries in the data) render as a thin divider
- * spanning both columns. */
+/* Keyboard / mouse shortcuts table. Two-column grid: [keys / mouse] [action].
+ * One grid per labelled section (Keyboard, Mouse). */
 .shortcuts-list {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -32,6 +30,11 @@
   align-items: center;
   margin: var(--cc-space-4) 0 0;
   font-size: var(--cc-font-md);
+}
+
+/* Space a following section label off the list above it. */
+.shortcuts-list + .text-label {
+  margin-top: var(--cc-space-6);
 }
 .shortcuts-list dt {
   color: var(--cc-text-secondary);
@@ -46,10 +49,4 @@
   color: var(--cc-text-faint);
   font-size: var(--cc-font-sm);
   margin-left: var(--cc-space-1);
-}
-.shortcuts-divider {
-  grid-column: 1 / -1;
-  height: 1px;
-  background: var(--cc-track);
-  margin: var(--cc-space-2) 0;
 }

--- a/app/src/views/ShortcutsModal/ShortcutsModal.tsx
+++ b/app/src/views/ShortcutsModal/ShortcutsModal.tsx
@@ -19,11 +19,13 @@ interface ShortcutItem {
   or?: string;
 }
 
-const GENERAL_SHORTCUTS: Array<ShortcutItem | null> = [
+const KEYBOARD_SHORTCUTS: ShortcutItem[] = [
   { kbd: [KEY_BINDINGS.RESET_VIEW.label], action: 'Reset the camera view' },
   { kbd: [KEY_BINDINGS.FOCUS_SELECTION.label], action: 'Focus camera on the current selection' },
   { kbd: [KEY_BINDINGS.CLEAR_SELECTION.label], action: 'Clear selection' },
-  null,
+];
+
+const MOUSE_SHORTCUTS: ShortcutItem[] = [
   { mouse: 'Click', action: 'Select building / street / gem' },
   { mouse: 'Double-click', action: 'Focus camera on the target' },
   { mouse: 'Left drag', action: 'Orbit' },
@@ -32,13 +34,10 @@ const GENERAL_SHORTCUTS: Array<ShortcutItem | null> = [
   { mouse: 'Scroll', action: 'Zoom toward cursor' },
 ];
 
-function ShortcutsList({ items }: { items: Array<ShortcutItem | null> }) {
+function ShortcutsList({ items }: { items: ShortcutItem[] }) {
   return (
     <dl class="shortcuts-list">
       {items.map((item, idx) => {
-        if (item == null) {
-          return <div key={`div-${idx}`} class="shortcuts-divider" />;
-        }
         const dt =
           item.kbd != null ? (
             <dt key={`dt-${idx}`}>
@@ -113,8 +112,10 @@ export function ShortcutsModal() {
           </button>
         </div>
         <div class="modal-body">
-          <h3 class="text-label">General</h3>
-          <ShortcutsList items={GENERAL_SHORTCUTS} />
+          <h3 class="text-label">Keyboard</h3>
+          <ShortcutsList items={KEYBOARD_SHORTCUTS} />
+          <h3 class="text-label">Mouse</h3>
+          <ShortcutsList items={MOUSE_SHORTCUTS} />
         </div>
       </div>
     </div>

--- a/app/src/views/StreetPane/StreetPane.css
+++ b/app/src/views/StreetPane/StreetPane.css
@@ -56,7 +56,7 @@
 .street-ext-icon {
   width: 15px;
   height: 15px;
-  color: #d3a85f; /* the almanac's "streets" accent */
+  color: var(--cc-layer-streets);
 }
 
 /* Shared 3-column grid (badge | bar | metric) so every row's bar is the same

--- a/app/src/views/TreePane/TreePane.css
+++ b/app/src/views/TreePane/TreePane.css
@@ -1,17 +1,11 @@
 /* ── Tree pane ─────────────────────────────────────────────────────────────── */
 
-.tree-pane {
+.tree-root {
   /* Row geometry the indent guide is derived from — single-sourced so the guide
      stays centered on the chevron if any of these change. */
   --tree-row-inset: var(--cc-space-4); /* row's left padding (the start indent) */
   --tree-glyph: 14px; /* file/folder icon column width (matches .file-icon) */
   --tree-guide: 1px; /* indent-guide line width */
-}
-
-/* Match the header's left inset to the rows so the repo name lines up over the
-   first icon column instead of sitting further in than the tree below it. */
-.tree-pane .pane-header {
-  padding-left: var(--tree-row-inset);
 }
 
 .tree-item.tree-hovered > .row {

--- a/app/src/views/TreePane/TreePane.tsx
+++ b/app/src/views/TreePane/TreePane.tsx
@@ -1,7 +1,8 @@
-// views/TreePane.tsx — Left sidebar tree view. Renders a
+// views/TreePane.tsx — the Explore pane's "File tree" subtab body. Renders a
 // collapsible folder/file tree that mirrors the city's layout
 // (alphabetical, files+dirs intermingled — see layout.js _layoutDir)
 // and stays bidirectionally synced with the scene's current selection.
+// Body-only — ExplorePane owns the Pane chrome + tab strip.
 //
 // Single-branch invariant: only one chain from the root is ever
 // exposed at a time. Expanding a dir closes every other branch;
@@ -16,7 +17,7 @@ import { NodeKind } from '@/types';
 import type { DirNode, Manifest, TreeNode } from '@/types';
 import { FolderOpen } from 'lucide-preact';
 import { NodeIcon } from '@/components/NodeIcon/NodeIcon';
-import { Pane, PaneEmpty } from '@/components/Pane';
+import { PaneEmpty } from '@/components/Pane';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -164,7 +165,6 @@ export interface TreePaneProps {
    *  signal's current value. */
   expanded: Signal<Set<string>>;
   rootPath: string;
-  onClose?: () => void;
   onSelect?: (node: TreeNode) => void;
   onHover?: (node: TreeNode) => void;
   onHoverEnd?: (node: TreeNode) => void;
@@ -176,7 +176,6 @@ export function TreePane({
   hoveredPath,
   expanded,
   rootPath,
-  onClose,
   onSelect,
   onHover,
   onHoverEnd,
@@ -199,37 +198,30 @@ export function TreePane({
   const noChildren =
     !tree || !('children' in tree) || ((tree as DirNode).children?.length ?? 0) === 0;
 
+  if (noChildren) {
+    return (
+      <PaneEmpty
+        icon={FolderOpen}
+        title={tree?.name ? 'Empty repository' : 'No project loaded'}
+        sub={tree?.name ? 'This project has no files yet.' : 'Open one to explore its file tree.'}
+      />
+    );
+  }
   return (
-    <Pane
-      paneClass="tree-pane"
-      // Header shows the repo name — the root node itself is no longer rendered
-      // as a row, so its children are the top level.
-      title={tree?.name || 'Explorer'}
-      onClose={onClose}
-    >
-      {noChildren ? (
-        <PaneEmpty
-          icon={FolderOpen}
-          title={tree?.name ? 'Empty repository' : 'No project loaded'}
-          sub={tree?.name ? 'This project has no files yet.' : 'Open one to explore its file tree.'}
+    <ul class="tree-list tree-root">
+      {_sortChildren((tree as DirNode).children).map((child) => (
+        <TreeItem
+          key={child.path ?? child.name}
+          node={child}
+          rootPath={rootPath}
+          expanded={expanded}
+          selectedPath={selectedPath}
+          hoveredPath={hoveredPath}
+          onSelect={onSelect}
+          onHover={onHover}
+          onHoverEnd={onHoverEnd}
         />
-      ) : (
-        <ul class="tree-list tree-root">
-          {_sortChildren((tree as DirNode).children).map((child) => (
-            <TreeItem
-              key={child.path ?? child.name}
-              node={child}
-              rootPath={rootPath}
-              expanded={expanded}
-              selectedPath={selectedPath}
-              hoveredPath={hoveredPath}
-              onSelect={onSelect}
-              onHover={onHover}
-              onHoverEnd={onHoverEnd}
-            />
-          ))}
-        </ul>
-      )}
-    </Pane>
+      ))}
+    </ul>
   );
 }

--- a/app/tests/city/render/framingDir.test.ts
+++ b/app/tests/city/render/framingDir.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { StreetAxis } from '@/types';
+import { computeFramingDir } from '@/city/render/framingDir';
+
+const DEG = Math.PI / 180;
+
+describe('computeFramingDir', () => {
+  it('returns a unit vector for every axis', () => {
+    for (const axis of [StreetAxis.X, StreetAxis.Y, null]) {
+      expect(computeFramingDir(44, 17, axis).length()).toBeCloseTo(1, 6);
+    }
+  });
+
+  it('dir.y encodes elevation (sin) independent of azimuth/axis', () => {
+    for (const axis of [StreetAxis.X, StreetAxis.Y, null]) {
+      expect(computeFramingDir(44, 17, axis).y).toBeCloseTo(Math.sin(44 * DEG), 6);
+    }
+  });
+
+  it('reproduces the legacy X-oriented framing (Vector3(-1, 1, 0.3))', () => {
+    // Legacy dir was new THREE.Vector3(-1, 1.0, 0.3).normalize() ≈ 43.75° / 16.7°.
+    const d = computeFramingDir(43.75, 16.7, StreetAxis.X);
+    expect(d.x).toBeCloseTo(-0.6917, 2);
+    expect(d.y).toBeCloseTo(0.6917, 2);
+    expect(d.z).toBeCloseTo(0.2075, 2);
+  });
+
+  it('azimuth 0 looks straight down the street (no lateral component)', () => {
+    expect(computeFramingDir(44, 0, StreetAxis.X).z).toBeCloseTo(0, 6); // lateral is Z
+    expect(computeFramingDir(44, 0, StreetAxis.Y).x).toBeCloseTo(0, 6); // lateral is X
+  });
+
+  it('90° elevation points straight down', () => {
+    const d = computeFramingDir(90, 30, StreetAxis.X);
+    expect(d.y).toBeCloseTo(1, 6);
+    expect(d.x).toBeCloseTo(0, 6);
+    expect(d.z).toBeCloseTo(0, 6);
+  });
+});

--- a/app/tests/layout/leftSidebar.test.tsx
+++ b/app/tests/layout/leftSidebar.test.tsx
@@ -61,7 +61,7 @@ describe('LeftSidebar', () => {
     const icons = container.querySelectorAll<HTMLButtonElement>('.activity-bar .activity-bar-icon');
     expect(icons.length).toBe(4);
     expect(icons[0].dataset.tab).toBe('info');
-    expect(icons[1].dataset.tab).toBe('tree');
+    expect(icons[1].dataset.tab).toBe('explore');
     expect(icons[2].dataset.tab).toBe('search');
     expect(icons[3].dataset.tab).toBe('controls');
   });
@@ -73,7 +73,7 @@ describe('LeftSidebar', () => {
     const bottom = container.querySelectorAll<HTMLButtonElement>(
       '.activity-bar-bottom .activity-bar-icon'
     );
-    expect(Array.from(top).map((b) => b.dataset.tab)).toEqual(['info', 'tree', 'search']);
+    expect(Array.from(top).map((b) => b.dataset.tab)).toEqual(['info', 'explore', 'search']);
     expect(Array.from(bottom).map((b) => b.dataset.tab)).toEqual(['controls']);
   });
 
@@ -107,9 +107,9 @@ describe('LeftSidebar', () => {
 
   it('reopens the Info tab when a new world loads', async () => {
     // Switch away from Info.
-    container.querySelector<HTMLButtonElement>('.activity-bar-icon[data-tab="tree"]')!.click();
+    container.querySelector<HTMLButtonElement>('.activity-bar-icon[data-tab="explore"]')!.click();
     await flush();
-    expect(container.querySelector('.tree-pane')).not.toBeNull();
+    expect(container.querySelector('.explore-pane')).not.toBeNull();
     // A world commits (cold-boot ?src= or a user switch both write CURRENT_SOURCE)
     // → snap back to the almanac.
     CURRENT_SOURCE.value = { src: 'github.com/o/r' };
@@ -119,6 +119,6 @@ describe('LeftSidebar', () => {
       container.querySelector('.activity-bar-icon[data-tab="info"]')!.classList.contains('active')
     ).toBe(true);
     expect(container.querySelector('.info-pane')).not.toBeNull();
-    expect(container.querySelector('.tree-pane')).toBeNull();
+    expect(container.querySelector('.explore-pane')).toBeNull();
   });
 });

--- a/app/tests/layout/leftSidebar.test.tsx
+++ b/app/tests/layout/leftSidebar.test.tsx
@@ -77,16 +77,14 @@ describe('LeftSidebar', () => {
     expect(Array.from(bottom).map((b) => b.dataset.tab)).toEqual(['controls']);
   });
 
-  it('shows the info pane by default and does not render the controls pane', () => {
-    // In the Preact port, hidden tabs aren't rendered at all (rather
-    // than mounted with display:none) — the activeTab signal drives a
-    // conditional render. Info is the default tab so a loaded world opens
-    // straight to its almanac.
+  it('starts collapsed by default, with no active tab', () => {
+    // The sidebar opens closed so a fresh load shows the city unobscured.
+    expect(container.querySelector('#left-sidebar')!.classList.contains('is-collapsed')).toBe(true);
+    expect(container.querySelector('.activity-bar-icon.active')).toBeNull();
+    // Info is still the default tab (its pane is mounted, just hidden), so
+    // opening the sidebar lands on the almanac; inactive tabs aren't rendered.
     expect(container.querySelector('.info-pane')).not.toBeNull();
     expect(container.querySelector('.controls-pane')).toBeNull();
-    expect(
-      container.querySelector('.activity-bar-icon[data-tab="info"]')!.classList.contains('active')
-    ).toBe(true);
   });
 
   it('switches panes when an icon is clicked', async () => {
@@ -105,20 +103,22 @@ describe('LeftSidebar', () => {
     ).toBe(true);
   });
 
-  it('reopens the Info tab when a new world loads', async () => {
-    // Switch away from Info.
+  it('collapses and resets to Info on world load (open state not remembered)', async () => {
+    // Open the sidebar on a non-default tab.
     container.querySelector<HTMLButtonElement>('.activity-bar-icon[data-tab="explore"]')!.click();
     await flush();
+    expect(container.querySelector('#left-sidebar')!.classList.contains('is-collapsed')).toBe(
+      false
+    );
     expect(container.querySelector('.explore-pane')).not.toBeNull();
     // A world commits (cold-boot ?src= or a user switch both write CURRENT_SOURCE)
-    // → snap back to the almanac.
+    // → force closed and reset to Info; the open state is not carried over.
     CURRENT_SOURCE.value = { src: 'github.com/o/r' };
-    // Two-hop settle: CURRENT_SOURCE → effect → activeTab → re-render.
+    // Two-hop settle: CURRENT_SOURCE → effect → activeTab/collapsed → re-render.
     await drainAsync();
-    expect(
-      container.querySelector('.activity-bar-icon[data-tab="info"]')!.classList.contains('active')
-    ).toBe(true);
-    expect(container.querySelector('.info-pane')).not.toBeNull();
+    expect(container.querySelector('#left-sidebar')!.classList.contains('is-collapsed')).toBe(true);
+    expect(container.querySelector('.activity-bar-icon.active')).toBeNull();
     expect(container.querySelector('.explore-pane')).toBeNull();
+    expect(container.querySelector('.info-pane')).not.toBeNull();
   });
 });

--- a/app/tests/state/settingsTips.test.ts
+++ b/app/tests/state/settingsTips.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { forEachSettingStore, getFieldKeys, getFieldDef } from '@/state/settingsSchema';
 // Import every settings store so it self-registers before we iterate.
 import '@/state/stores/settings/buildings';
+import '@/state/stores/settings/camera';
 import '@/state/stores/settings/effects';
 import '@/state/stores/settings/fireflies';
 import '@/state/stores/settings/footprint';

--- a/app/tests/views/ControlsPane/controlsPane.test.tsx
+++ b/app/tests/views/ControlsPane/controlsPane.test.tsx
@@ -52,7 +52,7 @@ describe('ControlsPane subtabs', () => {
   it('renders exactly three subtabs, World active by default', () => {
     const pane = mount();
     expect(pane.classList.contains('controls-pane')).toBe(true);
-    for (const label of ['World', 'Updates', 'Preview']) {
+    for (const label of ['World', 'Live updates', 'Preview']) {
       expect(tab(pane, label)).toBeTruthy();
     }
     expect(tab(pane, 'Shortcuts')).toBeUndefined();
@@ -63,7 +63,7 @@ describe('ControlsPane subtabs', () => {
   it('shows the action bar only on World; Updates/Preview autosave with no footer', () => {
     const pane = mount();
     expect(pane.querySelector('.controls-actions')).toBeTruthy(); // World
-    clickTab(pane, 'Updates');
+    clickTab(pane, 'Live updates');
     expect(pane.querySelector('.controls-actions')).toBeNull();
     clickTab(pane, 'Preview');
     expect(pane.querySelector('.controls-actions')).toBeNull();
@@ -71,7 +71,7 @@ describe('ControlsPane subtabs', () => {
 
   it('renders the Updates section inline, with no collapsible section wrapper', () => {
     const pane = mount();
-    clickTab(pane, 'Updates');
+    clickTab(pane, 'Live updates');
     expect(pane.querySelector('.controls-section')).toBeNull();
     expect(pane.querySelectorAll('.theme-row').length).toBeGreaterThan(0);
   });
@@ -100,7 +100,7 @@ describe('ControlsPane subtabs', () => {
   it('collapsed=true closes all <details> and resets to the World subtab', async () => {
     const pane = mount({ collapsed: false });
     pane.querySelectorAll<HTMLDetailsElement>('details').forEach((d) => (d.open = true));
-    clickTab(pane, 'Updates');
+    clickTab(pane, 'Live updates');
     act(() => {
       render(<ControlsPane onClose={() => {}} collapsed={true} />, container);
     });

--- a/app/tests/views/ExplorePane/explorePane.test.tsx
+++ b/app/tests/views/ExplorePane/explorePane.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { signal } from '@preact/signals';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { ExplorePane } from '@/views/ExplorePane/ExplorePane';
+import { flush } from '../../_helpers/preact';
+
+const TREE = {
+  name: 'project',
+  type: 'directory',
+  path: '.',
+  children: [
+    { name: 'index.ts', type: 'file', path: 'index.ts', fullPath: '/index.ts' },
+    { name: 'README.md', type: 'file', path: 'README.md', fullPath: '/README.md' },
+  ],
+};
+
+describe('ExplorePane', () => {
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  const tabByLabel = (label: string) =>
+    Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (el) => el.textContent === label
+    ) as HTMLButtonElement;
+
+  function mount() {
+    const manifest = signal<unknown>({ tree: TREE });
+    const selectedPath = signal<string | null>(null);
+    const hoveredPath = signal<string | null>(null);
+    const expanded = signal<Set<string>>(new Set(['.']));
+    act(() => {
+      render(
+        <ExplorePane
+          manifest={manifest as never}
+          selectedPath={selectedPath}
+          hoveredPath={hoveredPath}
+          expanded={expanded}
+          rootPath="."
+        />,
+        container
+      );
+    });
+  }
+
+  it('defaults to the File tree subtab', () => {
+    mount();
+    expect(tabByLabel('File tree').getAttribute('aria-selected')).toBe('true');
+    expect(tabByLabel('Readme').getAttribute('aria-selected')).toBe('false');
+    expect(container.querySelector('ul.tree-root')).not.toBeNull();
+  });
+
+  it('switches to the Readme subtab when clicked (tree body unmounts)', async () => {
+    mount();
+    tabByLabel('Readme').click();
+    await flush();
+    expect(tabByLabel('Readme').getAttribute('aria-selected')).toBe('true');
+    expect(container.querySelector('ul.tree-root')).toBeNull();
+  });
+});

--- a/app/tests/views/InfoPane/infoPane.test.tsx
+++ b/app/tests/views/InfoPane/infoPane.test.tsx
@@ -25,15 +25,15 @@ describe('InfoPane shell', () => {
     render(<InfoPane manifest={sig as never} />, container);
     await flush();
     expect(tabByLabel('Overview').getAttribute('aria-selected')).toBe('true');
-    expect(tabByLabel('Readme').getAttribute('aria-selected')).toBe('false');
+    expect(tabByLabel('Legend').getAttribute('aria-selected')).toBe('false');
   });
 
-  it('switches to Readme when its tab is clicked', async () => {
+  it('switches to Legend when its tab is clicked', async () => {
     const sig = signal(null);
     render(<InfoPane manifest={sig as never} />, container);
     await flush();
-    tabByLabel('Readme').click();
+    tabByLabel('Legend').click();
     await flush();
-    expect(tabByLabel('Readme').getAttribute('aria-selected')).toBe('true');
+    expect(tabByLabel('Legend').getAttribute('aria-selected')).toBe('true');
   });
 });

--- a/app/tests/views/InfoPane/legendPane.test.tsx
+++ b/app/tests/views/InfoPane/legendPane.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { signal } from '@preact/signals';
+import { render } from 'preact';
+import { LegendPane } from '@/views/InfoPane/LegendPane';
+import { InfoPane } from '@/views/InfoPane/InfoPane';
+import { LAYER_LEGEND } from '@/views/InfoPane/almanac';
+import { flush } from '../../_helpers/preact';
+
+describe('LegendPane', () => {
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it('renders every layer rule from the single source, keyed by section accent', () => {
+    render(<LegendPane />, container);
+    for (const layer of LAYER_LEGEND) {
+      const row = container.querySelector(`.legend-row[data-section="${layer.key}"]`);
+      expect(row, `row for ${layer.key}`).toBeTruthy();
+      expect(row!.textContent).toContain(layer.title);
+      expect(row!.textContent).toContain(layer.rule);
+    }
+  });
+
+  it('covers the non-layer cues (root gem + hover fade)', () => {
+    render(<LegendPane />, container);
+    const text = container.textContent ?? '';
+    expect(text).toContain('Root gem');
+    expect(text).toContain('Hover fade');
+  });
+
+  it('keeps all visible copy free of em-dashes (house style: colons/commas)', () => {
+    render(<LegendPane />, container);
+    expect(container.querySelector('.legend')!.textContent).not.toContain('—');
+  });
+
+  it('is reachable as the Legend subtab', async () => {
+    const sig = signal(null);
+    render(<InfoPane manifest={sig as never} />, container);
+    await flush();
+    const legendTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (el) => el.textContent === 'Legend'
+    ) as HTMLButtonElement;
+    expect(legendTab).toBeTruthy();
+    legendTab.click();
+    await flush();
+    expect(legendTab.getAttribute('aria-selected')).toBe('true');
+    expect(container.querySelector('.legend')).toBeTruthy();
+  });
+});

--- a/app/tests/views/InfoPane/legendPane.test.tsx
+++ b/app/tests/views/InfoPane/legendPane.test.tsx
@@ -17,13 +17,18 @@ describe('LegendPane', () => {
     container.remove();
   });
 
-  it('renders every layer rule from the single source, keyed by section accent', () => {
+  it('renders every layer + its cue rows from the single source, keyed by section accent', () => {
     render(<LegendPane />, container);
     for (const layer of LAYER_LEGEND) {
-      const row = container.querySelector(`.legend-row[data-section="${layer.key}"]`);
-      expect(row, `row for ${layer.key}`).toBeTruthy();
-      expect(row!.textContent).toContain(layer.title);
-      expect(row!.textContent).toContain(layer.rule);
+      const block = container.querySelector(`.legend-layer[data-section="${layer.key}"]`);
+      expect(block, `block for ${layer.key}`).toBeTruthy();
+      const text = block!.textContent ?? '';
+      expect(text).toContain(layer.title);
+      expect(text).toContain(layer.lead);
+      for (const cue of layer.cues) {
+        expect(text, `${layer.key} cue ${cue.label}`).toContain(cue.label);
+        expect(text, `${layer.key} cue ${cue.detail}`).toContain(cue.detail);
+      }
     }
   });
 

--- a/app/tests/views/filePreviewPane.test.tsx
+++ b/app/tests/views/filePreviewPane.test.tsx
@@ -143,9 +143,9 @@ describe('FilePreviewPane', () => {
   });
 
   it('renders the × close button only when onClose is provided', () => {
-    // No onClose (and no onFocus) → header renders no .btn-icon--text buttons.
+    // No onClose (and no onFocus) → header renders no trailing icon button.
     mount();
-    expect(container.querySelector('.pane-header .btn-icon--text:last-child')).toBeNull();
+    expect(container.querySelector('.pane-header .btn-icon:last-child')).toBeNull();
 
     // Tear down the no-close mount before remounting into the same container.
     render(null, container);
@@ -157,7 +157,7 @@ describe('FilePreviewPane', () => {
       },
     });
     const btn = container.querySelector(
-      '.pane-header .btn-icon--text:last-child'
+      '.pane-header .btn-icon:last-child'
     ) as HTMLButtonElement | null;
     expect(btn).not.toBeNull();
     btn!.click();

--- a/app/tests/views/searchPane.test.tsx
+++ b/app/tests/views/searchPane.test.tsx
@@ -89,17 +89,10 @@ const TREE = {
 describe('SearchPane', () => {
   let container: HTMLDivElement;
 
-  function mount(
-    opts: { onSelect?: (p: string) => void; onFocus?: (p: string) => void } = {}
-  ): ReturnType<typeof signal> {
+  function mount(opts: { onSelect?: (p: string) => void } = {}): ReturnType<typeof signal> {
     const manifest = signal<unknown>({ tree: TREE });
     render(
-      <SearchPane
-        manifest={manifest as never}
-        onClose={() => {}}
-        onSelect={opts.onSelect}
-        onFocus={opts.onFocus}
-      />,
+      <SearchPane manifest={manifest as never} onClose={() => {}} onSelect={opts.onSelect} />,
       container
     );
     return manifest;
@@ -195,20 +188,6 @@ describe('SearchPane', () => {
     const first = container.querySelector<HTMLLIElement>('.search-result')!;
     first.click();
     expect(selected).toBe('src/coordinator.ts');
-  });
-
-  it('calls onFocus(path) when a result is double-clicked', async () => {
-    let focused: string | null = null;
-    mount({
-      onFocus: (p: string) => {
-        focused = p;
-      },
-    });
-    await typeQuery('coord');
-
-    const first = container.querySelector<HTMLLIElement>('.search-result')!;
-    first.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-    expect(focused).toBe('src/coordinator.ts');
   });
 
   it('re-indexes when the manifest signal changes', async () => {

--- a/app/tests/views/treePane.test.tsx
+++ b/app/tests/views/treePane.test.tsx
@@ -56,14 +56,13 @@ describe('TreePane', () => {
   let expanded: ReturnType<typeof signal<Set<string>>>;
 
   interface MountOpts {
-    onClose?: () => void;
     onSelect?: (node: TreeNode) => void;
     onHover?: (node: TreeNode) => void;
     onHoverEnd?: (node: TreeNode) => void;
   }
 
-  // Renders <TreePane> into the test container with fresh signals and
-  // returns the `.pane` element (mirrors the old buildTreePane().pane).
+  // Renders the body-only <TreePane> into the test container with fresh signals
+  // and returns the container (TreePane owns no chrome — ExplorePane does).
   function mount(initialManifest: TreeLike, opts: MountOpts = {}): HTMLElement {
     manifest = signal<TreeLike | null>(initialManifest);
     selectedPath = signal<string | null>(null);
@@ -88,7 +87,6 @@ describe('TreePane', () => {
           hoveredPath={hoveredPath}
           expanded={expanded}
           rootPath={rootPath}
-          onClose={opts.onClose}
           onSelect={opts.onSelect}
           onHover={opts.onHover}
           onHoverEnd={opts.onHoverEnd}
@@ -96,7 +94,7 @@ describe('TreePane', () => {
         container
       );
     });
-    return container.querySelector('.pane') as HTMLElement;
+    return container;
   }
 
   beforeEach(() => {
@@ -132,28 +130,17 @@ describe('TreePane', () => {
     expect(collapsedDir.querySelector(':scope > .tree-list')).toBeNull();
   });
 
-  it('returns a pane with header + tree content', () => {
+  it('renders the tree content as a root list (chrome is ExplorePane’s)', () => {
     const pane = mount({ tree: TEST_TREE });
-
-    expect(pane.classList.contains('pane')).toBe(true);
-    expect(pane.classList.contains('tree-pane')).toBe(true);
-
-    const header = pane.querySelector('.pane-header');
-    expect(header).not.toBeNull();
-
-    const title = pane.querySelector('.text-pane-title');
-    expect(title).not.toBeNull();
-    // Header shows the repo name, not a static "Explorer" label.
-    expect(title!.textContent).toBe('project');
-
+    expect(pane.querySelector('ul.tree-root')).not.toBeNull();
     const items = pane.querySelectorAll<HTMLLIElement>('.tree-item');
     expect(items.length).toBeGreaterThan(0);
   });
 
   it('accepts a bare tree (no { tree } wrapper)', () => {
     const pane = mount(TEST_TREE);
-    const title = pane.querySelector('.text-pane-title');
-    expect(title!.textContent).toBe('project');
+    const labels = pane.querySelectorAll<HTMLElement>('ul.tree-root > li > .row > .tree-label');
+    expect(Array.from(labels, (el) => el.textContent)).toEqual(['index.ts', 'README.md', 'src']);
   });
 
   it("renders the root's children as the top level (root node has no row)", () => {


### PR DESCRIPTION
Closes #88.

Started as issue #88's "How this city is built" Legend and grew (by request) into a cohesive Info-pane, view, and chrome pass.

## Legend (the #88 ask)
- New static **Legend** subtab: each world layer renders as an accented header + a `cue → meaning` key, plus a "Reading the city" group (root gem, hover fade). Purely explanatory — no rendering change.
- **Audited every data-driven encoding** in the renderer and put the salient ones in the key:
  - **Buildings** — height ← lines, footprint ← file size, color & roof icon ← file type, brightness ← recent edits, grime & lean ← age.
  - **Billboards** — shape ← aspect ratio, width ← file size, video ← play button.
  - **Streets** — width ← file count, length ← content, label ← name.
  - **Forest** — height ← commit age, canopy ← commit size, color ← day busyness, position ← age.
  - **Fireflies** — color ← author identity, size ← commit count.

## Sidebar information architecture
- **Info** = *interpret* → Overview + Legend.
- **Explore** = *browse* (new pane, Compass icon) → File tree + Readme. Readme moved out of Info; TreePane became body-only (ExplorePane owns the chrome), mirroring InfoPane.
- The **left sidebar now starts closed** and force-closes (reset to Info) on every world load; its open state is no longer persisted.

## Camera
- New **World → Camera** section: live **Elevation** + **Azimuth** sliders that set the angle the default view frames the city from (always looking at the root gem). Autosave + `ChangeRoute.Live`, so dragging re-frames immediately (the rig subscribes and snaps). Framing direction moved from hardcoded constants to a pure, unit-tested `computeFramingDir()`.
- Default framing is a near-horizon 5° / 0°.

## Chrome polish
- **Search**: field moved into the pane header (one compact row), uniform padding, single-click/Enter to select (dropped double-click-to-focus).
- **Shortcuts modal**: vague "General" → labeled **Keyboard** / **Mouse** sections.
- **Settings**: "Updates" tab → **Live updates**.
- **Close buttons**: sidebar/pane × matches the app-header icon buttons; modal × is large + square.
- **Project switcher**: dropped the redundant Map icon (freed for the Legend).
- **Right sidebar**: defaults to a third of the viewport.

## Single-sourcing / cleanup
- Layer copy consolidated into one `LAYER_LEGEND` in `almanac.ts`; Overview tooltips compose from it.
- Per-layer accents promoted to shared `--cc-layer-*` tokens (Legend, Overview, landing icons, StreetPane); streets retuned to teal.
- `SECTION_ICON` lifted to a shared module.

## Verification
`just lint` + `just test` green — **2485 tests**, including new `LegendPane`, `ExplorePane`, and `computeFramingDir` coverage plus updated Info/Explore/sidebar/search/close-button tests. Eyeballed live via `just dev`.