### PR TITLE
Render a font specimen when previewing font files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        git ca-certificates wget \
+        git git-lfs ca-certificates wget \
     && rm -rf /var/lib/apt/lists/*
 
 # uv: bring in the static binary from the official image.

--- a/api/services/clone.py
+++ b/api/services/clone.py
@@ -455,6 +455,57 @@ def _resolve_default_branch(repo: Path) -> str | None:
     return out.rsplit("/", 1)[-1] if out else None
 
 
+def _repo_uses_lfs(target: Path) -> bool:
+    """True when the checked-out tree has Git-LFS-tracked files. Authoritative
+    (reads the index + .gitattributes wherever they live, not just the root) and
+    cheap — it lists pointers, not object contents. Returns False when git-lfs
+    isn't installed, so a host without it degrades to plain clones instead of
+    erroring."""
+    try:
+        return bool(_run_git("lfs", "ls-files", "-n", cwd=target).strip())
+    except CloneError:
+        return False
+
+
+def _pull_lfs(
+    target: Path,
+    *,
+    on_heartbeat: Callable[[int | None], None] | None = None,
+    cancel_event: "threading.Event | None" = None,
+) -> None:
+    """Materialize Git LFS objects for the checked-out tree, replacing pointer
+    stubs with real bytes. A plain clone leaves LFS files as tiny text pointers,
+    so without this a font/image/video stored in LFS reads as garbage (fonts
+    fail to parse; image billboards render broken).
+
+    Fetches only what HEAD references — consistent with the blobless clone, which
+    already skips historical blobs the scanner never reads.
+
+    Best effort: a failure (LFS server down, quota, auth) leaves the pointer
+    files in place and is logged, not raised. The scan still completes and the
+    preview / billboard falls back gracefully on the pointer bytes rather than
+    the whole load failing over unreachable LFS storage."""
+    if not _repo_uses_lfs(target):
+        return
+    _log(f"pulling git lfs objects for {target}")
+    try:
+        # Heartbeat off the LFS object store (not .git/objects/pack — LFS bytes
+        # land there) so a big download shows progress instead of a silent wait.
+        _run_git_streaming(
+            "lfs",
+            "pull",
+            cwd=target,
+            progress_dir=target / ".git" / "lfs" / "objects",
+            on_heartbeat=on_heartbeat,
+            cancel_event=cancel_event,
+        )
+        _log("git lfs pull complete")
+    except ScanCancelledError:
+        raise
+    except CloneError as e:
+        _log(f"git lfs pull failed ({e}); leaving pointer files in place")
+
+
 def _fresh_clone(
     url: str,
     branch: str | None,
@@ -497,6 +548,7 @@ def _fresh_clone(
         shutil.rmtree(target, ignore_errors=True)
         _maybe_raise_clean_clone_error(url, branch, str(e))
         raise
+    _pull_lfs(target, on_heartbeat=on_heartbeat, cancel_event=cancel_event)
     return target
 
 
@@ -550,6 +602,7 @@ def ensure_clone(
                 # the working tree empty; the scanner will produce an
                 # empty manifest and the frontend renders an empty world.
                 _log("remote has no commits; skipping reset")
+            _pull_lfs(target, on_heartbeat=on_heartbeat, cancel_event=cancel_event)
             _log("update complete")
             return target
         except CloneError as e:

--- a/api/tests/test_clone.py
+++ b/api/tests/test_clone.py
@@ -26,6 +26,7 @@ from api.services.clone import (
     _maybe_raise_clean_clone_error,
     ensure_clone,
 )
+from api.services.scan import ScanCancelledError
 
 
 os.environ["CODECITY_QUIET"] = "1"
@@ -541,11 +542,17 @@ def test_ensure_clone_emits_throttled_progress_via_callback(tmp_path):
 
     cache = tmp_path / "cache"
     on_progress = MagicMock()
-    with mock.patch.object(clone_mod, "CLONES_ROOT", cache):
-        with mock.patch.object(subprocess, "Popen", return_value=FakeProc()):
-            clone_mod.ensure_clone(
-                "https://example.com/foo.git", None, on_progress=on_progress
-            )
+    with (
+        mock.patch.object(clone_mod, "CLONES_ROOT", cache),
+        # This test fakes the whole subprocess layer to exercise clone-progress
+        # emission; the post-clone LFS pull is a separate concern and would try
+        # to spawn a real git against the fake tree, so stub it out.
+        mock.patch.object(clone_mod, "_pull_lfs"),
+        mock.patch.object(subprocess, "Popen", return_value=FakeProc()),
+    ):
+        clone_mod.ensure_clone(
+            "https://example.com/foo.git", None, on_progress=on_progress
+        )
 
     assert on_progress.call_count >= 1, (
         f"callback should fire at least once; calls={on_progress.call_args_list}"
@@ -608,11 +615,17 @@ def test_ensure_clone_emits_terminal_percent_of_each_stage(tmp_path):
 
     cache = tmp_path / "cache"
     on_progress = MagicMock()
-    with mock.patch.object(clone_mod, "CLONES_ROOT", cache):
-        with mock.patch.object(subprocess, "Popen", return_value=FakeProc()):
-            clone_mod.ensure_clone(
-                "https://example.com/foo.git", None, on_progress=on_progress
-            )
+    with (
+        mock.patch.object(clone_mod, "CLONES_ROOT", cache),
+        # This test fakes the whole subprocess layer to exercise clone-progress
+        # emission; the post-clone LFS pull is a separate concern and would try
+        # to spawn a real git against the fake tree, so stub it out.
+        mock.patch.object(clone_mod, "_pull_lfs"),
+        mock.patch.object(subprocess, "Popen", return_value=FakeProc()),
+    ):
+        clone_mod.ensure_clone(
+            "https://example.com/foo.git", None, on_progress=on_progress
+        )
 
     # Collect per-stage the highest percent ever emitted.
     per_stage_max: dict[str, int] = {}
@@ -630,6 +643,101 @@ def test_ensure_clone_emits_terminal_percent_of_each_stage(tmp_path):
     assert per_stage_max.get("resolving") == 100, (
         f"resolving should reach 100%; per-stage max: {per_stage_max}"
     )
+
+
+class GitLfsTests(unittest.TestCase):
+    """Git LFS materialization: a plain clone leaves LFS files as pointer stubs,
+    so ensure_clone runs `git lfs pull` to swap in the real bytes. Mocked at the
+    subprocess boundary so these run without git-lfs installed on the host."""
+
+    def test_repo_uses_lfs_true_when_pointers_listed(self) -> None:
+        with mock.patch.object(
+            clone_mod, "_run_git", return_value="fonts/Inter.woff2\n"
+        ):
+            self.assertTrue(clone_mod._repo_uses_lfs(Path("/x")))
+
+    def test_repo_uses_lfs_false_when_no_lfs_files(self) -> None:
+        with mock.patch.object(clone_mod, "_run_git", return_value="\n"):
+            self.assertFalse(clone_mod._repo_uses_lfs(Path("/x")))
+
+    def test_repo_uses_lfs_false_when_git_lfs_unavailable(self) -> None:
+        # Host without git-lfs: `git lfs ls-files` errors → treat as non-LFS and
+        # fall back to a plain clone rather than crashing.
+        with mock.patch.object(
+            clone_mod, "_run_git", side_effect=CloneError("'lfs' is not a git command")
+        ):
+            self.assertFalse(clone_mod._repo_uses_lfs(Path("/x")))
+
+    def test_pull_lfs_skips_non_lfs_repo(self) -> None:
+        with (
+            mock.patch.object(clone_mod, "_repo_uses_lfs", return_value=False),
+            mock.patch.object(clone_mod, "_run_git_streaming") as streamed,
+        ):
+            clone_mod._pull_lfs(Path("/x"))
+            streamed.assert_not_called()
+
+    def test_pull_lfs_runs_git_lfs_pull(self) -> None:
+        with (
+            mock.patch.object(clone_mod, "_repo_uses_lfs", return_value=True),
+            mock.patch.object(
+                clone_mod, "_run_git_streaming", return_value=""
+            ) as streamed,
+        ):
+            clone_mod._pull_lfs(Path("/x"))
+            streamed.assert_called_once()
+            self.assertEqual(streamed.call_args.args[:2], ("lfs", "pull"))
+
+    def test_pull_lfs_swallows_failure(self) -> None:
+        # LFS server down / quota / auth: leave the pointer files in place and
+        # let the scan continue rather than failing the whole load.
+        with (
+            mock.patch.object(clone_mod, "_repo_uses_lfs", return_value=True),
+            mock.patch.object(
+                clone_mod,
+                "_run_git_streaming",
+                side_effect=CloneError("lfs fetch failed"),
+            ),
+        ):
+            clone_mod._pull_lfs(Path("/x"))  # must not raise
+
+    def test_pull_lfs_propagates_cancel(self) -> None:
+        with (
+            mock.patch.object(clone_mod, "_repo_uses_lfs", return_value=True),
+            mock.patch.object(
+                clone_mod, "_run_git_streaming", side_effect=ScanCancelledError()
+            ),
+        ):
+            with self.assertRaises(ScanCancelledError):
+                clone_mod._pull_lfs(Path("/x"))
+
+
+class EnsureCloneLfsWiringTests(unittest.TestCase):
+    """ensure_clone must invoke the LFS pull on both the fresh-clone and the
+    update path, against the checked-out clone directory."""
+
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.tmp_path = Path(self.tmp.name)
+        self.cache = self.tmp_path / "cache"
+        patch = mock.patch.object(clone_mod, "CLONES_ROOT", self.cache)
+        patch.start()
+        self.addCleanup(patch.stop)
+        self.remote, _ = _make_fake_remote(self.tmp_path)
+        self.url = str(self.remote)
+
+    def test_fresh_clone_pulls_lfs(self) -> None:
+        with mock.patch.object(clone_mod, "_pull_lfs") as pull:
+            local = ensure_clone(self.url)
+            pull.assert_called_once()
+            self.assertEqual(pull.call_args.args[0], local)
+
+    def test_update_path_pulls_lfs(self) -> None:
+        ensure_clone(self.url)  # first clone (real pull, no-op on this repo)
+        with mock.patch.object(clone_mod, "_pull_lfs") as pull:
+            local = ensure_clone(self.url)  # second call takes the update path
+            pull.assert_called_once()
+            self.assertEqual(pull.call_args.args[0], local)
 
 
 if __name__ == "__main__":

--- a/app/src/api/file.ts
+++ b/app/src/api/file.ts
@@ -16,3 +16,15 @@ export async function fetchFileText(path: string): Promise<string> {
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.text();
 }
+
+/**
+ * Fetch the raw bytes for a file. Throws on non-2xx. Used by the font preview,
+ * which sniffs the bytes and builds a FontFace from them directly (rather than
+ * pointing FontFace at the URL) so it can reject non-fonts before the browser
+ * attempts — and noisily fails — to decode them.
+ */
+export async function fetchFileBytes(path: string): Promise<ArrayBuffer> {
+  const resp = await fetch(fileUrl(path));
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.arrayBuffer();
+}

--- a/app/src/views/FilePreviewPane/FilePreviewPane.css
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.css
@@ -191,3 +191,76 @@
   background: transparent !important;
   padding: 0 !important;
 }
+
+/* ── Font specimen (font preview) ───────────────────────────────────────
+   A scrollable column with two sections: a Google-Fonts-style Preview
+   waterfall (uppercase / lowercase / digits / pangram) and a Font-Book-style
+   Repertoire grid of every glyph. The loaded face is applied via an inline
+   font-family (a per-mount family name), so these rules only own layout,
+   section chrome, and neutral color. */
+
+.font-specimen {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cc-space-9);
+  padding: var(--cc-space-8);
+  color: var(--cc-text-primary);
+}
+
+.font-specimen-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cc-space-6);
+}
+
+/* The Preview / Repertoire eyebrows stay in the UI font (.text-label), never
+   the previewed face, so they read even for display / symbol fonts. */
+.font-specimen-label {
+  color: var(--cc-text-muted);
+}
+
+.font-specimen-waterfall {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cc-space-2);
+}
+
+.font-specimen-line {
+  margin: var(--cc-space-0);
+  font-size: 44px;
+  line-height: var(--cc-lh-tight);
+  word-break: break-word;
+}
+
+.font-specimen-pangram {
+  margin: var(--cc-space-4) var(--cc-space-0) var(--cc-space-0);
+  font-size: 24px;
+  line-height: var(--cc-lh-base);
+  color: var(--cc-text-secondary);
+  word-break: break-word;
+}
+
+/* Character grid — auto-fill so it reflows to the pane width; each glyph is
+   centered in a fixed-height cell so rows stay aligned regardless of glyph
+   metrics. */
+.font-specimen-repertoire {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(2.75rem, 1fr));
+  gap: var(--cc-space-1);
+}
+
+.font-specimen-glyph {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.75rem;
+  font-size: 28px;
+  line-height: 1;
+  border-radius: var(--cc-radius-sm);
+}
+.font-specimen-glyph:hover {
+  background: var(--cc-bg-chrome);
+}

--- a/app/src/views/FilePreviewPane/FilePreviewPane.css
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.css
@@ -230,14 +230,14 @@
 
 .font-specimen-line {
   margin: var(--cc-space-0);
-  font-size: 36px;
+  font-size: 28px;
   line-height: var(--cc-lh-tight);
   word-break: break-word;
 }
 
 .font-specimen-pangram {
   margin: var(--cc-space-4) var(--cc-space-0) var(--cc-space-0);
-  font-size: 20px;
+  font-size: 16px;
   line-height: var(--cc-lh-base);
   color: var(--cc-text-secondary);
   word-break: break-word;
@@ -248,7 +248,7 @@
    metrics. */
 .font-specimen-repertoire {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(2.25rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(2rem, 1fr));
   gap: var(--cc-space-1);
 }
 
@@ -256,8 +256,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 2.25rem;
-  font-size: 22px;
+  height: 2rem;
+  font-size: 18px;
   line-height: 1;
   border-radius: var(--cc-radius-sm);
 }

--- a/app/src/views/FilePreviewPane/FilePreviewPane.css
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.css
@@ -230,14 +230,14 @@
 
 .font-specimen-line {
   margin: var(--cc-space-0);
-  font-size: 44px;
+  font-size: 36px;
   line-height: var(--cc-lh-tight);
   word-break: break-word;
 }
 
 .font-specimen-pangram {
   margin: var(--cc-space-4) var(--cc-space-0) var(--cc-space-0);
-  font-size: 24px;
+  font-size: 20px;
   line-height: var(--cc-lh-base);
   color: var(--cc-text-secondary);
   word-break: break-word;
@@ -248,7 +248,7 @@
    metrics. */
 .font-specimen-repertoire {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(2.75rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(2.25rem, 1fr));
   gap: var(--cc-space-1);
 }
 
@@ -256,8 +256,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 2.75rem;
-  font-size: 28px;
+  height: 2.25rem;
+  font-size: 22px;
   line-height: 1;
   border-radius: var(--cc-radius-sm);
 }

--- a/app/src/views/FilePreviewPane/FilePreviewPane.tsx
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.tsx
@@ -24,9 +24,10 @@ export enum PreviewKind {
   Video = 'video',
   Audio = 'audio',
   Pdf = 'pdf',
+  Font = 'font',
   Text = 'text',
 }
-import { fileUrl, fetchFileText } from '@/api/file';
+import { fileUrl, fetchFileText, fetchFileBytes } from '@/api/file';
 import { FileWarning, FileX, Info, MousePointerClick } from 'lucide-preact';
 import { Pane, PaneEmpty } from '@/components/Pane';
 import { KEY_BINDINGS } from '@/constants/keyboard';
@@ -54,6 +55,7 @@ const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.
 const VIDEO_EXTS = ['.mp4', '.webm', '.mov', '.ogv', '.m4v'];
 const AUDIO_EXTS = ['.mp3', '.wav', '.ogg', '.flac', '.aac', '.m4a'];
 const PDF_EXTS = ['.pdf'];
+const FONT_EXTS = ['.woff2', '.woff', '.ttf', '.otf'];
 
 // ── State shape for Preact component ─────────────────────────────────────────
 
@@ -67,12 +69,13 @@ export interface FilePreviewPaneProps {
   onFocus?: (file: FileNode) => void;
 }
 
-function _previewKind(file: FileNode | { extension?: string }): PreviewKind {
+export function _previewKind(file: FileNode | { extension?: string }): PreviewKind {
   const ext = (file.extension || '').toLowerCase();
   if (IMAGE_EXTS.includes(ext)) return PreviewKind.Image;
   if (VIDEO_EXTS.includes(ext)) return PreviewKind.Video;
   if (AUDIO_EXTS.includes(ext)) return PreviewKind.Audio;
   if (PDF_EXTS.includes(ext)) return PreviewKind.Pdf;
+  if (FONT_EXTS.includes(ext)) return PreviewKind.Font;
   // Anything else: try as text. The Preview helper will swap to a "Binary"
   // notice if the response isn't decodable as UTF-8.
   return PreviewKind.Text;
@@ -223,6 +226,183 @@ function CodeEditor({ text, file }: CodeEditorProps) {
   );
 }
 
+// ── Font specimen preview sub-component ──────────────────────────────────────
+
+// Discriminant for the FontFace load — mirrors FileTextPreview's
+// loading → ready → error state machine.
+enum FontStateKind {
+  Loading = 'loading',
+  Ready = 'ready',
+  Error = 'error',
+}
+
+type FontState =
+  | { kind: FontStateKind.Loading }
+  | { kind: FontStateKind.Ready }
+  | { kind: FontStateKind.Error; message: string };
+
+// Specimen content. The Preview block is a Google-Fonts-style waterfall
+// (uppercase, lowercase, digits, then a pangram); the Repertoire block is a
+// Font-Book-style grid of every glyph we render.
+const SPECIMEN_UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const SPECIMEN_LOWER = 'abcdefghijklmnopqrstuvwxyz';
+const SPECIMEN_DIGITS = '1234567890';
+const SPECIMEN_PANGRAM = 'The quick brown fox jumps over the lazy dog';
+
+// Repertoire: printable ASCII (skip 0x20 space — it's a blank cell) plus a
+// curated run of common Latin-1 / extended glyphs, ligatures, and punctuation,
+// mirroring a Font Book character grid. Glyphs the face lacks fall back to the
+// browser's default font rather than being hidden — detecting true coverage
+// needs font-table parsing this preview intentionally avoids.
+const REPERTOIRE: string[] = [
+  ...Array.from({ length: 0x7e - 0x21 + 1 }, (_, i) => String.fromCharCode(0x21 + i)),
+  ...'¡¿€£¥¢©®™°±×÷§¶†‡–—…«»‹›“”‘’·•',
+  ...'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØŒÙÚÛÜÝÞ',
+  ...'àáâãäåæçèéêëìíîïðñòóôõöøœùúûüýþÿ',
+  ...'ﬁﬂßıŁłĐđ',
+];
+
+// Monotonic id so each mounted preview registers a distinct @font-face family;
+// two files with the same basename must not collide on one document-level face.
+let fontFamilySeq = 0;
+
+// sfnt / WOFF signatures (first 4 bytes, big-endian) for the formats a browser
+// can render via FontFace. We sniff these before handing bytes to FontFace so a
+// non-font (a Git LFS pointer, a text file with a .ttf name) never reaches the
+// decoder, which would otherwise log "Failed to decode downloaded font" to the
+// console for every attempt.
+const FONT_SIGNATURES = new Set([
+  0x00010000, // TrueType outlines
+  0x4f54544f, // 'OTTO' — OpenType with CFF outlines
+  0x74727565, // 'true' — TrueType (legacy Mac)
+  0x74797031, // 'typ1' — PostScript in an sfnt wrapper
+  0x74746366, // 'ttcf' — TrueType/OpenType collection
+  0x774f4646, // 'wOFF' — WOFF
+  0x774f4632, // 'wOF2' — WOFF2
+]);
+
+/**
+ * Decide whether a file's bytes are a font we can render. Returns null when
+ * they are; otherwise a human-readable reason for the fallback notice. Catches
+ * the common "font stored via Git LFS, not smudged on clone" case with a
+ * specific message.
+ */
+function fontRejectReason(buf: ArrayBuffer): string | null {
+  if (buf.byteLength < 4) return 'This file is empty or too small to be a font.';
+  const signature = new DataView(buf).getUint32(0, false);
+  if (FONT_SIGNATURES.has(signature)) return null;
+
+  const head = new TextDecoder().decode(new Uint8Array(buf, 0, Math.min(48, buf.byteLength)));
+  if (head.startsWith('version https://git-lfs')) {
+    return 'This is a Git LFS pointer, not the font itself. Clone with Git LFS to preview it.';
+  }
+  return 'This file is not a recognized font (ttf, otf, woff, or woff2).';
+}
+
+interface FontPreviewProps {
+  file: FileNode;
+}
+
+/**
+ * Loads a font file through the FontFace API and renders a live specimen in
+ * that face. The face is registered on document.fonts for the component's
+ * lifetime and removed on unmount / file change, so switching files never
+ * leaves orphaned faces behind. Parse failures fall back to a graceful notice
+ * rather than dumping the binary bytes.
+ */
+function FontPreview({ file }: FontPreviewProps) {
+  const [family] = useState(() => `cc-font-specimen-${(fontFamilySeq += 1)}`);
+  const [fontState, setFontState] = useState<FontState>({ kind: FontStateKind.Loading });
+
+  useEffect(() => {
+    setFontState({ kind: FontStateKind.Loading });
+
+    if (typeof FontFace === 'undefined' || typeof document.fonts === 'undefined') {
+      setFontState({ kind: FontStateKind.Error, message: 'Font preview is unavailable here.' });
+      return;
+    }
+
+    let cancelled = false;
+    // Only faces we actually register get cleaned up, so a rejected load never
+    // tries to delete a face that was never added.
+    let added: FontFace | null = null;
+
+    fetchFileBytes(file.fullPath || '').then(
+      async (buf) => {
+        if (cancelled) return;
+        const reason = fontRejectReason(buf);
+        if (reason) {
+          // Bail before FontFace so the browser never logs a decode error.
+          setFontState({ kind: FontStateKind.Error, message: reason });
+          return;
+        }
+        try {
+          // Build from the bytes we already have (not a url()), so there's no
+          // second network round trip.
+          const loaded = await new FontFace(family, buf).load();
+          if (cancelled) return;
+          document.fonts.add(loaded);
+          added = loaded;
+          setFontState({ kind: FontStateKind.Ready });
+        } catch {
+          if (cancelled) return;
+          setFontState({
+            kind: FontStateKind.Error,
+            message: 'This file could not be read as a font.',
+          });
+        }
+      },
+      (err) => {
+        if (cancelled) return;
+        setFontState({
+          kind: FontStateKind.Error,
+          message: err && err.message ? err.message : 'Could not load this file.',
+        });
+      }
+    );
+
+    return () => {
+      cancelled = true;
+      if (added) document.fonts?.delete(added);
+    };
+    // Key on fullPath so a live-update poll (same path, new bytes) re-loads.
+  }, [file.fullPath, family]);
+
+  return (
+    <div class="pane preview-shell">
+      {fontState.kind === FontStateKind.Error ? (
+        <PaneEmpty icon={FileWarning} title="Couldn't render this font" sub={fontState.message} />
+      ) : fontState.kind === FontStateKind.Ready ? (
+        <div class="font-specimen" style={{ fontFamily: `"${family}", sans-serif` }}>
+          <section class="font-specimen-section">
+            <h3 class="text-label font-specimen-label">Preview</h3>
+            <div class="font-specimen-waterfall">
+              <p class="font-specimen-line">{SPECIMEN_UPPER}</p>
+              <p class="font-specimen-line">{SPECIMEN_LOWER}</p>
+              <p class="font-specimen-line">{SPECIMEN_DIGITS}</p>
+              <p class="font-specimen-pangram">{SPECIMEN_PANGRAM}</p>
+            </div>
+          </section>
+          <section class="font-specimen-section">
+            <h3 class="text-label font-specimen-label">Repertoire</h3>
+            <div class="font-specimen-repertoire">
+              {REPERTOIRE.map((ch, i) => (
+                <span key={i} class="font-specimen-glyph">
+                  {ch}
+                </span>
+              ))}
+            </div>
+          </section>
+        </div>
+      ) : (
+        <span class="sr-only" role="status">
+          Loading font
+        </span>
+      )}
+    </div>
+  );
+}
+
 // ── Body content ─────────────────────────────────────────────────────────────
 
 function _previewBody(file: FileNode | null) {
@@ -258,6 +438,11 @@ function _previewBody(file: FileNode | null) {
         title={`PDF preview: ${file.name || 'document'}`}
       />
     );
+  }
+
+  if (kind === PreviewKind.Font) {
+    // Keyed on fullPath so switching files remounts the FontFace state machine.
+    return <FontPreview key={file.fullPath} file={file} />;
   }
 
   // Text path: skip the fetch entirely if the file is too big.

--- a/app/src/views/FilePreviewPane/FilePreviewPane.tsx
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.tsx
@@ -294,7 +294,7 @@ function fontRejectReason(buf: ArrayBuffer): string | null {
 
   const head = new TextDecoder().decode(new Uint8Array(buf, 0, Math.min(48, buf.byteLength)));
   if (head.startsWith('version https://git-lfs')) {
-    return 'This is a Git LFS pointer, not the font itself. Clone with Git LFS to preview it.';
+    return 'This font is stored in Git LFS and its content could not be fetched (the LFS object may be missing, private, or over its bandwidth quota).';
   }
   return 'This file is not a recognized font (ttf, otf, woff, or woff2).';
 }

--- a/app/tests/views/filePreviewPane.test.tsx
+++ b/app/tests/views/filePreviewPane.test.tsx
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render } from 'preact';
 import { act } from 'preact/test-utils';
 import { signal } from '@preact/signals';
-import { FilePreviewPane } from '@/views/FilePreviewPane/FilePreviewPane';
+import {
+  FilePreviewPane,
+  PreviewKind,
+  _previewKind,
+} from '@/views/FilePreviewPane/FilePreviewPane';
 import type { FilePreviewPaneState } from '@/views/FilePreviewPane/FilePreviewPane';
 import { NodeKind } from '@/types';
 import type { FileNode } from '@/types';
@@ -140,6 +144,95 @@ describe('FilePreviewPane', () => {
     expect(container.querySelector('.preview-shell')).toBeNull();
     expect(container.querySelector('.empty-state')).not.toBeNull();
     expect(container.querySelector('.text-card-title')!.textContent).toContain('too large');
+  });
+
+  describe('font specimen', () => {
+    const FONT_NODE: FileNode = {
+      ...FILE_NODE,
+      name: 'Inter.woff2',
+      path: 'fonts/Inter.woff2',
+      fullPath: '/tmp/project/fonts/Inter.woff2',
+      extension: '.woff2',
+      binary: true,
+    };
+
+    // A minimal valid TrueType signature (0x00010000) padded to a few bytes.
+    const TTF_BYTES = new Uint8Array([0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    const LFS_POINTER = new TextEncoder().encode(
+      'version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 4\n'
+    );
+
+    // jsdom ships no FontFace/document.fonts and the component now fetches the
+    // bytes itself, so stub a controllable FontFace plus a fetch that returns a
+    // chosen byte body. `loads` controls whether FontFace.load() resolves.
+    let origFontFace: unknown;
+    let origFonts: unknown;
+    let loadCalls = 0;
+    function installFont(bytes: Uint8Array, loads = true): void {
+      loadCalls = 0;
+      class FakeFontFace {
+        family: string;
+        constructor(family: string) {
+          this.family = family;
+        }
+        load(): Promise<FakeFontFace> {
+          loadCalls += 1;
+          return loads ? Promise.resolve(this) : Promise.reject(new Error('bad font table'));
+        }
+      }
+      origFontFace = (globalThis as Record<string, unknown>).FontFace;
+      origFonts = (document as unknown as Record<string, unknown>).fonts;
+      (globalThis as Record<string, unknown>).FontFace = FakeFontFace;
+      (document as unknown as Record<string, unknown>).fonts = { add() {}, delete() {} };
+      globalThis.fetch = (async () =>
+        new Response(bytes.buffer as ArrayBuffer, { status: 200 })) as unknown as typeof fetch;
+    }
+    afterEach(() => {
+      (globalThis as Record<string, unknown>).FontFace = origFontFace;
+      (document as unknown as Record<string, unknown>).fonts = origFonts;
+    });
+
+    it('_previewKind maps font extensions to Font', () => {
+      expect(_previewKind({ extension: '.woff2' })).toBe(PreviewKind.Font);
+      expect(_previewKind({ extension: '.WOFF' })).toBe(PreviewKind.Font);
+      expect(_previewKind({ extension: '.ttf' })).toBe(PreviewKind.Font);
+      expect(_previewKind({ extension: '.otf' })).toBe(PreviewKind.Font);
+      // Non-fonts still fall through to text.
+      expect(_previewKind({ extension: '.ts' })).toBe(PreviewKind.Text);
+    });
+
+    it('renders a specimen (alphabet + pangram + glyph grid) once the face loads', async () => {
+      installFont(TTF_BYTES);
+      mount();
+      await setFile(FONT_NODE);
+      const specimen = container.querySelector('.font-specimen') as HTMLElement;
+      expect(specimen).not.toBeNull();
+      expect(specimen.textContent).toContain('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+      expect(specimen.textContent).toContain('The quick brown fox jumps over the lazy dog');
+      // Repertoire grid renders a cell per glyph (well past the 26-letter alphabet).
+      expect(container.querySelectorAll('.font-specimen-glyph').length).toBeGreaterThan(26);
+    });
+
+    it('rejects a Git LFS pointer without attempting to decode it', async () => {
+      installFont(LFS_POINTER);
+      mount();
+      await setFile(FONT_NODE);
+      expect(container.querySelector('.font-specimen')).toBeNull();
+      expect(container.querySelector('.empty-state')).not.toBeNull();
+      expect(container.querySelector('.text-card-sub')!.textContent).toContain('Git LFS');
+      // The whole point: never hand non-font bytes to the browser's decoder.
+      expect(loadCalls).toBe(0);
+    });
+
+    it('falls back to a graceful notice when a real font fails to parse', async () => {
+      installFont(TTF_BYTES, false);
+      mount();
+      await setFile(FONT_NODE);
+      expect(container.querySelector('.font-specimen')).toBeNull();
+      expect(container.querySelector('.empty-state')).not.toBeNull();
+      expect(container.querySelector('.text-card-title')!.textContent).toContain('font');
+      expect(loadCalls).toBe(1);
+    });
   });
 
   it('renders the × close button only when onClose is provided', () => {


### PR DESCRIPTION
Closes #99

## What

Font files (`.woff2`/`.woff`/`.ttf`/`.otf`) previewed as garbage bytes. Now they render a live **specimen** in the face:

- **Preview** — a Google-Fonts-style waterfall: uppercase / lowercase / digits, then the pangram.
- **Repertoire** — a Font-Book-style grid of glyphs (printable ASCII + common Latin-1/extended + ligatures).

Preview-only: the manifest/wire model and `city/utils/mediaKind.ts` are untouched, per the issue's design lean.

## The two real bugs found while testing

Testing against real repos surfaced that *every* "font" on disk was a non-font, for two different reasons — both now handled:

1. **Non-font bytes spammed the console.** The old approach handed every file straight to `FontFace.load(url)`, so the browser fetched and tried to decode garbage, logging `Failed to decode` / `OTS parsing error` (which JS can't suppress). Now the preview **fetches the bytes and sniffs the signature** (and detects Git LFS pointers) before touching `FontFace` — non-fonts get a graceful notice with zero decode attempts. The face is built from the fetched buffer (no second request) and removed from `document.fonts` on unmount / file change.

2. **Git LFS files were never materialized.** Repos that store fonts/images/video in Git LFS (e.g. `islandoftex/arara`) checked out as tiny pointer stubs, since the clone was a plain `git clone --filter=blob:none` with no LFS step and the image had no git-lfs. This wasn't font-specific — image billboards were equally broken. Fixed by installing `git-lfs` in the runtime image and running `git lfs pull` after clone/update (guarded so non-LFS repos skip it; best-effort so an LFS outage leaves pointers in place and logs rather than failing the scan; cancels propagate; heartbeat tracks the LFS object store).

## Verification

- Frontend: 2512 tests pass; tsc / eslint / prettier clean. New tests cover `_previewKind` → Font, specimen render, LFS-pointer rejection (no decode attempt), and real-font parse failure.
- Backend: 275 tests pass, 90% coverage, ruff clean. New tests cover LFS detection, pull wiring on both clone paths, best-effort failure, and cancel propagation.
- End-to-end in a rebuilt container: `git lfs pull` turned arara's `firasans-bold.otf` from a 130-byte pointer into the real 521 KB OpenType font (`OTTO`), and the specimen renders.

## Follow-up

Coverage-accurate glyph repertoire (true Font Book parity via font-table parsing) is scoped separately in #100.