### PR TITLE
Project switcher backdrop: live-city showcase + landing swirl

### DIFF
--- a/app/src/city/render/cameraRig.ts
+++ b/app/src/city/render/cameraRig.ts
@@ -40,6 +40,11 @@ import {
   CAMERA_INITIAL_DISTANCE_MULT,
   CAMERA_BASE_DURATION_MS,
   CAMERA_EASING_POWER,
+  SHOWCASE_FILL_MULT,
+  SHOWCASE_ELEVATION_DEG,
+  SHOWCASE_AZIMUTH_DEG,
+  SHOWCASE_TARGET_Y_FRAC,
+  SHOWCASE_ROTATE_SPEED,
 } from '@/constants/camera';
 import { NodeKind, StreetAxis } from '@/types';
 import type { Building, PickTarget, Street } from '@/types';
@@ -51,6 +56,13 @@ import { CAMERA } from '@/state/stores/settings/camera';
  *  geometry (repoLabel/trees). World framing inputs (bbox, gem, root street,
  *  tallest building) come from cityState directly, not through here. createCity
  *  (city/index.ts) passes a small deps literal that satisfies this. */
+/** A snapshot of the user's camera, restored verbatim on switcher dismiss. */
+export interface CameraPose {
+  position: THREE.Vector3;
+  target: THREE.Vector3;
+  up: THREE.Vector3;
+}
+
 export interface CameraRigDeps {
   getRepoLabelBounds(): {
     centerX: number;
@@ -603,6 +615,77 @@ export function createCameraRig({
     else if (sel.kind === NodeKind.Commit) focusTree(sel.commit.sha);
   }
 
+  // ── Showcase mode ────────────────────────────────────────────────
+  // The project switcher drives the live city into a hero turntable behind its
+  // overlay. The user's pose isn't stored in any signal (it lives on
+  // camera/controls), so the caller snapshots getPose() before entering and
+  // hard-snaps back with applyPose() on dismiss. Both transitions snap (no
+  // tween): the entry animation read as jarring on top of the chrome-hide.
+
+  function getPose(): CameraPose {
+    return {
+      position: camera.position.clone(),
+      target: controls.target.clone(),
+      up: camera.up.clone(),
+    };
+  }
+
+  /** Hard-snap the camera to a pose, matching reset()'s damping-off snap so
+   *  residual inertia can't drift it off the restored pose. */
+  function _snapTo(target: THREE.Vector3, camPos: THREE.Vector3, up: THREE.Vector3): void {
+    camAnimToken++; // cancel any in-flight tween
+    const wasDamping = controls.enableDamping;
+    controls.enableDamping = false;
+    camera.up.copy(up);
+    camera.position.copy(camPos);
+    controls.target.copy(target);
+    camera.lookAt(target);
+    controls.update();
+    controls.enableDamping = wasDamping;
+    controls.saveState();
+  }
+
+  /** Restore a snapshot verbatim (the switcher's dismiss path). */
+  function applyPose(pose: CameraPose): void {
+    _snapTo(pose.target, pose.position, pose.up);
+  }
+
+  /** Snap to a tight, low, whole-city frame and (optionally) start spinning. */
+  function enterShowcase({ autoRotate }: { autoRotate: boolean }): void {
+    const a = captureAnchors();
+    if (a.center && a.cityRadius > 0) {
+      // Frame against the viewport the canvas is ABOUT to fill once the chrome
+      // is hidden, not its current sidebar-constrained aspect — otherwise the
+      // zoom distance depends on how much room the city had when the switcher
+      // opened (e.g. whether the right sidebar was showing).
+      const aspect = window.innerWidth / Math.max(1, window.innerHeight);
+      const halfV = (camera.fov * Math.PI) / 180 / 2;
+      const halfH = Math.atan(Math.tan(halfV) * aspect);
+      const halfFov = Math.min(halfV, halfH);
+      const dist = Math.max(
+        (a.cityRadius / Math.sin(halfFov)) * SHOWCASE_FILL_MULT,
+        controls.minDistance
+      );
+      const target = new THREE.Vector3(
+        a.center.x,
+        a.tallestHeight * SHOWCASE_TARGET_Y_FRAC,
+        a.center.z
+      );
+      const dir = computeFramingDir(
+        SHOWCASE_ELEVATION_DEG,
+        SHOWCASE_AZIMUTH_DEG,
+        cityState.rootStreet.value?.orientation ?? null
+      );
+      _snapTo(target, target.clone().addScaledVector(dir, dist), new THREE.Vector3(0, 1, 0));
+    }
+    controls.autoRotate = autoRotate;
+    controls.autoRotateSpeed = SHOWCASE_ROTATE_SPEED;
+  }
+
+  function exitShowcase(): void {
+    controls.autoRotate = false;
+  }
+
   function dispose() {
     _disposeReframeEffect();
     _disposeCameraAngleEffect();
@@ -623,6 +706,10 @@ export function createCameraRig({
     captureAnchors,
     treeAnchor,
     streetAnchor,
+    getPose,
+    applyPose,
+    enterShowcase,
+    exitShowcase,
     dispose,
   };
 }

--- a/app/src/components/LandingBackdrop/LandingBackdrop.css
+++ b/app/src/components/LandingBackdrop/LandingBackdrop.css
@@ -1,0 +1,13 @@
+/* Full-screen WebGL "dark swirl" backdrop for the cold-boot landing. Fixed +
+   behind the content (z:-1 sits above .landing's opaque base fill, below the
+   in-flow content). Non-interactive. No CSS fallback needed: if WebGL is
+   unavailable the city can't render at all, so the canvas just stays transparent
+   and .landing's flat surface shows through. */
+.landing-backdrop {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  pointer-events: none;
+}

--- a/app/src/components/LandingBackdrop/LandingBackdrop.tsx
+++ b/app/src/components/LandingBackdrop/LandingBackdrop.tsx
@@ -1,0 +1,204 @@
+// components/LandingBackdrop — the cold-boot landing's "dark swirl" backdrop.
+// A full-screen WebGL layer that renders a domain-warped gem-palette gradient:
+// a color ramp pushed around by smooth fbm noise, which is what gives these
+// gradients their organic curved-ribbon flow (flat CSS radial gradients can't —
+// they're concentric circles). Theme-aware (reads the --cc-gem-* tokens),
+// honors prefers-reduced-motion (renders one static frame), non-interactive.
+// If WebGL is unavailable it renders nothing and the CSS fallback wash shows.
+
+import './LandingBackdrop.css';
+import { useEffect, useRef } from 'preact/hooks';
+
+const VERT = `#version 300 es
+in vec2 aPos;
+void main() { gl_Position = vec4(aPos, 0.0, 1.0); }
+`;
+
+const FRAG = `#version 300 es
+precision highp float;
+out vec4 fragColor;
+uniform vec2 uResolution;
+uniform float uTime;
+uniform vec3 uBg;
+uniform vec3 uCol[4];
+
+// Lower = larger, calmer forms; higher = smaller, busier.
+const float SCALE = 0.3;
+
+float hash(vec2 p) {
+  p = fract(p * vec2(123.34, 456.21));
+  p += dot(p, p + 45.32);
+  return fract(p.x * p.y);
+}
+float noise(vec2 p) {
+  vec2 i = floor(p), f = fract(p);
+  float a = hash(i), b = hash(i + vec2(1.0, 0.0));
+  float c = hash(i + vec2(0.0, 1.0)), d = hash(i + vec2(1.0, 1.0));
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+float fbm(vec2 p) {
+  float v = 0.0, a = 0.5;
+  for (int i = 0; i < 5; i++) { v += a * noise(p); p = p * 2.0 + 11.3; a *= 0.5; }
+  return v;
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uResolution.xy;
+  // Aspect-correct, centered coords so the flow isn't stretched.
+  vec2 p = (gl_FragCoord.xy - 0.5 * uResolution.xy) / uResolution.y;
+  float t = uTime * 0.008;
+
+  // Domain warp (Inigo Quilez): warp the sample point twice, so the color ramp
+  // bends into curved organic ribbons instead of concentric bands.
+  vec2 q = vec2(fbm(p * SCALE + vec2(0.0, 0.3 * t)), fbm(p * SCALE + vec2(5.2, 1.3) + vec2(0.0, 0.2 * t)));
+  vec2 r = vec2(
+    fbm(p * SCALE + 2.5 * q + vec2(1.7, 9.2) + 0.15 * t),
+    fbm(p * SCALE + 2.5 * q + vec2(8.3, 2.8) - 0.15 * t)
+  );
+  float f = fbm(p * SCALE + 2.5 * r);
+
+  // Hue ramp through all four gems. A positional sweep (uv) spreads the colors
+  // across the frame so all four are visible at once; the warp (r/q) bends that
+  // sweep into organic bands instead of a straight rainbow. Even thirds keep any
+  // one gem from dominating (it read purple-heavy before). cyan->purple->magenta->lime.
+  float h = clamp(
+    0.5 + 0.6 * (uv.x - 0.5) + 0.35 * (uv.y - 0.5) + 1.0 * (r.x - 0.5) + 0.7 * (q.y - 0.5),
+    0.0,
+    1.0
+  );
+  vec3 col = uCol[0];
+  col = mix(col, uCol[1], smoothstep(0.12, 0.38, h));
+  col = mix(col, uCol[2], smoothstep(0.38, 0.62, h));
+  col = mix(col, uCol[3], smoothstep(0.62, 0.88, h));
+
+  // Energy mask: vivid along the ridges, pure background elsewhere — the
+  // "mostly black + one bright swirl" contrast the flat washes were missing.
+  float energy = smoothstep(0.35, 0.95, f + 0.55 * length(q) - 0.15);
+  // Keep the central band (where the hero + cards sit) calmer for readability.
+  float band = smoothstep(0.06, 0.40, abs(uv.y - 0.5));
+  energy *= mix(0.4, 1.0, band);
+
+  col = mix(uBg, col, clamp(energy, 0.0, 1.0));
+  fragColor = vec4(col, 1.0);
+}
+`;
+
+/** Resolve a CSS custom property to a linear [r,g,b] in 0..1. Goes through a
+ *  probe element (so var() + any color space resolve) then a 1x1 2D canvas
+ *  (which normalizes oklch/color() serialization to plain sRGB bytes). */
+function resolveVarToRgb(varName: string): [number, number, number] {
+  const probe = document.createElement('span');
+  probe.style.color = `var(${varName})`;
+  document.body.appendChild(probe);
+  const resolved = getComputedStyle(probe).color;
+  probe.remove();
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = 1;
+  const ctx = cv.getContext('2d');
+  if (!ctx) return [1, 1, 1];
+  ctx.fillStyle = resolved || '#fff';
+  ctx.fillRect(0, 0, 1, 1);
+  const d = ctx.getImageData(0, 0, 1, 1).data;
+  return [d[0] / 255, d[1] / 255, d[2] / 255];
+}
+
+function compile(gl: WebGL2RenderingContext, type: number, src: string): WebGLShader | null {
+  const sh = gl.createShader(type);
+  if (!sh) return null;
+  gl.shaderSource(sh, src);
+  gl.compileShader(sh);
+  if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+    console.warn('[codecity] landing backdrop shader failed', gl.getShaderInfoLog(sh));
+    gl.deleteShader(sh);
+    return null;
+  }
+  return sh;
+}
+
+// Backdrop renders at a fraction of viewport pixels — it's a soft gradient, so
+// upscaling is invisible and the fbm stays cheap.
+const RENDER_SCALE = 0.65;
+
+export function LandingBackdrop() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const gl = canvas.getContext('webgl2', { alpha: true, antialias: false, depth: false });
+    if (!gl) return; // no WebGL (or jsdom) → CSS fallback wash shows through
+
+    const vs = compile(gl, gl.VERTEX_SHADER, VERT);
+    const fs = compile(gl, gl.FRAGMENT_SHADER, FRAG);
+    const prog = gl.createProgram();
+    if (!vs || !fs || !prog) return;
+    gl.attachShader(prog, vs);
+    gl.attachShader(prog, fs);
+    gl.linkProgram(prog);
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+      console.warn('[codecity] landing backdrop link failed', gl.getProgramInfoLog(prog));
+      return;
+    }
+    gl.useProgram(prog);
+
+    const buf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+    const aPos = gl.getAttribLocation(prog, 'aPos');
+    gl.enableVertexAttribArray(aPos);
+    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+    const uResolution = gl.getUniformLocation(prog, 'uResolution');
+    const uTime = gl.getUniformLocation(prog, 'uTime');
+    const uBg = gl.getUniformLocation(prog, 'uBg');
+    const uCol = gl.getUniformLocation(prog, 'uCol');
+
+    const bg = resolveVarToRgb('--cc-bg-app');
+    const cols = ['--cc-gem-cyan', '--cc-gem-purple', '--cc-gem-magenta', '--cc-gem-lime'].map(
+      resolveVarToRgb
+    );
+    gl.uniform3f(uBg, bg[0], bg[1], bg[2]);
+    gl.uniform3fv(uCol, new Float32Array(cols.flat()));
+
+    const resize = () => {
+      const w = Math.max(1, Math.round(canvas.clientWidth * RENDER_SCALE));
+      const h = Math.max(1, Math.round(canvas.clientHeight * RENDER_SCALE));
+      if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w;
+        canvas.height = h;
+      }
+      gl.viewport(0, 0, canvas.width, canvas.height);
+      gl.uniform2f(uResolution, canvas.width, canvas.height);
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+
+    const render = (seconds: number) => {
+      gl.uniform1f(uTime, seconds);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    };
+
+    const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    let raf = 0;
+    if (reduce) {
+      render(0);
+    } else {
+      const t0 = performance.now();
+      const frame = (now: number) => {
+        render((now - t0) / 1000);
+        raf = requestAnimationFrame(frame);
+      };
+      raf = requestAnimationFrame(frame);
+    }
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} class="landing-backdrop" aria-hidden="true" />;
+}

--- a/app/src/constants/camera.ts
+++ b/app/src/constants/camera.ts
@@ -28,4 +28,4 @@ export const SHOWCASE_FILL_MULT = 0.62; // < INITIAL_DISTANCE_MULT: tighter, "fi
 export const SHOWCASE_ELEVATION_DEG = 20; // low, cinematic angle above the horizon
 export const SHOWCASE_AZIMUTH_DEG = 35; // 3/4 starting swing; auto-rotate carries it on
 export const SHOWCASE_TARGET_Y_FRAC = 0.32; // aim a third up the skyline, not the ground
-export const SHOWCASE_ROTATE_SPEED = 0.6; // OrbitControls autoRotateSpeed
+export const SHOWCASE_ROTATE_SPEED = 0.3; // OrbitControls autoRotateSpeed

--- a/app/src/constants/camera.ts
+++ b/app/src/constants/camera.ts
@@ -20,3 +20,12 @@ export const CAMERA_INITIAL_DISTANCE_MULT = 0.75; // boot framing tightness (1.0
 // all camera tweens (1 = linear, 3 = ease-out cubic, higher = snappier).
 export const CAMERA_BASE_DURATION_MS = 500;
 export const CAMERA_EASING_POWER = 3;
+
+// Showcase framing — the "hero turntable" the project switcher drives the live
+// city into while its overlay is up (see hooks/useSwitcherShowcase). A tight,
+// low, slowly-rotating whole-city shot that reads as a backdrop.
+export const SHOWCASE_FILL_MULT = 0.62; // < INITIAL_DISTANCE_MULT: tighter, "fills the view"
+export const SHOWCASE_ELEVATION_DEG = 20; // low, cinematic angle above the horizon
+export const SHOWCASE_AZIMUTH_DEG = 35; // 3/4 starting swing; auto-rotate carries it on
+export const SHOWCASE_TARGET_Y_FRAC = 0.32; // aim a third up the skyline, not the ground
+export const SHOWCASE_ROTATE_SPEED = 0.6; // OrbitControls autoRotateSpeed

--- a/app/src/hooks/useSwitcherShowcase.ts
+++ b/app/src/hooks/useSwitcherShowcase.ts
@@ -1,0 +1,81 @@
+// hooks/useSwitcherShowcase.ts — turns the live city into a backdrop while the
+// project switcher is open over it. On open: snapshot the user's camera pose +
+// selection, clear the selection, hide the chrome, and drive the camera into a
+// slow auto-rotating hero shot. On dismiss: restore all of it verbatim.
+//
+// The restore is gated on the source key: if the user actually SWITCHED
+// projects (a new city committed), the old pose + selection belong to the gone
+// city, so we bow out and let the new city's own framing stand.
+
+import { useEffect } from 'preact/hooks';
+import { effect } from '@preact/signals';
+import { SWITCHER_SHOWCASE } from '@/state/stores/ui';
+import { SCENE_HANDLE, type SceneHandle } from '@/state/stores/scene';
+import { CURRENT_SOURCE_KEY } from '@/state/stores/source';
+import { NodeKind, type PickerSelectionKey } from '@/types';
+import type { CameraPose } from '@/city/render/cameraRig';
+
+const SHOWCASE_CLASS = 'cc-showcase';
+
+function setChromeHidden(hidden: boolean): void {
+  document.getElementById('app')?.classList.toggle(SHOWCASE_CLASS, hidden);
+}
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function restoreSelection(handle: SceneHandle, key: PickerSelectionKey | null): void {
+  if (!key) return;
+  if (key.kind === NodeKind.Commit) handle.picker.selectByCommit(key.sha);
+  else handle.picker.selectByPath(key.path);
+}
+
+export function useSwitcherShowcase(): void {
+  useEffect(() => {
+    let active = false;
+    let savedPose: CameraPose | null = null;
+    let savedSelKey: PickerSelectionKey | null = null;
+    let savedSourceKey: string | null = null;
+
+    // peek the handle (untracked): showcase only turns true over a loaded city,
+    // so the handle is present — no need to re-run when it changes.
+    const stop = effect(() => {
+      const showcase = SWITCHER_SHOWCASE.value;
+      const handle = SCENE_HANDLE.peek();
+
+      if (showcase && !active) {
+        if (!handle) return; // no scene to drive (shouldn't happen over a city)
+        active = true;
+        savedSourceKey = CURRENT_SOURCE_KEY.peek();
+        savedPose = handle.rig.getPose();
+        savedSelKey = handle.picker.selectionKey.peek();
+        handle.picker.clearSelection();
+        setChromeHidden(true);
+        handle.rig.enterShowcase({ autoRotate: !prefersReducedMotion() });
+      } else if (!showcase && active) {
+        active = false;
+        setChromeHidden(false);
+        if (handle) {
+          handle.rig.exitShowcase();
+          // Same city → restore verbatim. Switched → the new city owns its
+          // framing (and App already cleared the selection on commit).
+          if (CURRENT_SOURCE_KEY.peek() === savedSourceKey) {
+            if (savedPose) handle.rig.applyPose(savedPose);
+            restoreSelection(handle, savedSelKey);
+          }
+        }
+        savedPose = null;
+        savedSelKey = null;
+        savedSourceKey = null;
+      }
+    });
+
+    return () => {
+      stop();
+      // Safety net if App unmounts mid-showcase (HMR / teardown).
+      setChromeHidden(false);
+      SCENE_HANDLE.peek()?.rig.exitShowcase();
+    };
+  }, []);
+}

--- a/app/src/layout/App/App.css
+++ b/app/src/layout/App/App.css
@@ -32,3 +32,14 @@ body {
   flex-direction: row;
   align-items: stretch;
 }
+
+/* Switcher showcase: with the switcher open over a loaded city, hide the chrome
+   so the canvas fills the viewport as a backdrop. #app-body then grows to the
+   full column and the canvas auto-fits (ResizeObserver + per-frame size guard).
+   Toggled by useSwitcherShowcase. */
+#app.cc-showcase #app-header,
+#app.cc-showcase #left-sidebar,
+#app.cc-showcase #right-sidebar,
+#app.cc-showcase #app-footer {
+  display: none;
+}

--- a/app/src/layout/App/App.tsx
+++ b/app/src/layout/App/App.tsx
@@ -43,14 +43,14 @@ import { openProjectsView, closeProjectsView } from '@/state/stores/ui';
 import { SOURCE_ERROR, CURRENT_SOURCE } from '@/state/stores/source';
 import { MANIFEST } from '@/state/stores/manifest';
 import { isEmptyManifest } from '@/utils/manifest';
-import { URL_PARAMS } from '@/constants/urlParams';
-import { srcNeedsBranch } from '@/utils/sources';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useManifestSource } from '@/hooks/useManifestSource';
+import { useSwitcherShowcase } from '@/hooks/useSwitcherShowcase';
 import { attachLoadingReactions } from '@/state/loadingReactions';
 
 export function App() {
   useDocumentTitle();
+  useSwitcherShowcase();
   const { submitSource, cancelLoad } = useManifestSource();
 
   useEffect(() => attachLoadingReactions(), []);
@@ -74,20 +74,8 @@ export function App() {
     SOURCE_ERROR.value = null;
   };
 
-  // Cold boot needs a source pick when there's no ?src, OR when ?src is a remote
-  // URL with no ?branch (branch choice is explicit — the hook won't auto-load
-  // it). Prefill the URL so the picker resolves its branches and preselects the
-  // default. Non-dismissible either way: nothing is loaded to fall back to.
-  useEffect(() => {
-    const qp = new URLSearchParams(window.location.search);
-    const src = qp.get(URL_PARAMS.SRC);
-    const branch = qp.get(URL_PARAMS.BRANCH) ?? undefined;
-    if (!src) {
-      openProjectsView({ dismissible: false });
-    } else if (srcNeedsBranch(src, branch)) {
-      openProjectsView({ dismissible: false, prefill: { src } });
-    }
-  }, []);
+  // The cold-boot picker decision runs pre-paint in main.tsx (openBootPickerIfNeeded)
+  // so the landing covers the chrome from frame one; App only handles reopens below.
 
   // A source-load failure (boot or submit) reopens the view. Dismissible only
   // when a city is already loaded to fall back to (a failed FIRST pick stays

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -8,7 +8,12 @@ import './styles/index.css';
 // render (no flash). persistedSignal hydrates synchronously, so the module's
 // effect sets data-cc-* before Preact mounts.
 import '@/state/stores/settings/theme';
+import { openBootPickerIfNeeded } from '@/state/bootView';
 import { App } from '@/layout/App/App';
+
+// Decide the cold-boot picker BEFORE the first render so the full-page landing
+// covers the chrome from frame one (no chrome flash).
+openBootPickerIfNeeded();
 
 const mount = document.getElementById('app');
 if (mount) {

--- a/app/src/state/bootView.ts
+++ b/app/src/state/bootView.ts
@@ -1,0 +1,23 @@
+// state/bootView.ts — the cold-boot picker decision, run synchronously before
+// the first paint (see main.tsx). Deciding it here rather than in an App effect
+// means the opaque full-page landing is present on frame one and covers the
+// chrome, instead of the chrome flashing for a frame before the effect opens it.
+//
+// No ?src → open the picker. A remote ?src with no ?branch → open it prefilled
+// (the branch choice is explicit; the manifest hook won't auto-load it). A ?src
+// that can auto-load opens nothing here (the loading overlay owns that path).
+
+import { openProjectsView } from '@/state/stores/ui';
+import { URL_PARAMS } from '@/constants/urlParams';
+import { srcNeedsBranch } from '@/utils/sources';
+
+export function openBootPickerIfNeeded(): void {
+  const qp = new URLSearchParams(window.location.search);
+  const src = qp.get(URL_PARAMS.SRC);
+  const branch = qp.get(URL_PARAMS.BRANCH) ?? undefined;
+  if (!src) {
+    openProjectsView({ dismissible: false });
+  } else if (srcNeedsBranch(src, branch)) {
+    openProjectsView({ dismissible: false, prefill: { src } });
+  }
+}

--- a/app/src/state/stores/ui.ts
+++ b/app/src/state/stores/ui.ts
@@ -59,6 +59,14 @@ export function closeProjectsView(): void {
   PROJECTS_VIEW.value = { ...PROJECTS_VIEW.peek(), visible: false };
 }
 
+/** True while the switcher is open OVER a loaded city (the dismissible / modal
+ *  case) — the only case with a city behind it to turn into a backdrop. Drives
+ *  the showcase: chrome hidden, camera into a hero turntable (useSwitcherShowcase).
+ *  The non-dismissible full-page boot has no city behind, so it stays false. */
+export const SWITCHER_SHOWCASE = computed(
+  () => PROJECTS_VIEW.value.visible && PROJECTS_VIEW.value.opts.dismissible === true
+);
+
 /** Drop a stale open-error banner (e.g. once the user edits the source), leaving
  *  the view open and its prefill intact. No-ops when there's no error so it's
  *  cheap to call on every keystroke. peek() to avoid subscribing callers. */

--- a/app/src/views/ProjectsView/ProjectsView.css
+++ b/app/src/views/ProjectsView/ProjectsView.css
@@ -13,8 +13,7 @@
 }
 
 /* Modal mode (dismissible, over a loaded city): the live city is driven into an
-   auto-rotating backdrop (useSwitcherShowcase). Reveal it rather than blur it
-   away, softened by just a touch of blur for depth + readability. Scrim only the
+   auto-rotating backdrop (useSwitcherShowcase), revealed crisp. Scrim only the
    hero side, letting its text keep AA contrast over the city; the action cards
    carry their own opaque surface and the center/right stays clear. */
 .landing--modal {
@@ -25,8 +24,6 @@
     color-mix(in oklch, var(--cc-bg-app) 24%, transparent) 46%,
     transparent 64%
   );
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
 }
 
 /* Stacked layout: the hero is full-width at the top with no card column beside
@@ -36,6 +33,10 @@
     background: color-mix(in oklch, var(--cc-bg-app) 70%, transparent);
   }
 }
+
+/* The cold-boot backdrop is a WebGL domain-warped gradient — see the
+   <LandingBackdrop> component (ProjectsView renders it on the full-page landing
+   only; the modal shows the live city). */
 
 .landing-close {
   position: absolute;

--- a/app/src/views/ProjectsView/ProjectsView.css
+++ b/app/src/views/ProjectsView/ProjectsView.css
@@ -1,7 +1,6 @@
 /* ── codecity landing / project switcher ────────────────────────────────────
    Full-bleed page (not a modal): a brand hero beside an action panel. The gem
-   palette (lime/cyan/purple/magenta) doubles as a soft holographic backdrop and
-   colors the three "what it does" cues. */
+   palette (lime/cyan/purple/magenta) colors the three "what it does" cues. */
 
 .landing {
   position: fixed;
@@ -9,40 +8,33 @@
   z-index: 1000;
   overflow-y: auto;
   /* Full-page mode (non-dismissible: cold boot / nothing loaded to fall back to).
-     A solid surface with the gem wash (::before) — nothing meaningful is behind
-     to reveal, so no blur. */
+     A solid surface — nothing meaningful is behind to reveal, so no blur. */
   background: var(--cc-bg-app);
 }
 
-/* Modal mode (dismissible, over a loaded city): translucent + blurred so the
-   city shows through as soft hints behind the overlay. Tint stays dark enough to
-   keep the hero text and cards readable over any city. */
+/* Modal mode (dismissible, over a loaded city): the live city is driven into an
+   auto-rotating backdrop (useSwitcherShowcase). Reveal it rather than blur it
+   away, softened by just a touch of blur for depth + readability. Scrim only the
+   hero side, letting its text keep AA contrast over the city; the action cards
+   carry their own opaque surface and the center/right stays clear. */
 .landing--modal {
-  background: color-mix(in oklch, var(--cc-bg-app) 82%, transparent);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
+  background: linear-gradient(
+    100deg,
+    color-mix(in oklch, var(--cc-bg-app) 82%, transparent) 0%,
+    color-mix(in oklch, var(--cc-bg-app) 62%, transparent) 24%,
+    color-mix(in oklch, var(--cc-bg-app) 24%, transparent) 46%,
+    transparent 64%
+  );
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
-/* Subtle holographic wash — two low-opacity gem-tinted glows, non-interactive,
-   behind the content. */
-.landing::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    radial-gradient(
-      75% 65% at 18% 12%,
-      color-mix(in oklch, var(--cc-gem-cyan) 10%, transparent),
-      color-mix(in oklch, var(--cc-gem-cyan) 3%, transparent) 45%,
-      transparent 100%
-    ),
-    radial-gradient(
-      70% 65% at 88% 85%,
-      color-mix(in oklch, var(--cc-gem-purple) 10%, transparent),
-      color-mix(in oklch, var(--cc-gem-purple) 3%, transparent) 45%,
-      transparent 100%
-    );
+/* Stacked layout: the hero is full-width at the top with no card column beside
+   it, so a directional scrim can't cover it, fall back to an even veil. */
+@media (max-width: 900px) {
+  .landing--modal {
+    background: color-mix(in oklch, var(--cc-bg-app) 70%, transparent);
+  }
 }
 
 .landing-close {

--- a/app/src/views/ProjectsView/ProjectsView.tsx
+++ b/app/src/views/ProjectsView/ProjectsView.tsx
@@ -15,6 +15,7 @@ import { useEffect, useRef } from 'preact/hooks';
 import { X, Waypoints, Building2, TreePine, Sparkles } from 'lucide-preact';
 import { useDialogFocus } from '@/hooks/useDialogFocus';
 import { GemIcon } from '@/components/GemIcon/GemIcon';
+import { LandingBackdrop } from '@/components/LandingBackdrop/LandingBackdrop';
 import { PROJECTS_VIEW, clearProjectsViewError, type SourcePayload } from '@/state/stores/ui';
 import { SERVER_CONFIG } from '@/state/stores/serverConfig';
 import { SCAN_PROGRESS } from '@/state/stores/scanProgress';
@@ -63,6 +64,10 @@ export function ProjectsView({ onSubmit, onCancel, onClose }: ProjectsViewProps)
       aria-modal={isModal ? 'true' : undefined}
       aria-label="codecity: open a project"
     >
+      {/* Cold-boot only: the swirl backdrop. The dismissible modal shows the
+          live city behind it instead (useSwitcherShowcase). */}
+      {!pv.opts.dismissible && <LandingBackdrop />}
+
       {pv.opts.dismissible && !loading && (
         <button class="landing-close btn-icon btn-icon--lg" aria-label="Close" onClick={onClose}>
           <X class="lucide-icon" />


### PR DESCRIPTION
Reworks the project switcher's backdrop in both of its modes.

## Switcher over a loaded city (modal)
Opening the switcher over a loaded city now turns the live city into the backdrop:

- Hides the chrome (header / sidebars / footer) so the canvas fills the viewport.
- Snaps the camera into a tight, low, slowly auto-rotating hero shot of the whole city.
- Reveals the city crisp behind the overlay, with a hero-side scrim so the text keeps AA contrast.
- **Dismissing** snaps back to the exact prior camera pose, selection, and open panels. **Switching projects** lets the new city own its framing instead (guarded on the source key).
- Framing is computed against the viewport the canvas is about to fill, so the zoom is identical every time regardless of what was open. Honors `prefers-reduced-motion` (no spin).

Driven by a small view-layer controller (`useSwitcherShowcase` / `SWITCHER_SHOWCASE`) plus a showcase API on the camera rig; the city instance and all UI state stay mounted, so restore is a snapshot/replay, not a rebuild.

## Cold-boot landing
The full-page landing gets a new backdrop: a WebGL **domain-warped gradient** (`LandingBackdrop`) — fbm noise warps a gem-palette color ramp into flowing organic bands (the "dark swirl" look flat CSS radial gradients can't do). Theme-aware (reads the `--cc-gem-*` tokens), `prefers-reduced-motion` aware (static frame), cold-boot only.

## Also
- Fixes a cold-boot chrome flash: the picker decision now runs pre-paint in `main.tsx` so the full-page landing covers the chrome from frame one.

## Follow-up
- #102 — extending the same domain-warp into the live city sky as a subtle aurora.

## Verification
`just lint` + `just test` green (2512 app tests, incl. the ProjectsView a11y audit). Visual pass by the author across cold-boot, the modal-over-city showcase, dismiss/restore, a real project switch, and reduced-motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
