### PR TITLE
Exclude files and directories from the city via the UI

### DIFF
--- a/api/routers/manifest.py
+++ b/api/routers/manifest.py
@@ -59,18 +59,29 @@ router = APIRouter(prefix="/api", tags=["manifest"])
 logger = logging.getLogger("codecity.manifest")
 
 
+def _norm_excludes(exclude: list[str]) -> frozenset[str]:
+    """Normalize repeated ?exclude= params to root-anchored rel-paths:
+    trim whitespace, drop empties, strip a single leading '/'."""
+    return frozenset(e.strip().lstrip("/") for e in exclude if e.strip())
+
+
 @router.get("/manifest/signature", response_model=SignatureResponse)
 def signature(
     src: str = Query(...),
     branch: str | None = Query(None),
     no_cache: bool = Query(False),
+    exclude: list[str] = Query(default_factory=list),
 ) -> SignatureResponse:
     try:
         target = resolve_source(src, branch)
     except ResolveError as e:
         raise HTTPException(e.status, e.message)
     try:
-        sig = signature_tree(str(target), use_cache=not no_cache)
+        sig = signature_tree(
+            str(target),
+            use_cache=not no_cache,
+            extra_exclude_paths=_norm_excludes(exclude),
+        )
     except Exception as e:  # noqa: BLE001
         raise HTTPException(500, f"signature failed: {e}")
     return SignatureResponse.model_validate(dict(sig))
@@ -148,8 +159,10 @@ async def manifest(
     src: str = Query(""),
     branch: str | None = Query(None),
     no_cache: bool = Query(False),
+    exclude: list[str] = Query(default_factory=list),
 ) -> EventSourceResponse:
     use_cache = not no_cache
+    excludes = _norm_excludes(exclude)
 
     async def gen() -> AsyncIterator[dict[str, Any]]:
         # Classify + (for local) validate WITHOUT cloning. The git clone runs
@@ -249,7 +262,9 @@ async def manifest(
                 _put(_sse(ScanEvent.SCAN_PROGRESS, {"label": pending_label}))
 
                 # Signature (cache key) + warm-cache short-circuit.
-                sig = signature_tree(str(path), use_cache=use_cache)["signature"]
+                sig = signature_tree(
+                    str(path), use_cache=use_cache, extra_exclude_paths=excludes
+                )["signature"]
                 holder["sig"] = sig
                 if use_cache:
                     cached = cache_load_manifest(path.resolve(), sig)
@@ -263,6 +278,7 @@ async def manifest(
                     use_cache=use_cache,
                     cancel_event=cancel,
                     on_scan_progress=_on_scan,
+                    extra_exclude_paths=excludes,
                 ):
                     phase = ev["phase"]  # ScanEvent.MANIFEST_PARTIAL | _COMPLETE
                     m = ev["manifest"]

--- a/api/services/scan.py
+++ b/api/services/scan.py
@@ -1288,6 +1288,7 @@ def scan_tree(
     use_cache: bool = True,
     cancel_event: "threading.Event | None" = None,
     on_scan_progress: Callable[[int], None] | None = None,
+    extra_exclude_paths: frozenset[str] = frozenset(),
 ) -> Iterator["ScanStreamEvent"]:
     """Scan a git working tree and yield manifest events.
 
@@ -1304,7 +1305,10 @@ def scan_tree(
     is always applied on top of the tracked-files filter — handy for
     hiding committed noise like ``node_modules/`` or vendor bundles.
     Per-project additions go in ``<root>/.codecityignore`` (one literal
-    name per line, or relative paths containing ``/``)."""
+    name per line, or relative paths containing ``/``).
+
+    ``extra_exclude_paths`` — extra rel-paths skipped in addition to
+    ``.codecityignore``, supplied by the UI."""
     root_abs = str(Path(root).resolve())
     _log(f"resolving {root_abs}")
 
@@ -1325,6 +1329,11 @@ def scan_tree(
     ignore_names, ignore_paths, unignore_names, unignore_paths = _load_codecityignore(
         Path(root_abs)
     )
+    # UI excludes are additive rel-path skips on top of .codecityignore. They
+    # feed ignore_paths so _should_skip's existing precedence (negation,
+    # ALWAYS_SKIP, then ignores) holds — a UI exclude can't resurrect a default.
+    if extra_exclude_paths:
+        ignore_paths = ignore_paths | extra_exclude_paths
 
     heartbeat = _Heartbeat(on_progress=on_scan_progress)
     _log("walking tree…")
@@ -1472,6 +1481,7 @@ def signature_tree(
     root: str,
     *,
     use_cache: bool = True,
+    extra_exclude_paths: frozenset[str] = frozenset(),
 ) -> SignatureResponse:
     """Cheap fingerprint of the tree — equivalent to scan_tree(root)['signature']
     but without building the full manifest.
@@ -1490,6 +1500,9 @@ def signature_tree(
     params) but is a no-op here — signature_tree doesn't compute
     per-file lines/binary or per-file git history, so there's nothing
     to cache.
+
+    ``extra_exclude_paths`` — extra rel-paths skipped in addition to
+    ``.codecityignore``, supplied by the UI.
     """
     root_abs = str(Path(root).resolve())
     root_path = Path(root_abs)
@@ -1502,6 +1515,8 @@ def signature_tree(
     ignore_names, ignore_paths, unignore_names, unignore_paths = _load_codecityignore(
         root_path
     )
+    if extra_exclude_paths:
+        ignore_paths = ignore_paths | extra_exclude_paths
 
     sig = hashlib.blake2b(digest_size=16)
     _walk_for_signature(

--- a/api/tests/test_scan.py
+++ b/api/tests/test_scan.py
@@ -924,6 +924,84 @@ def _walk_dirs(node):
         yield from _walk_dirs(c)
 
 
+class ExtraExcludePathsTests(_CacheRedirectMixin, unittest.TestCase):
+    def test_excludes_directory_and_subtree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            (root / "keep.txt").write_text("k")
+            vendored = root / "vendor" / "big"
+            vendored.mkdir(parents=True)
+            (vendored / "lib.js").write_text("x\n" * 100)
+            _commit_all(root)
+            m = _final_manifest(str(root), extra_exclude_paths=frozenset({"vendor"}))
+            paths = [n["path"] for n in _walk_dirs(m["tree"])]
+            self.assertNotIn("vendor", paths)
+            self.assertNotIn("vendor/big", paths)
+
+    def test_excludes_root_level_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            (root / "keep.txt").write_text("k")
+            (root / "drop.md").write_text("d")
+            _commit_all(root)
+            m = _final_manifest(str(root), extra_exclude_paths=frozenset({"drop.md"}))
+            names = [c["name"] for c in m["tree"]["children"]]
+            self.assertIn("keep.txt", names)
+            self.assertNotIn("drop.md", names)
+
+    def test_rollups_reflect_smaller_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            (root / "a.txt").write_text("a")
+            sub = root / "sub"
+            sub.mkdir()
+            (sub / "b.txt").write_text("b")
+            _commit_all(root)
+            full = _final_manifest(str(root))
+            filtered = _final_manifest(
+                str(root), extra_exclude_paths=frozenset({"sub"})
+            )
+            self.assertLess(
+                filtered["tree"]["descendants_file_count"],
+                full["tree"]["descendants_file_count"],
+            )
+
+    def test_signature_differs_and_is_stable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            (root / "a.txt").write_text("a")
+            sub = root / "sub"
+            sub.mkdir()
+            (sub / "b.txt").write_text("b")
+            _commit_all(root)
+            base = signature_tree(str(root))["signature"]
+            ex1 = signature_tree(str(root), extra_exclude_paths=frozenset({"sub"}))[
+                "signature"
+            ]
+            ex2 = signature_tree(str(root), extra_exclude_paths=frozenset({"sub"}))[
+                "signature"
+            ]
+            self.assertNotEqual(base, ex1)
+            self.assertEqual(ex1, ex2)
+
+    def test_cannot_override_always_skip(self):
+        # An extra-exclude is additive: it can't un-hide .git or a lockfile.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            (root / "a.txt").write_text("a")
+            _commit_all(root)
+            # Excluding a normal file still works; .git stays gone regardless.
+            m = _final_manifest(str(root), extra_exclude_paths=frozenset({"a.txt"}))
+            names = [c["name"] for c in m["tree"]["children"]]
+            self.assertNotIn(".git", names)
+            self.assertNotIn("a.txt", names)
+
+
 class BuildAuthorsListTests(unittest.TestCase):
     """Direct coverage for the build_authors_list helper.
 

--- a/api/tests/test_server_manifest.py
+++ b/api/tests/test_server_manifest.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.app import create_app
+from api.routers.manifest import _norm_excludes
 
 
 def _git(*a: str, cwd: Path) -> None:
@@ -51,6 +52,13 @@ def _parse_sse(text: str) -> list[tuple[str, dict]]:
                 events.append((name, json.loads("".join(data_lines))))
             name, data_lines = "message", []
     return events
+
+
+class TestExcludeParam:
+    def test_normalizer_strips_and_drops_empties(self) -> None:
+        assert _norm_excludes(["", " sub ", "/a.md", "sub"]) == frozenset(
+            {"sub", "a.md"}
+        )
 
 
 def test_manifest_stream_local(

--- a/api/tests/test_server_signature.py
+++ b/api/tests/test_server_signature.py
@@ -36,6 +36,23 @@ def client(tmp_path: Path, redirect_cache_root) -> TestClient:
     return TestClient(create_app(static_dir=static))
 
 
+@pytest.fixture()
+def local_repo_with_subdir(tmp_path: Path) -> Path:
+    """A committed repo with a `sub/` dir, for exercising ?exclude=sub."""
+    p = tmp_path / "repo-with-subdir"
+    p.mkdir()
+    _git("init", "-q", cwd=p)
+    _git("config", "user.email", "a@b.c", cwd=p)
+    _git("config", "user.name", "T", cwd=p)
+    (p / "f.txt").write_text("hello\nworld\n")
+    sub = p / "sub"
+    sub.mkdir()
+    (sub / "g.txt").write_text("nested\n")
+    _git("add", ".", cwd=p)
+    _git("commit", "-qm", "c", cwd=p)
+    return p
+
+
 def test_signature_missing_src_400(client: TestClient) -> None:
     assert client.get("/api/manifest/signature").status_code in (400, 422)
 
@@ -53,3 +70,16 @@ def test_signature_ok(client: TestClient, repo: Path, allow_local_repos) -> None
     assert r.status_code == 200
     body = r.json()
     assert set(body) == {"root", "scanned_at", "signature"}
+
+
+def test_signature_endpoint_honors_exclude(
+    client: TestClient, local_repo_with_subdir: Path, allow_local_repos
+) -> None:
+    src = str(local_repo_with_subdir)
+    base = client.get("/api/manifest/signature", params={"src": src}).json()[
+        "signature"
+    ]
+    excluded = client.get(
+        "/api/manifest/signature", params={"src": src, "exclude": ["sub"]}
+    ).json()["signature"]
+    assert base != excluded

--- a/app/bench/decorationGolden.bench.test.ts
+++ b/app/bench/decorationGolden.bench.test.ts
@@ -19,8 +19,9 @@ import {
 } from '../tests/_helpers/layoutTreeFixtures';
 import { commitStats, fileStats } from '../tests/_helpers/statsFixtures';
 
-// Captured before the decoration-pass perf work.
-const EXPECTED = '12k:trees43000:orbs51600:74166740';
+// Recaptured for #98's building height/width ceiling (decorations place relative
+// to building heights); tree/orb counts unchanged, only positions shifted.
+const EXPECTED = '12k:trees43000:orbs51600:4c54aab2';
 
 describe('decoration golden (bit-identical guard)', () => {
   it('placeTrees + placeFireflies + renderer buffers match baseline', () => {

--- a/app/bench/layoutGolden.bench.test.ts
+++ b/app/bench/layoutGolden.bench.test.ts
@@ -45,11 +45,13 @@ const CASES: Array<[string, number]> = [
   ['t-30k', 30000],
 ];
 
-// Captured against main before the #63 perf work. Format: `${nBuildings}/${nStreets}/${hash}`.
+// Format: `${nBuildings}/${nStreets}/${hash}`. Recaptured for #98's absolute
+// height/width ceiling (small-file repos no longer stretch to full height) —
+// the building/street counts are unchanged, only dimensions shifted.
 const EXPECTED: Record<string, string> = {
-  't-2k': '2000/644/a47ac69',
-  't-10k': '10000/3190/83797bd1',
-  't-30k': '30000/8129/14c61670',
+  't-2k': '2000/644/1a3845ab',
+  't-10k': '10000/3190/46986f99',
+  't-30k': '30000/8129/857d1160',
 };
 
 describe('layoutCity golden (bit-identical guard)', () => {

--- a/app/src/api/apiUrl.ts
+++ b/app/src/api/apiUrl.ts
@@ -3,13 +3,25 @@
 // a subpath, not only at the domain root, and sets query params uniformly
 // (undefined values are skipped, so callers can pass optional params inline).
 
-/** Build a URL for the `/api/<path>` endpoint. `path` has no leading slash. */
-export function apiUrl(path: string, params?: Record<string, string | undefined>): string {
+/**
+ * Build a URL for the `/api/<path>` endpoint. `path` has no leading slash.
+ * Array values emit one repeated query param per entry (e.g. `exclude`); scalar
+ * values overwrite, matching the backend's repeated-param contract.
+ */
+export function apiUrl(
+  path: string,
+  params?: Record<string, string | string[] | undefined>
+): string {
   const base = import.meta.env.BASE_URL || '/';
   const url = new URL(`${base}api/${path}`, window.location.origin);
   if (params) {
     for (const [key, value] of Object.entries(params)) {
-      if (value != null) url.searchParams.set(key, value);
+      if (value == null) continue;
+      if (Array.isArray(value)) {
+        for (const v of value) url.searchParams.append(key, v);
+      } else {
+        url.searchParams.set(key, value);
+      }
     }
   }
   return url.toString();

--- a/app/src/api/manifest.ts
+++ b/app/src/api/manifest.ts
@@ -27,19 +27,26 @@ import { apiUrl } from '@/api/apiUrl';
 // load and would make the poll fetch the wrong source mid-switch.
 
 /** URL for the manifest stream of an explicit source. */
-export function manifestUrlFor(opts: { src: string; branch?: string; noCache?: boolean }): string {
+export function manifestUrlFor(opts: {
+  src: string;
+  branch?: string;
+  noCache?: boolean;
+  exclude?: string[];
+}): string {
   return apiUrl('manifest', {
     [URL_PARAMS.SRC]: opts.src,
     [URL_PARAMS.BRANCH]: opts.branch,
     [URL_PARAMS.NO_CACHE]: opts.noCache ? 'true' : undefined,
+    [URL_PARAMS.EXCLUDE]: opts.exclude,
   });
 }
 
 /** URL for the lightweight signature poll of an explicit source. */
-export function signatureUrlFor(src: string, branch?: string): string {
+export function signatureUrlFor(src: string, branch?: string, exclude?: string[]): string {
   return apiUrl('manifest/signature', {
     [URL_PARAMS.SRC]: src,
     [URL_PARAMS.BRANCH]: branch,
+    [URL_PARAMS.EXCLUDE]: exclude,
   });
 }
 

--- a/app/src/city/layout/dimensions.ts
+++ b/app/src/city/layout/dimensions.ts
@@ -77,11 +77,14 @@ export function computeFileStats(stats: RepoStats | null | undefined): {
 
 // getBuildingDimensions(file, lineStats?, byteStats?) -> { w, d, h, floors }
 //
-// Floors and width are BOTH project-relative: the smallest file lands at
-// MIN_*, the largest at MAX_*, everything else interpolated. Floors uses
-// sqrt to spread the bottom of the range while compressing the long tail;
-// width uses log (file sizes span many orders of magnitude). Without a
-// stats object, the corresponding dimension falls back to MIN_*.
+// Floors and width are project-relative: the smallest file lands at MIN_*, and
+// the range is spread by sqrt (lines) / log (bytes) so the bottom of the range
+// reads clearly while the long tail compresses. The TOP of the range is a
+// per-repo ceiling anchored to the ABSOLUTE size of the biggest file
+// (FULL_HEIGHT_LINES / FULL_WIDTH_KB): a repo whose largest file is small tops
+// out below MAX_* (short/narrow city) instead of always stretching to the cap,
+// while the per-repo relative order is retained. Without a stats object, the
+// corresponding dimension falls back to MIN_*.
 export function getBuildingDimensions(
   file: {
     lines?: number | null;
@@ -107,7 +110,17 @@ export function getBuildingDimensions(
     let tH = (sLines - sMin) / (sMax - sMin);
     if (tH < 0) tH = 0;
     else if (tH > 1) tH = 1;
-    floors = Math.round(dims.MIN_FLOORS + tH * (maxFloorsCap - dims.MIN_FLOORS));
+    // Absolute ceiling: the repo's tallest building reaches the full cap only if
+    // its largest file is >= FULL_HEIGHT_LINES; smaller-file repos top out lower
+    // (sqrt of the biggest file vs the reference). So the per-repo relative
+    // spread (tH) is preserved, but a repo of tiny files reads as a low-rise
+    // city instead of being stretched to full height.
+    const refLines =
+      dims.FULL_HEIGHT_LINES && dims.FULL_HEIGHT_LINES > 0 ? dims.FULL_HEIGHT_LINES : 2000;
+    let ceilH = Math.sqrt(lineStats.max) / Math.sqrt(refLines);
+    if (ceilH > 1) ceilH = 1;
+    const repoMaxFloors = dims.MIN_FLOORS + ceilH * (maxFloorsCap - dims.MIN_FLOORS);
+    floors = Math.round(dims.MIN_FLOORS + tH * (repoMaxFloors - dims.MIN_FLOORS));
     if (floors < dims.MIN_FLOORS) floors = dims.MIN_FLOORS;
   }
   const height = floors * dims.FLOOR_HEIGHT;
@@ -127,7 +140,16 @@ export function getBuildingDimensions(
     let tW = (lBytes - lMin) / (lMax - lMin);
     if (tW < 0) tW = 0;
     else if (tW > 1) tW = 1;
-    width = dims.MIN_WIDTH + tW * (dims.MAX_WIDTH - dims.MIN_WIDTH);
+    // Absolute ceiling mirrors floors: full width only when the repo's largest
+    // file is >= FULL_WIDTH_KB; smaller-file repos keep proportionally narrower
+    // footprints while retaining the per-repo relative spread (tW).
+    const refBytes =
+      (dims.FULL_WIDTH_KB && dims.FULL_WIDTH_KB > 0 ? dims.FULL_WIDTH_KB : 64) * 1024;
+    let ceilW = Math.log(bMax) / Math.log(refBytes);
+    if (ceilW < 0) ceilW = 0;
+    else if (ceilW > 1) ceilW = 1;
+    const repoMaxWidth = dims.MIN_WIDTH + ceilW * (dims.MAX_WIDTH - dims.MIN_WIDTH);
+    width = dims.MIN_WIDTH + tW * (repoMaxWidth - dims.MIN_WIDTH);
   }
 
   // Media files (image/video) override the lines-driven height: the

--- a/app/src/components/BranchSelect/BranchSelect.tsx
+++ b/app/src/components/BranchSelect/BranchSelect.tsx
@@ -76,7 +76,7 @@ export function BranchSelect({ url, value, onChange, onError }: BranchSelectProp
       <label htmlFor="branch-select">Branch</label>
       {state.status === BranchStatus.Loading && (
         <div class="branch-select-status" role="status">
-          <LoaderCircle class="lucide-icon branch-select-spinner" aria-hidden="true" />
+          <LoaderCircle class="icon branch-select-spinner" aria-hidden="true" />
           Resolving branches…
         </div>
       )}

--- a/app/src/components/ColorInput/ColorInput.css
+++ b/app/src/components/ColorInput/ColorInput.css
@@ -1,7 +1,7 @@
 /* ── ColorInput ── */
 
 /* Color swatch — small native color picker */
-.theme-color {
+.setting-color {
   -webkit-appearance: none;
   appearance: none;
   width: 32px;
@@ -12,14 +12,14 @@
   border-radius: var(--cc-radius-sm);
   cursor: pointer;
 }
-.theme-color::-webkit-color-swatch-wrapper {
+.setting-color::-webkit-color-swatch-wrapper {
   padding: var(--cc-space-0);
 }
-.theme-color::-webkit-color-swatch {
+.setting-color::-webkit-color-swatch {
   border: none;
   border-radius: var(--cc-radius-sm);
 }
-.theme-color::-moz-color-swatch {
+.setting-color::-moz-color-swatch {
   border: none;
   border-radius: var(--cc-radius-sm);
 }

--- a/app/src/components/ColorInput/ColorInput.tsx
+++ b/app/src/components/ColorInput/ColorInput.tsx
@@ -17,7 +17,7 @@ export function ColorInput({ value, onCommit, describedBy, id }: ColorInputProps
   return (
     <input
       type="color"
-      class="theme-color"
+      class="setting-color"
       id={id}
       value={normalizeHex(value)}
       aria-describedby={describedBy}

--- a/app/src/components/CommitChip.tsx
+++ b/app/src/components/CommitChip.tsx
@@ -30,7 +30,7 @@ export function CommitChip({ sha, authors, onFocus }: CommitChipProps) {
           aria-label={focusTitle}
           onClick={() => onFocus()}
         >
-          <Focus class="lucide-icon" />
+          <Focus class="icon" />
         </button>
       )}
       {'Commit '}

--- a/app/src/components/CopyButton/CopyButton.tsx
+++ b/app/src/components/CopyButton/CopyButton.tsx
@@ -57,7 +57,7 @@ export function CopyButton({
         aria-label={label}
         onClick={onClick}
       >
-        <Copy class="lucide-icon" />
+        <Copy class="icon" />
       </button>
       {/* The copied state is otherwise a color-only flash; announce it. */}
       <span class="sr-only" role="status">

--- a/app/src/components/Field.tsx
+++ b/app/src/components/Field.tsx
@@ -9,7 +9,7 @@
 import { useId } from 'preact/hooks';
 import { FieldKind, getFieldDef } from '@/state/settingsSchema';
 import { useField } from '@/hooks/useSettings';
-import { ThemeRow } from './ThemeRow/ThemeRow';
+import { SettingRow } from './SettingRow/SettingRow';
 import { TierWidthsField } from './TierWidthsField';
 import { HueMapField } from './HueMapField/HueMapField';
 import { ColorInput } from '@/components/ColorInput/ColorInput';
@@ -141,7 +141,7 @@ export function Field({ store, fieldKey }: FieldProps) {
     def.kind === FieldKind.Number ||
     def.kind === FieldKind.Select;
   return (
-    <ThemeRow
+    <SettingRow
       label={def.label}
       tip={def.tip}
       inline={inline}
@@ -153,6 +153,6 @@ export function Field({ store, fieldKey }: FieldProps) {
       keys={[fieldKey]}
     >
       {control}
-    </ThemeRow>
+    </SettingRow>
   );
 }

--- a/app/src/components/GemIcon/GemIcon.css
+++ b/app/src/components/GemIcon/GemIcon.css
@@ -2,7 +2,7 @@
 
 /* .gem-icon — sizing for the codecity gem, an inline <svg> whose per-face
    palette fills render directly (see the GemIcon component). Same 1em sizing
-   as .lucide-icon so it slots into header buttons without throwing off alignment. */
+   as .icon so it slots into header buttons without throwing off alignment. */
 .gem-icon {
   display: inline-block;
   width: 1em;

--- a/app/src/components/HueMapField/HueMapField.css
+++ b/app/src/components/HueMapField/HueMapField.css
@@ -3,7 +3,7 @@
 /* Hue preview — sits at the right end of a hue slider row, showing the
  * current hue as a solid swatch (S/L are fixed mid-range so it reads
  * as a pure-hue chip rather than a final building color). */
-.theme-hue-preview {
+.setting-hue-preview {
   display: inline-block;
   width: 18px;
   height: 18px;

--- a/app/src/components/HueMapField/HueMapField.tsx
+++ b/app/src/components/HueMapField/HueMapField.tsx
@@ -9,7 +9,7 @@ import { useEffective, useDefault } from '@/hooks/useSettings';
 import { setDraft } from '@/state/settingsDrafts';
 import { RotateCcw } from 'lucide-preact';
 import { Slider } from '@/components/Slider/Slider';
-import { ThemeRow } from '../ThemeRow/ThemeRow';
+import { SettingRow } from '../SettingRow/SettingRow';
 import { fileTagHsl } from '@/utils/colors';
 import type { FieldProps } from '../Field';
 
@@ -31,7 +31,7 @@ export function HueMapField({ store, fieldKey }: FieldProps) {
           const descId = `${baseId}-${k}`;
           const controlId = `${baseId}-${k}-c`;
           return (
-            <ThemeRow
+            <SettingRow
               label={k}
               tip={tip}
               descId={descId}
@@ -64,7 +64,7 @@ export function HueMapField({ store, fieldKey }: FieldProps) {
                 onCommit={(v) => commit({ ...map, [k]: v })}
               />
               <span class="theme-hue-preview" style={{ background: fileTagHsl(value) }} />
-            </ThemeRow>
+            </SettingRow>
           );
         })}
     </>

--- a/app/src/components/HueMapField/HueMapField.tsx
+++ b/app/src/components/HueMapField/HueMapField.tsx
@@ -50,7 +50,7 @@ export function HueMapField({ store, fieldKey }: FieldProps) {
                     commit({ ...map, [k]: defaultVal });
                   }}
                 >
-                  <RotateCcw class="lucide-icon" />
+                  <RotateCcw class="icon" />
                 </button>
               }
             >

--- a/app/src/components/HueMapField/HueMapField.tsx
+++ b/app/src/components/HueMapField/HueMapField.tsx
@@ -40,7 +40,7 @@ export function HueMapField({ store, fieldKey }: FieldProps) {
               resetSlot={
                 <button
                   type="button"
-                  class="theme-row-reset"
+                  class="setting-row-reset"
                   title={`Default: ${defaultVal}`}
                   aria-label="Reset to default"
                   disabled={disabled}
@@ -63,7 +63,7 @@ export function HueMapField({ store, fieldKey }: FieldProps) {
                 id={controlId}
                 onCommit={(v) => commit({ ...map, [k]: v })}
               />
-              <span class="theme-hue-preview" style={{ background: fileTagHsl(value) }} />
+              <span class="setting-hue-preview" style={{ background: fileTagHsl(value) }} />
             </SettingRow>
           );
         })}

--- a/app/src/components/NewProjectForm/NewProjectForm.tsx
+++ b/app/src/components/NewProjectForm/NewProjectForm.tsx
@@ -150,7 +150,7 @@ export function NewProjectForm({
         aria-controls="new-project-advanced"
         onClick={() => setAdvanced((a) => !a)}
       >
-        <ChevronRight class="lucide-icon new-project-advanced-caret" />
+        <ChevronRight class="icon new-project-advanced-caret" />
         Advanced
       </button>
       {advanced && (

--- a/app/src/components/NodeIcon/NodeIcon.tsx
+++ b/app/src/components/NodeIcon/NodeIcon.tsx
@@ -11,7 +11,7 @@
 // Why not lucide masks: lucide icons render via CSS mask-image so they pick
 // up currentColor. The Material icons are full-color brand glyphs — the
 // COLOR is the info — so we render them as plain <img> instead. Trade: no
-// theme-tint, but every-node-recognizable-at-a-glance is the whole point.
+// setting-tint, but every-node-recognizable-at-a-glance is the whole point.
 //
 // Lookup tables live in constants/fileIcons.ts; the name resolvers live in
 // utils/fileIcons.ts. This file just renders.

--- a/app/src/components/Pane.tsx
+++ b/app/src/components/Pane.tsx
@@ -34,6 +34,9 @@ export interface PaneProps {
   /** fn() for the header × button. Omit to render no button. */
   onClose?: () => void;
   closeTitle?: string;
+  /** fn() for the header "exclude from city" button. Omit to render no button. */
+  onExclude?: () => void;
+  excludeTitle?: string;
   /** When set (or when `bodyRef` is set), Pane renders a `.pane-body` wrapper
    *  with this extra class around `children`. Omit for custom body layout. */
   bodyClass?: string;
@@ -63,6 +66,8 @@ export function Pane({
   focusTitle,
   onClose,
   closeTitle,
+  onExclude,
+  excludeTitle,
   bodyClass,
   bodyRef,
   bodyProps,
@@ -83,6 +88,8 @@ export function Pane({
           focusTitle={focusTitle}
           onClose={onClose}
           closeTitle={closeTitle}
+          onExclude={onExclude}
+          excludeTitle={excludeTitle}
         />
       )}
       {ownsBody ? (

--- a/app/src/components/Pane.tsx
+++ b/app/src/components/Pane.tsx
@@ -121,7 +121,7 @@ export interface PaneEmptyProps {
 export function PaneEmpty({ icon: Icon, title, sub, large = true }: PaneEmptyProps) {
   return (
     <div class={large ? 'empty-state empty-state--lg' : 'empty-state'}>
-      {Icon && <Icon class="lucide-icon" />}
+      {Icon && <Icon class="icon" />}
       <p class="text-card-title">{title}</p>
       {sub && <p class="text-card-sub">{sub}</p>}
     </div>

--- a/app/src/components/PaneHeader/PaneHeader.tsx
+++ b/app/src/components/PaneHeader/PaneHeader.tsx
@@ -6,7 +6,7 @@
 
 import './PaneHeader.css';
 import type { ComponentChildren } from 'preact';
-import { Focus, X } from 'lucide-preact';
+import { Focus, X, EyeOff } from 'lucide-preact';
 
 // ── Props interface ─────────────────────────────────────────────────────────
 
@@ -24,6 +24,10 @@ export interface PaneHeaderProps {
   onClose?: () => void;
   /** Tooltip text on the × button. Defaults to "Hide sidebar". */
   closeTitle?: string;
+  /** fn() when the user clicks the "exclude from city" button. Omit to render none. */
+  onExclude?: () => void;
+  /** Tooltip / aria-label for the exclude button. */
+  excludeTitle?: string;
   /** Optional prefix element rendered between focus button and title. */
   prefixSlot?: ComponentChildren;
   /** Rich title content rendered inside the title element instead of the
@@ -40,6 +44,8 @@ export function PaneHeader({
   focusTitle = 'Focus camera',
   onClose,
   closeTitle = 'Hide sidebar',
+  onExclude,
+  excludeTitle,
   prefixSlot,
   titleSlot,
 }: PaneHeaderProps) {
@@ -64,6 +70,17 @@ export function PaneHeader({
       )}
       {prefixSlot ?? null}
       <h3 class={`text-pane-title${mono ? ' is-mono' : ''}`}>{titleSlot ?? title}</h3>
+      {typeof onExclude === 'function' && (
+        <button
+          type="button"
+          class="btn-icon"
+          title={excludeTitle ?? 'Exclude from city'}
+          aria-label={excludeTitle ?? 'Exclude from city'}
+          onClick={() => onExclude()}
+        >
+          <EyeOff class="lucide-icon" />
+        </button>
+      )}
       {typeof onClose === 'function' && <PaneCloseButton onClose={onClose} title={closeTitle} />}
     </div>
   );

--- a/app/src/components/PaneHeader/PaneHeader.tsx
+++ b/app/src/components/PaneHeader/PaneHeader.tsx
@@ -65,7 +65,7 @@ export function PaneHeader({
             onFocus();
           }}
         >
-          <Focus class="lucide-icon" />
+          <Focus class="icon" />
         </button>
       )}
       {prefixSlot ?? null}
@@ -78,7 +78,7 @@ export function PaneHeader({
           aria-label={excludeTitle ?? 'Exclude from city'}
           onClick={() => onExclude()}
         >
-          <EyeOff class="lucide-icon" />
+          <EyeOff class="icon" />
         </button>
       )}
       {typeof onClose === 'function' && <PaneCloseButton onClose={onClose} title={closeTitle} />}
@@ -106,7 +106,7 @@ export function PaneCloseButton({ onClose, title = 'Hide sidebar' }: PaneCloseBu
       aria-label={title}
       onClick={() => onClose()}
     >
-      <X class="lucide-icon" />
+      <X class="icon" />
     </button>
   );
 }

--- a/app/src/components/PaneTabs/PaneTabs.css
+++ b/app/src/components/PaneTabs/PaneTabs.css
@@ -35,13 +35,23 @@
   color: var(--cc-text-strong);
 }
 
-/* "Something under this tab differs from default" dot (PaneTabs.tsx). */
-.pane-tab-dot {
+/* Count of changed-from-default items under this tab (PaneTabs.tsx). A small
+ * rounded-square chip: a light surface fill + surface-toned border, light text. */
+.pane-tab-badge {
   flex: 0 0 auto;
-  width: var(--cc-space-3);
-  height: var(--cc-space-3);
-  border-radius: var(--cc-radius-circle);
-  background: var(--cc-accent);
+  min-width: 16px;
+  height: 16px;
+  padding: 0 var(--cc-space-1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--cc-radius-sm);
+  background: var(--cc-overlay-bg-strong);
+  border: 1px solid var(--cc-border-subtle);
+  color: var(--cc-text-strong);
+  font-size: var(--cc-font-2xs);
+  font-weight: var(--cc-fw-medium);
+  line-height: 1;
 }
 
 .pane-tab--active {

--- a/app/src/components/PaneTabs/PaneTabs.css
+++ b/app/src/components/PaneTabs/PaneTabs.css
@@ -40,6 +40,6 @@
   border-bottom-color: var(--cc-accent);
 }
 
-.pane-tab .lucide-icon {
+.pane-tab .icon {
   font-size: var(--cc-font-md); /* icons are 1em (icons.css) — size off a token */
 }

--- a/app/src/components/PaneTabs/PaneTabs.css
+++ b/app/src/components/PaneTabs/PaneTabs.css
@@ -35,6 +35,15 @@
   color: var(--cc-text-strong);
 }
 
+/* "Something under this tab differs from default" dot (PaneTabs.tsx). */
+.pane-tab-dot {
+  flex: 0 0 auto;
+  width: var(--cc-space-3);
+  height: var(--cc-space-3);
+  border-radius: var(--cc-radius-circle);
+  background: var(--cc-accent);
+}
+
 .pane-tab--active {
   color: var(--cc-text-strong);
   border-bottom-color: var(--cc-accent);

--- a/app/src/components/PaneTabs/PaneTabs.tsx
+++ b/app/src/components/PaneTabs/PaneTabs.tsx
@@ -9,6 +9,8 @@ export interface PaneTab {
   id: string;
   label: string;
   icon?: LucideIcon;
+  /** Show a small "something under here changed from default" dot on the tab. */
+  indicator?: boolean;
 }
 
 export interface PaneTabsProps {
@@ -73,6 +75,13 @@ export function PaneTabs({ tabs, active, onSelect, class: className, panelId }: 
           >
             {Icon && <Icon class="icon" aria-hidden="true" />}
             <span>{t.label}</span>
+            {t.indicator && (
+              <span
+                class="pane-tab-dot"
+                aria-label="changed from default"
+                title="Changed from default"
+              />
+            )}
           </button>
         );
       })}

--- a/app/src/components/PaneTabs/PaneTabs.tsx
+++ b/app/src/components/PaneTabs/PaneTabs.tsx
@@ -71,7 +71,7 @@ export function PaneTabs({ tabs, active, onSelect, class: className, panelId }: 
             onClick={() => onSelect(t.id)}
             onKeyDown={(e) => onKeyDown(e, idx)}
           >
-            {Icon && <Icon class="lucide-icon" aria-hidden="true" />}
+            {Icon && <Icon class="icon" aria-hidden="true" />}
             <span>{t.label}</span>
           </button>
         );

--- a/app/src/components/PaneTabs/PaneTabs.tsx
+++ b/app/src/components/PaneTabs/PaneTabs.tsx
@@ -9,8 +9,9 @@ export interface PaneTab {
   id: string;
   label: string;
   icon?: LucideIcon;
-  /** Show a small "something under here changed from default" dot on the tab. */
-  indicator?: boolean;
+  /** Count of changed-from-default items under this tab; renders a small count
+   *  badge when > 0, omitted otherwise. */
+  badge?: number;
 }
 
 export interface PaneTabsProps {
@@ -75,12 +76,10 @@ export function PaneTabs({ tabs, active, onSelect, class: className, panelId }: 
           >
             {Icon && <Icon class="icon" aria-hidden="true" />}
             <span>{t.label}</span>
-            {t.indicator && (
-              <span
-                class="pane-tab-dot"
-                aria-label="changed from default"
-                title="Changed from default"
-              />
+            {t.badge != null && t.badge > 0 && (
+              <span class="pane-tab-badge" aria-label={`${t.badge} changed from default`}>
+                {t.badge}
+              </span>
             )}
           </button>
         );

--- a/app/src/components/PathBreadcrumbs/PathBreadcrumbs.tsx
+++ b/app/src/components/PathBreadcrumbs/PathBreadcrumbs.tsx
@@ -56,7 +56,7 @@ export function PathBreadcrumbs({
           aria-label={focusTitle}
           onClick={() => onFocus()}
         >
-          <Focus class="lucide-icon" />
+          <Focus class="icon" />
         </button>
       )}
       <ExtensionBadge extension={isFileSel ? (extension ?? null) : null} isDir={!isFileSel} />

--- a/app/src/components/ProjectSwitcher/ProjectSwitcher.css
+++ b/app/src/components/ProjectSwitcher/ProjectSwitcher.css
@@ -9,7 +9,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.btn-chip .lucide-icon {
+.btn-chip .icon {
   font-size: var(--cc-font-md);
   flex: 0 0 auto;
 }

--- a/app/src/components/ProjectSwitcher/ProjectSwitcher.tsx
+++ b/app/src/components/ProjectSwitcher/ProjectSwitcher.tsx
@@ -28,7 +28,7 @@ export function ProjectSwitcher({ rootLabel, branch, onSwitchSource }: ProjectSw
     >
       <span class="btn-chip-label">{rootLabel}</span>
       {branch && <span class="app-header-branch-pill">@{branch}</span>}
-      <ChevronsUpDown class="lucide-icon btn-chip-affordance" />
+      <ChevronsUpDown class="icon btn-chip-affordance" />
     </button>
   );
 }

--- a/app/src/components/RangePair/RangePair.css
+++ b/app/src/components/RangePair/RangePair.css
@@ -6,7 +6,7 @@
  * webkit naturally centers each thumb vertically on the input box, which
  * is the same vertical center as the visual track (top:50%/translateY).
  * Result: thumbs sit ON the track, never below it. */
-.theme-range-pair {
+.setting-range-pair {
   position: relative;
   flex: 1 1 auto;
   min-width: 60px;
@@ -14,7 +14,7 @@
 }
 
 /* Visual track: a thin bar centered vertically in the pair container. */
-.theme-range-pair-track {
+.setting-range-pair-track {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -24,7 +24,7 @@
   background: var(--cc-track);
   border-radius: var(--cc-radius-sm);
 }
-.theme-range-pair-fill {
+.setting-range-pair-fill {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -39,7 +39,7 @@
  * is transparent (we draw the visible track above), so each input only
  * contributes its thumb to the visual. pointer-events:none on the input
  * lets clicks pass through except where the thumb itself sits. */
-.theme-range-pair input[type='range'] {
+.setting-range-pair input[type='range'] {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -54,14 +54,14 @@
 /* The transparent overlay input spans the whole container, so a default
  * focus outline would frame the entire pair. Suppress that and put the
  * keyboard ring on the thumb instead, where the focused value actually is. */
-.theme-range-pair input[type='range']:focus {
+.setting-range-pair input[type='range']:focus {
   outline: none;
 }
-.theme-range-pair input[type='range']:focus-visible::-webkit-slider-thumb {
+.setting-range-pair input[type='range']:focus-visible::-webkit-slider-thumb {
   outline: 2px solid var(--cc-accent-light);
   outline-offset: 2px;
 }
-.theme-range-pair input[type='range']:focus-visible::-moz-range-thumb {
+.setting-range-pair input[type='range']:focus-visible::-moz-range-thumb {
   outline: 2px solid var(--cc-accent-light);
   outline-offset: 2px;
 }
@@ -70,12 +70,12 @@
  * on the runnable-track midline, so a full-height track means the thumb's
  * vertical center aligns with the input's vertical center — and that's
  * the same center as our visible track element above. */
-.theme-range-pair input[type='range']::-webkit-slider-runnable-track {
+.setting-range-pair input[type='range']::-webkit-slider-runnable-track {
   background: transparent;
   height: 100%;
   border: none;
 }
-.theme-range-pair input[type='range']::-moz-range-track {
+.setting-range-pair input[type='range']::-moz-range-track {
   background: transparent;
   height: 100%;
   border: none;
@@ -85,7 +85,7 @@
  * sit centered on a track of the same height — but since we set the
  * runnable-track to fill the input, the natural centering takes over and
  * no margin nudge is needed. */
-.theme-range-pair input[type='range']::-webkit-slider-thumb {
+.setting-range-pair input[type='range']::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
   width: 14px;
@@ -97,7 +97,7 @@
   pointer-events: auto;
   box-shadow: var(--cc-shadow-sm);
 }
-.theme-range-pair input[type='range']::-moz-range-thumb {
+.setting-range-pair input[type='range']::-moz-range-thumb {
   width: 14px;
   height: 14px;
   background: var(--cc-accent);
@@ -109,9 +109,9 @@
 }
 /* Lo thumb a touch darker so it reads as the "lower" anchor when the
  * two thumbs sit at the same value (otherwise they'd be a single dot). */
-.theme-range-pair input.theme-range-pair-lo::-webkit-slider-thumb {
+.setting-range-pair input.setting-range-pair-lo::-webkit-slider-thumb {
   background: var(--cc-accent-dark);
 }
-.theme-range-pair input.theme-range-pair-lo::-moz-range-thumb {
+.setting-range-pair input.setting-range-pair-lo::-moz-range-thumb {
   background: var(--cc-accent-dark);
 }

--- a/app/src/components/RangePair/RangePair.tsx
+++ b/app/src/components/RangePair/RangePair.tsx
@@ -49,13 +49,13 @@ export function RangePair({
   }
 
   return (
-    <span class="theme-slider-wrap">
-      <span class="theme-range-pair">
-        <span class="theme-range-pair-track" />
-        <span class="theme-range-pair-fill" style={{ left: fillLeft, right: fillRight }} />
+    <span class="setting-slider-wrap">
+      <span class="setting-range-pair">
+        <span class="setting-range-pair-track" />
+        <span class="setting-range-pair-fill" style={{ left: fillLeft, right: fillRight }} />
         <input
           type="range"
-          class="theme-range-pair-lo"
+          class="setting-range-pair-lo"
           id={id}
           min={String(min)}
           max={String(max)}
@@ -67,7 +67,7 @@ export function RangePair({
         />
         <input
           type="range"
-          class="theme-range-pair-hi"
+          class="setting-range-pair-hi"
           id={id ? `${id}-hi` : undefined}
           min={String(min)}
           max={String(max)}
@@ -78,7 +78,7 @@ export function RangePair({
           onInput={onInputHi}
         />
       </span>
-      <span class="theme-slider-readout">
+      <span class="setting-slider-readout">
         {formatNumberForStep(lo, step)} – {formatNumberForStep(hi, step)}
       </span>
     </span>

--- a/app/src/components/RecentsList/RecentRow.tsx
+++ b/app/src/components/RecentsList/RecentRow.tsx
@@ -70,7 +70,7 @@ export function RecentRow(props: RecentRowProps) {
         onClick={unavailable ? undefined : props.onOpen}
       >
         <span class="recent-icon">
-          {isLocal ? <Folder class="lucide-icon" /> : <HostingIcon src={r.src} />}
+          {isLocal ? <Folder class="icon" /> : <HostingIcon src={r.src} />}
         </span>
         <div class="recent-row-body">
           <div class="recent-label-row">
@@ -90,7 +90,7 @@ export function RecentRow(props: RecentRowProps) {
         aria-label="Remove from recents"
         onClick={props.onAskRemove}
       >
-        <X class="lucide-icon" />
+        <X class="icon" />
       </button>
     </div>
   );

--- a/app/src/components/ResetButton/ResetButton.css
+++ b/app/src/components/ResetButton/ResetButton.css
@@ -1,11 +1,11 @@
 /* ── ResetButton ── */
 
-/* Tiny accent reset buttons (controls section + subgroup + theme row).
+/* Tiny accent reset buttons (controls section + subgroup + setting row).
    Two near-identical rules from the audit consolidated into a shared
    ruleset; no new component class. */
 .controls-section-reset,
 .controls-subgroup-reset,
-.theme-row-reset {
+.setting-row-reset {
   flex: 0 0 auto;
   appearance: none;
   display: inline-flex;
@@ -22,19 +22,19 @@
 }
 .controls-section-reset:not(:disabled):hover,
 .controls-subgroup-reset:not(:disabled):hover,
-.theme-row-reset:not(:disabled):hover {
+.setting-row-reset:not(:disabled):hover {
   color: var(--cc-white);
   background: var(--cc-accent-bg);
   border-color: var(--cc-accent-border);
 }
 .controls-section-reset:not(:disabled):active,
 .controls-subgroup-reset:not(:disabled):active,
-.theme-row-reset:not(:disabled):active {
+.setting-row-reset:not(:disabled):active {
   background: var(--cc-accent-bg-strong);
 }
 .controls-section-reset:disabled,
 .controls-subgroup-reset:disabled,
-.theme-row-reset:disabled {
+.setting-row-reset:disabled {
   color: var(--cc-accent-bg);
   cursor: default;
 }
@@ -49,7 +49,7 @@
 
 /* Per-row reset icon. ACTIONABLE — clearly shown in brand-blue when the
  * row's value differs from its default, fades in on hover. */
-/* .theme-row-reset typography in .btn-reset-inline. */
-.theme-row-reset {
+/* .setting-row-reset typography in .btn-reset-inline. */
+.setting-row-reset {
   margin: var(--cc-space-0);
 }

--- a/app/src/components/ResetButton/ResetButton.tsx
+++ b/app/src/components/ResetButton/ResetButton.tsx
@@ -57,7 +57,7 @@ export function ResetButton({ store, keys, formatTitle = _defaultTitle }: ResetB
         for (const k of keys) stageReset(store, k);
       }}
     >
-      <RotateCcw class="lucide-icon" />
+      <RotateCcw class="icon" />
     </button>
   );
 }

--- a/app/src/components/ResetButton/ResetButton.tsx
+++ b/app/src/components/ResetButton/ResetButton.tsx
@@ -47,7 +47,7 @@ export function ResetButton({ store, keys, formatTitle = _defaultTitle }: ResetB
   return (
     <button
       type="button"
-      class="theme-row-reset"
+      class="setting-row-reset"
       title={title}
       aria-label="Reset to default"
       disabled={!hasDiff}

--- a/app/src/components/Section/Section.tsx
+++ b/app/src/components/Section/Section.tsx
@@ -29,6 +29,9 @@ export interface SectionProps {
   /** Tooltip + aria-label for the reset button when the default draft-reset copy
    *  ("...values...to defaults") doesn't fit the section. */
   resetTitle?: string;
+  /** Start expanded instead of collapsed (e.g. the Scan/Appearance tabs, where a
+   *  section or two reads better open). Defaults to collapsed. */
+  defaultOpen?: boolean;
   children: ComponentChildren;
 }
 
@@ -39,6 +42,7 @@ export function Section({
   onReset,
   resetEnabled,
   resetTitle,
+  defaultOpen,
   children,
 }: SectionProps) {
   const keys = resetKeys ?? [];
@@ -46,7 +50,7 @@ export function Section({
   const customReset = typeof onReset === 'function';
   const showReset = customReset || keys.length > 0;
   const canReset = customReset ? !!resetEnabled : keysResettable;
-  const open = useSignal(false);
+  const open = useSignal(defaultOpen ?? false);
 
   // A disclosure, NOT a <details>: the header is a flex row with a real
   // aria-expanded toggle button and the reset button as SIBLINGS. (An

--- a/app/src/components/Section/Section.tsx
+++ b/app/src/components/Section/Section.tsx
@@ -64,7 +64,7 @@ export function Section({
             open.value = !open.value;
           }}
         >
-          <ChevronRight class="lucide-icon chevron" />
+          <ChevronRight class="icon chevron" />
           <span class="text-label">{name}</span>
         </button>
         {showReset && (
@@ -82,7 +82,7 @@ export function Section({
               for (const r of keys) stageReset(r.store, r.key);
             }}
           >
-            <RotateCcw class="lucide-icon" />
+            <RotateCcw class="icon" />
           </button>
         )}
       </div>

--- a/app/src/components/Section/Section.tsx
+++ b/app/src/components/Section/Section.tsx
@@ -21,12 +21,31 @@ export interface SectionProps {
   /** The (store, key) refs of every field under this section. Drives the
    *  header reset button; omit (bespoke sections) to render no section reset. */
   resetKeys?: ResettableRef[];
+  /** Custom reset for sections not backed by the settings-draft system (e.g. the
+   *  excludes list): the header reset button calls this instead of stageReset,
+   *  enabled iff `resetEnabled`. Takes precedence over `resetKeys`. */
+  onReset?: () => void;
+  resetEnabled?: boolean;
+  /** Tooltip + aria-label for the reset button when the default draft-reset copy
+   *  ("...values...to defaults") doesn't fit the section. */
+  resetTitle?: string;
   children: ComponentChildren;
 }
 
-export function Section({ name, hint, resetKeys, children }: SectionProps) {
+export function Section({
+  name,
+  hint,
+  resetKeys,
+  onReset,
+  resetEnabled,
+  resetTitle,
+  children,
+}: SectionProps) {
   const keys = resetKeys ?? [];
-  const canReset = useAnyResettable(keys);
+  const keysResettable = useAnyResettable(keys);
+  const customReset = typeof onReset === 'function';
+  const showReset = customReset || keys.length > 0;
+  const canReset = customReset ? !!resetEnabled : keysResettable;
   const open = useSignal(false);
 
   // A disclosure, NOT a <details>: the header is a flex row with a real
@@ -48,14 +67,18 @@ export function Section({ name, hint, resetKeys, children }: SectionProps) {
           <ChevronRight class="lucide-icon chevron" />
           <span class="text-label">{name}</span>
         </button>
-        {keys.length > 0 && (
+        {showReset && (
           <button
             type="button"
             class="controls-section-reset"
-            title="Reset all values in this section to defaults"
-            aria-label="Reset section to defaults"
+            title={resetTitle ?? 'Reset all values in this section to defaults'}
+            aria-label={resetTitle ?? 'Reset section to defaults'}
             disabled={!canReset}
             onClick={() => {
+              if (customReset) {
+                onReset!();
+                return;
+              }
               for (const r of keys) stageReset(r.store, r.key);
             }}
           >

--- a/app/src/components/SegmentedSelect/SegmentedSelect.css
+++ b/app/src/components/SegmentedSelect/SegmentedSelect.css
@@ -2,7 +2,7 @@
 
 /* Segmented select — used for enum picks like "Detail: full / silhouette
  * / hidden". One button per option; the active option lights up. */
-.theme-select {
+.setting-select {
   display: inline-flex;
   background: var(--cc-bg-chrome);
   border: 1px solid var(--cc-border-input);

--- a/app/src/components/SegmentedSelect/SegmentedSelect.tsx
+++ b/app/src/components/SegmentedSelect/SegmentedSelect.tsx
@@ -55,7 +55,12 @@ export function SegmentedSelect({
   }
 
   return (
-    <span class="theme-select" role="radiogroup" aria-label={label} aria-describedby={describedBy}>
+    <span
+      class="setting-select"
+      role="radiogroup"
+      aria-label={label}
+      aria-describedby={describedBy}
+    >
       {options.map((opt, idx) => {
         const checked = opt.value === value;
         return (

--- a/app/src/components/SettingRow/SettingRow.css
+++ b/app/src/components/SettingRow/SettingRow.css
@@ -1,4 +1,4 @@
-/* ── ThemeRow (layout B: stacked) ──
+/* ── SettingRow (layout B: stacked) ──
  * .theme-row is a vertical stack:
  *   .theme-row-main    — the <label>, covering only head + control (NOT the
  *                        description — a wrapping <label>'s text becomes the

--- a/app/src/components/SettingRow/SettingRow.css
+++ b/app/src/components/SettingRow/SettingRow.css
@@ -1,14 +1,14 @@
 /* ── SettingRow (layout B: stacked) ──
- * .theme-row is a vertical stack:
- *   .theme-row-main    — the <label>, covering only head + control (NOT the
+ * .setting-row is a vertical stack:
+ *   .setting-row-main    — the <label>, covering only head + control (NOT the
  *                        description — a wrapping <label>'s text becomes the
  *                        control's accessible name, so the desc stays a sibling)
- *   .theme-row-head    — label (grows) + reset, and for inline kinds the control
- *   .theme-row-control — full-width control (stacked kinds) or inline (head row)
- *   .theme-row-desc    — optional one-line description, sibling of .theme-row-main
+ *   .setting-row-head    — label (grows) + reset, and for inline kinds the control
+ *   .setting-row-control — full-width control (stacked kinds) or inline (head row)
+ *   .setting-row-desc    — optional one-line description, sibling of .setting-row-main
  * Labels get the full row width, so they never truncate; every stacked control
  * is full-width, so sliders line up. */
-.theme-row {
+.setting-row {
   display: flex;
   flex-direction: column;
   gap: var(--cc-space-3);
@@ -19,21 +19,21 @@
   min-width: 0;
 }
 
-.theme-row-main {
+.setting-row-main {
   display: flex;
   flex-direction: column;
   gap: var(--cc-space-3);
   min-width: 0;
 }
 
-.theme-row-head {
+.setting-row-head {
   display: flex;
   align-items: center;
   gap: var(--cc-space-4);
   min-width: 0;
 }
 
-.theme-row-label {
+.setting-row-label {
   flex: 1 1 auto;
   min-width: 0;
   color: var(--cc-text-strong);
@@ -41,24 +41,24 @@
 }
 
 /* Stacked control: full row width, its own readout at the end. */
-.theme-row-control {
+.setting-row-control {
   min-width: 0;
   display: flex;
   align-items: center;
   gap: var(--cc-space-4);
 }
-.theme-row:not(.theme-row--inline) .theme-row-main > .theme-row-control {
+.setting-row:not(.setting-row--inline) .setting-row-main > .setting-row-control {
   width: 100%;
 }
 
 /* Inline kinds (toggle, color): control sits on the head row, pinned right
  * before the reset icon; no full-width control follows. */
-.theme-row--inline .theme-row-head > .theme-row-control {
+.setting-row--inline .setting-row-head > .setting-row-control {
   flex: 0 0 auto;
   margin-left: auto;
 }
 
-.theme-row-desc {
+.setting-row-desc {
   color: var(--cc-text-secondary);
   font-size: var(--cc-font-2xs);
   line-height: var(--cc-lh-base);

--- a/app/src/components/SettingRow/SettingRow.tsx
+++ b/app/src/components/SettingRow/SettingRow.tsx
@@ -1,4 +1,4 @@
-// components/SettingRow.tsx — Labeled control-panel row (renders .theme-row).
+// components/SettingRow.tsx — Labeled control-panel row (renders .setting-row).
 // Layout B (stacked): a head row (label + reset; plus the control itself for
 // inline kinds like toggle/color), then — for stacked kinds — the full-width
 // control, then the field's description when it has one.
@@ -60,17 +60,17 @@ export function SettingRow({
     resetSlot ??
     (store && keys && keys.length > 0 ? <ResetButton store={store} keys={keys} /> : null);
   return (
-    <div class={inline ? 'theme-row theme-row--inline' : 'theme-row'}>
-      <label class="theme-row-main" htmlFor={htmlFor} title={fullTip}>
-        <span class="theme-row-head">
-          <span class="theme-row-label">{label}</span>
-          {inline && <span class="theme-row-control">{children}</span>}
+    <div class={inline ? 'setting-row setting-row--inline' : 'setting-row'}>
+      <label class="setting-row-main" htmlFor={htmlFor} title={fullTip}>
+        <span class="setting-row-head">
+          <span class="setting-row-label">{label}</span>
+          {inline && <span class="setting-row-control">{children}</span>}
           {reset}
         </span>
-        {!inline && <span class="theme-row-control">{children}</span>}
+        {!inline && <span class="setting-row-control">{children}</span>}
       </label>
       {tip && (
-        <span class="theme-row-desc" id={descId}>
+        <span class="setting-row-desc" id={descId}>
           {tip}
         </span>
       )}

--- a/app/src/components/SettingRow/SettingRow.tsx
+++ b/app/src/components/SettingRow/SettingRow.tsx
@@ -1,4 +1,4 @@
-// components/ThemeRow.tsx — Labeled control-panel row (renders .theme-row).
+// components/SettingRow.tsx — Labeled control-panel row (renders .theme-row).
 // Layout B (stacked): a head row (label + reset; plus the control itself for
 // inline kinds like toggle/color), then — for stacked kinds — the full-width
 // control, then the field's description when it has one.
@@ -10,7 +10,7 @@
 // inline toggle/color rows) make clicking the description text activate the
 // control. The caller wires it back via aria-describedby using `descId`.
 
-import './ThemeRow.css';
+import './SettingRow.css';
 import type { ComponentChildren } from 'preact';
 import { ResetButton } from '../ResetButton/ResetButton';
 
@@ -19,7 +19,7 @@ interface SignalLike {
   set value(v: any);
 }
 
-export interface ThemeRowProps {
+export interface SettingRowProps {
   label: string;
   /** One-line description, shown inline under the control and as the hover
    *  title. Omit for controls that need no explanation. */
@@ -44,7 +44,7 @@ export interface ThemeRowProps {
   children: ComponentChildren;
 }
 
-export function ThemeRow({
+export function SettingRow({
   label,
   tip,
   inline,
@@ -54,7 +54,7 @@ export function ThemeRow({
   keys,
   resetSlot,
   children,
-}: ThemeRowProps) {
+}: SettingRowProps) {
   const fullTip = tip ? `${label}: ${tip}` : label;
   const reset =
     resetSlot ??

--- a/app/src/components/Slider/Slider.css
+++ b/app/src/components/Slider/Slider.css
@@ -4,7 +4,7 @@
  * auto-sized to its content (with a small floor so short numbers don't
  * collapse). No fixed widths anywhere — this row scales cleanly from a
  * narrow sidebar up to the max width. */
-.theme-slider-wrap {
+.setting-slider-wrap {
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
@@ -12,7 +12,7 @@
   gap: var(--cc-space-4);
 }
 
-.theme-slider {
+.setting-slider {
   -webkit-appearance: none;
   appearance: none;
   flex: 1 1 auto;
@@ -22,7 +22,7 @@
   border-radius: var(--cc-radius-sm);
   cursor: pointer;
 }
-.theme-slider::-webkit-slider-thumb {
+.setting-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
   width: 12px;
@@ -32,7 +32,7 @@
   border-radius: var(--cc-radius-circle);
   cursor: pointer;
 }
-.theme-slider::-moz-range-thumb {
+.setting-slider::-moz-range-thumb {
   width: 12px;
   height: 12px;
   background: var(--cc-accent);
@@ -41,7 +41,7 @@
   cursor: pointer;
 }
 
-.theme-slider-readout {
+.setting-slider-readout {
   flex: 0 0 auto;
   min-width: 36px;
   text-align: right;

--- a/app/src/components/Slider/Slider.tsx
+++ b/app/src/components/Slider/Slider.tsx
@@ -27,10 +27,10 @@ export function formatNumberForStep(v: number, step: number): string {
 
 export function Slider({ value, min, max, step, onCommit, describedBy, id }: SliderProps) {
   return (
-    <span class="theme-slider-wrap">
+    <span class="setting-slider-wrap">
       <input
         type="range"
-        class="theme-slider"
+        class="setting-slider"
         id={id}
         min={String(min)}
         max={String(max)}
@@ -42,7 +42,7 @@ export function Slider({ value, min, max, step, onCommit, describedBy, id }: Sli
           if (Number.isFinite(v)) onCommit(v);
         }}
       />
-      <span class="theme-slider-readout">{formatNumberForStep(value, step)}</span>
+      <span class="setting-slider-readout">{formatNumberForStep(value, step)}</span>
     </span>
   );
 }

--- a/app/src/components/Subgroup/Subgroup.css
+++ b/app/src/components/Subgroup/Subgroup.css
@@ -2,11 +2,11 @@
 
 /* Sub-accordions are separated by spacing only — no dividing border.
    Only top-level .controls-section blocks get a divider between siblings. */
-.theme-subgroup {
+.setting-subgroup {
   margin-top: var(--cc-space-2);
   padding-top: var(--cc-space-2);
 }
-.theme-subgroup:first-of-type {
+.setting-subgroup:first-of-type {
   margin-top: var(--cc-space-3);
   padding-top: var(--cc-space-0);
 }
@@ -14,7 +14,7 @@
 /* Subgroup label spacing — the inline label <div> at the top of a
    non-collapsible subgroup adds breathing room above its rows. Typography
    (color, weight, size) comes from .text-label. */
-.theme-subgroup > .text-label {
+.setting-subgroup > .text-label {
   margin-bottom: var(--cc-space-4);
 }
 
@@ -23,7 +23,7 @@
  * treatment as .controls-section-summary so the open/closed affordance is
  * consistent at every level of the panel; nesting is shown by the indent guide
  * on .controls-disclosure-body (ControlsPane.css). */
-.theme-subgroup-collapsible > .theme-subgroup-summary {
+.setting-subgroup-collapsible > .setting-subgroup-summary {
   /* Sticky header stacked below the sticky section header (offset = section
    * header height, set on .controls-pane). Opaque bg so rows don't show through. */
   position: sticky;
@@ -33,6 +33,6 @@
   cursor: default; /* the toggle button carries the pointer affordance */
 }
 /* Collapsed: hide the nested body (mirrors a closed <details>). */
-.theme-subgroup-collapsible:not(.is-open) > .controls-disclosure-body {
+.setting-subgroup-collapsible:not(.is-open) > .controls-disclosure-body {
   display: none;
 }

--- a/app/src/components/Subgroup/Subgroup.tsx
+++ b/app/src/components/Subgroup/Subgroup.tsx
@@ -62,7 +62,7 @@ export function Subgroup({ name, collapsible = true, resetKeys, children }: Subg
             open.value = !open.value;
           }}
         >
-          <ChevronRight class="lucide-icon chevron" />
+          <ChevronRight class="icon chevron" />
           <span class="theme-subgroup-label-text text-label">{name}</span>
         </button>
         {keys.length > 0 && (
@@ -76,7 +76,7 @@ export function Subgroup({ name, collapsible = true, resetKeys, children }: Subg
               for (const r of keys) stageReset(r.store, r.key);
             }}
           >
-            <RotateCcw class="lucide-icon" />
+            <RotateCcw class="icon" />
           </button>
         )}
       </div>

--- a/app/src/components/Subgroup/Subgroup.tsx
+++ b/app/src/components/Subgroup/Subgroup.tsx
@@ -33,7 +33,7 @@ export function Subgroup({ name, collapsible = true, resetKeys, children }: Subg
 
   if (!collapsible) {
     return (
-      <div class="theme-subgroup">
+      <div class="setting-subgroup">
         <div class="text-label">{name}</div>
         {children}
       </div>
@@ -49,11 +49,11 @@ export function Subgroup({ name, collapsible = true, resetKeys, children }: Subg
     <div
       class={
         open.value
-          ? 'theme-subgroup theme-subgroup-collapsible is-open'
-          : 'theme-subgroup theme-subgroup-collapsible'
+          ? 'setting-subgroup setting-subgroup-collapsible is-open'
+          : 'setting-subgroup setting-subgroup-collapsible'
       }
     >
-      <div class="row theme-subgroup-summary">
+      <div class="row setting-subgroup-summary">
         <button
           type="button"
           class="controls-disclosure-toggle"
@@ -63,7 +63,7 @@ export function Subgroup({ name, collapsible = true, resetKeys, children }: Subg
           }}
         >
           <ChevronRight class="icon chevron" />
-          <span class="theme-subgroup-label-text text-label">{name}</span>
+          <span class="setting-subgroup-label-text text-label">{name}</span>
         </button>
         {keys.length > 0 && (
           <button

--- a/app/src/components/TierWidthsField.tsx
+++ b/app/src/components/TierWidthsField.tsx
@@ -9,7 +9,7 @@ import { setDraft } from '@/state/settingsDrafts';
 import type { StreetTier } from '@/state/stores/settings/streets';
 import { RotateCcw } from 'lucide-preact';
 import { Slider } from '@/components/Slider/Slider';
-import { ThemeRow } from './ThemeRow/ThemeRow';
+import { SettingRow } from './SettingRow/SettingRow';
 import type { FieldProps } from './Field';
 
 export function TierWidthsField({ store, fieldKey }: FieldProps) {
@@ -28,7 +28,7 @@ export function TierWidthsField({ store, fieldKey }: FieldProps) {
         const descId = `${baseId}-${i}`;
         const controlId = `${baseId}-${i}-c`;
         return (
-          <ThemeRow
+          <SettingRow
             label={label}
             tip={tip}
             descId={descId}
@@ -66,7 +66,7 @@ export function TierWidthsField({ store, fieldKey }: FieldProps) {
                 commit(next);
               }}
             />
-          </ThemeRow>
+          </SettingRow>
         );
       })}
     </>

--- a/app/src/components/TierWidthsField.tsx
+++ b/app/src/components/TierWidthsField.tsx
@@ -37,7 +37,7 @@ export function TierWidthsField({ store, fieldKey }: FieldProps) {
             resetSlot={
               <button
                 type="button"
-                class="theme-row-reset"
+                class="setting-row-reset"
                 title={`Default: ${defaultWidth}`}
                 aria-label="Reset to default"
                 disabled={disabled}

--- a/app/src/components/TierWidthsField.tsx
+++ b/app/src/components/TierWidthsField.tsx
@@ -49,7 +49,7 @@ export function TierWidthsField({ store, fieldKey }: FieldProps) {
                   commit(next);
                 }}
               >
-                <RotateCcw class="lucide-icon" />
+                <RotateCcw class="icon" />
               </button>
             }
           >

--- a/app/src/components/Toggle/Toggle.css
+++ b/app/src/components/Toggle/Toggle.css
@@ -1,7 +1,7 @@
 /* ── Toggle ── */
 
 /* Boolean toggle — native checkbox styled to match the brand blue. */
-.theme-toggle {
+.setting-toggle {
   width: 16px;
   height: 16px;
   cursor: pointer;

--- a/app/src/components/Toggle/Toggle.tsx
+++ b/app/src/components/Toggle/Toggle.tsx
@@ -14,7 +14,7 @@ export function Toggle({ checked, onCommit, describedBy, id }: ToggleProps) {
   return (
     <input
       type="checkbox"
-      class="theme-toggle"
+      class="setting-toggle"
       id={id}
       checked={checked}
       aria-describedby={describedBy}

--- a/app/src/constants/storage.ts
+++ b/app/src/constants/storage.ts
@@ -19,4 +19,6 @@ export const PERSISTED_KEYS = {
   LEFT_SIDEBAR_WIDTH: 'leftSidebarWidth',
   /** Right (file/commit/street pane) sidebar drag-handle width in px. */
   RIGHT_SIDEBAR_WIDTH: 'rightSidebarWidth',
+  /** Per-repo UI exclude lists (repo key -> rel-paths hidden from the city). */
+  EXCLUDES: 'excludes',
 } as const;

--- a/app/src/constants/urlParams.ts
+++ b/app/src/constants/urlParams.ts
@@ -10,4 +10,6 @@ export const URL_PARAMS = {
   BRANCH: 'branch',
   /** When 'true', forces a fresh server-side scan (bypasses the scan cache). */
   NO_CACHE: 'no_cache',
+  /** Repeated rel-path the UI hides from the rendered city (client-side pref). */
+  EXCLUDE: 'exclude',
 } as const;

--- a/app/src/hooks/useManifestSource.ts
+++ b/app/src/hooks/useManifestSource.ts
@@ -38,6 +38,8 @@ import {
 import { SERVER_CONFIG } from '@/state/stores/serverConfig';
 import { MANIFEST, setManifest, markError } from '@/state/stores/manifest';
 import { SCAN_PROGRESS } from '@/state/stores/scanProgress';
+import { activeExcludePathsFor, ACTIVE_EXCLUDES } from '@/state/stores/excludes';
+import { sourceKey } from '@/state/stores/source';
 import { srcKind, SourceKind, srcNeedsBranch } from '@/utils/sources';
 import { isEmptyManifest } from '@/utils/manifest';
 import { URL_PARAMS } from '@/constants/urlParams';
@@ -147,6 +149,7 @@ export async function loadSource(payload: SourcePayload): Promise<void> {
       src: payload.src,
       branch: payload.branch,
       noCache: !!payload.skipCache,
+      exclude: activeExcludePathsFor(payload.src),
     });
     // Publish the skeleton as it streams (early structure, behind the overlay);
     // the final is published below, AFTER committing the source.
@@ -233,16 +236,22 @@ interface SignatureResponse {
  * error). The loop no-ops until a source is loaded and yields (via loadGeneration
  * + the SCAN_PROGRESS gate) while a foreground load is in flight, so an update
  * firing mid-load can't clobber the world being loaded. Returns a dispose fn
- * (stop timer + tear down the ENABLED effect). Gated on LIVE_UPDATES.ENABLED.
+ * (stop timer + tear down the ENABLED effect + the exclude-refresh reaction).
+ * The poll loop itself is gated on LIVE_UPDATES.ENABLED, but the exclude-refresh
+ * reaction below is NOT — it's the only trigger for an exclude edit and must run
+ * regardless of the live-update toggle. Exported so the exclude-refresh reaction
+ * is directly testable.
  */
-function setupLiveUpdates(): () => void {
+export function setupLiveUpdates(): () => void {
   let timer: number | null = null;
   let inFlight = false;
 
   async function fetchAndApply(src: string, branch: string | undefined): Promise<void> {
     const myGen = loadGeneration; // capture; a foreground load bumping this drops our write
     try {
-      for await (const event of streamManifest(manifestUrlFor({ src, branch }))) {
+      for await (const event of streamManifest(
+        manifestUrlFor({ src, branch, exclude: activeExcludePathsFor(src) })
+      )) {
         if (event.phase === ScanPhase.Error) throw new Error(event.error);
         // Live-update path: skip skeleton. The city is already drawn; applying
         // a skeleton would animate every building to placeholder heights and
@@ -272,7 +281,9 @@ function setupLiveUpdates(): () => void {
     const applied = (current as Manifest).signature;
     inFlight = true;
     try {
-      const sigResp = await fetch(signatureUrlFor(cur.src, cur.branch));
+      const sigResp = await fetch(
+        signatureUrlFor(cur.src, cur.branch, activeExcludePathsFor(cur.src))
+      );
       if (!sigResp.ok) return;
       const sig: SignatureResponse | null = await sigResp.json();
       if (!sig?.signature || sig.signature === applied) return;
@@ -302,9 +313,32 @@ function setupLiveUpdates(): () => void {
     else stop();
   });
 
+  // Re-fetch the loaded source in place when ITS exclude set changes. The poll
+  // is gated by LIVE_UPDATES.ENABLED (default off), so excludes need their own
+  // trigger. Uses fetchAndApply (final-only, no overlay/skeleton) for a smooth
+  // in-place update. Key-guarded: ACTIVE_EXCLUDES also recomputes on a source
+  // switch (repo key changes) — only a same-repo list change refreshes.
+  let lastExcludeKey: string | null = null;
+  const disposeExcludeRefresh = effect(() => {
+    const serialized = ACTIVE_EXCLUDES.value.join('\n');
+    const cur = CURRENT_SOURCE.peek();
+    const repoKey = cur ? sourceKey(cur.src) : null;
+    const nextKey = repoKey === null ? null : `${repoKey}|${serialized}`;
+    const prev = lastExcludeKey;
+    lastExcludeKey = nextKey;
+    if (prev === null || nextKey === null) return; // first run / no source
+    const [prevRepo] = prev.split('|', 1);
+    if (prevRepo !== repoKey) return; // source switched — the load owns it
+    if (prev === nextKey) return; // no actual change
+    if (SCAN_PROGRESS.peek() !== null) return; // yield to a foreground load
+    if (!cur) return;
+    void fetchAndApply(cur.src, cur.branch);
+  });
+
   return () => {
     stop();
     disposeEnabledEffect();
+    disposeExcludeRefresh();
   };
 }
 

--- a/app/src/hooks/useManifestSource.ts
+++ b/app/src/hooks/useManifestSource.ts
@@ -332,7 +332,11 @@ export function setupLiveUpdates(): () => void {
     if (prev === nextKey) return; // no actual change
     if (SCAN_PROGRESS.peek() !== null) return; // yield to a foreground load
     if (!cur) return;
-    void fetchAndApply(cur.src, cur.branch);
+    if (inFlight) return; // the poll's tick is already covering this refresh
+    inFlight = true;
+    void fetchAndApply(cur.src, cur.branch).finally(() => {
+      inFlight = false;
+    });
   });
 
   return () => {

--- a/app/src/hooks/useSettings.ts
+++ b/app/src/hooks/useSettings.ts
@@ -96,7 +96,7 @@ export function useAnyDiffersFromDefault(store: SignalLike, keys: string[]): boo
  * differing from its default. Draft-aware — tracks DRAFTS_REV + each store's
  * value, so it re-runs on any draft or committed change. Used by the
  * Section / Subgroup reset buttons over their descendant fields
- * (replaces the old DOM-scrape that read each `.theme-row-reset`'s disabled).
+ * (replaces the old DOM-scrape that read each `.setting-row-reset`'s disabled).
  */
 export function useAnyResettable(refs: ResettableRef[]): boolean {
   void DRAFTS_REV.value;

--- a/app/src/layout/AppHeader/AppHeader.tsx
+++ b/app/src/layout/AppHeader/AppHeader.tsx
@@ -100,7 +100,7 @@ export function AppHeader({
             aria-label="Debug tools"
             onClick={openDebug}
           >
-            <Bug class="lucide-icon" />
+            <Bug class="icon" />
           </button>
         )}
         <button
@@ -110,7 +110,7 @@ export function AppHeader({
           aria-label="Keyboard shortcuts"
           onClick={openShortcuts}
         >
-          <Keyboard class="lucide-icon" />
+          <Keyboard class="icon" />
         </button>
       </div>
     </header>

--- a/app/src/layout/LeftSidebar/LeftSidebar.css
+++ b/app/src/layout/LeftSidebar/LeftSidebar.css
@@ -96,15 +96,18 @@
   position: absolute;
   top: var(--cc-space-1);
   right: var(--cc-space-1);
-  min-width: 14px;
-  height: 14px;
+  min-width: 16px;
+  height: 16px;
   padding: 0 var(--cc-space-1);
   display: flex;
   align-items: center;
   justify-content: center;
+  /* Surface fill (opaque, covers the glyph) + accent border + accent text reads
+   * cleaner at this size than solid accent with white text. */
   border-radius: var(--cc-radius-pill);
-  background: var(--cc-accent);
-  color: var(--cc-white);
+  background: var(--cc-bg-sidebar);
+  border: 1px solid var(--cc-accent-border);
+  color: var(--cc-accent);
   font-size: var(--cc-font-2xs);
   font-weight: var(--cc-fw-medium);
   line-height: 1;

--- a/app/src/layout/LeftSidebar/LeftSidebar.css
+++ b/app/src/layout/LeftSidebar/LeftSidebar.css
@@ -62,6 +62,7 @@
 }
 
 .activity-bar-icon {
+  position: relative; /* anchor for the settings-change count badge */
   background: none;
   border: none;
   color: var(--cc-text-muted);
@@ -86,6 +87,38 @@
 .activity-bar-icon.active {
   color: var(--cc-accent);
   background: var(--cc-accent-bg-soft);
+}
+
+/* Count of settings + excludes changed from default, badged over the Settings
+ * icon. Remounted with a key on the count (LeftSidebar.tsx), so it replays the
+ * pop each time the number changes — the "something was customized" cue. */
+.activity-bar-badge {
+  position: absolute;
+  top: var(--cc-space-1);
+  right: var(--cc-space-1);
+  min-width: 14px;
+  height: 14px;
+  padding: 0 var(--cc-space-1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--cc-radius-pill);
+  background: var(--cc-accent);
+  color: var(--cc-white);
+  font-size: var(--cc-font-2xs);
+  font-weight: var(--cc-fw-medium);
+  line-height: 1;
+  pointer-events: none;
+  animation: cc-badge-pop var(--cc-t-base) ease-out;
+}
+
+@keyframes cc-badge-pop {
+  from {
+    transform: scale(1.5);
+  }
+  to {
+    transform: scale(1);
+  }
 }
 
 /* Lucide glyph sizing: CSS width/height override the SVG's own size attrs so

--- a/app/src/layout/LeftSidebar/LeftSidebar.css
+++ b/app/src/layout/LeftSidebar/LeftSidebar.css
@@ -102,21 +102,33 @@
   border-radius: var(--cc-radius-circle);
   background: var(--cc-accent);
   pointer-events: none;
-  animation: cc-dot-ring 1.2s ease-out;
+  animation: cc-dot-pulse 0.6s ease-out;
 }
 
-@keyframes cc-dot-ring {
+/* Bold scale bounce so a change is unmistakable at this size. */
+@keyframes cc-dot-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(2);
+  }
+}
+
+/* Reduced motion: keep a cue, but a quick opacity flash instead of scaling. */
+@keyframes cc-dot-flash {
   from {
-    box-shadow: 0 0 0 0 var(--cc-accent-bg);
+    opacity: 0.25;
   }
   to {
-    box-shadow: 0 0 0 7px transparent;
+    opacity: 1;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .activity-bar-dot {
-    animation: none;
+    animation-name: cc-dot-flash;
   }
 }
 

--- a/app/src/layout/LeftSidebar/LeftSidebar.css
+++ b/app/src/layout/LeftSidebar/LeftSidebar.css
@@ -89,38 +89,34 @@
   background: var(--cc-accent-bg-soft);
 }
 
-/* Count of settings + excludes changed from default, badged over the Settings
- * icon. Remounted with a key on the count (LeftSidebar.tsx), so it replays the
- * pop each time the number changes — the "something was customized" cue. */
-.activity-bar-badge {
+/* "Settings differ from default" dot over the Settings icon. Remounted with a
+ * key on the total (LeftSidebar.tsx), so it replays the expanding ring each time
+ * the count changes — the "something was customized" cue. The per-tab counts
+ * live on the subtabs. */
+.activity-bar-dot {
   position: absolute;
-  top: var(--cc-space-1);
-  right: var(--cc-space-1);
-  min-width: 16px;
-  height: 16px;
-  padding: 0 var(--cc-space-1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  /* Surface fill (opaque, covers the glyph) + accent border + accent text reads
-   * cleaner at this size than solid accent with white text. */
-  border-radius: var(--cc-radius-pill);
-  background: var(--cc-bg-sidebar);
-  border: 1px solid var(--cc-accent-border);
-  color: var(--cc-accent);
-  font-size: var(--cc-font-2xs);
-  font-weight: var(--cc-fw-medium);
-  line-height: 1;
+  top: var(--cc-space-2);
+  right: var(--cc-space-2);
+  width: var(--cc-space-3);
+  height: var(--cc-space-3);
+  border-radius: var(--cc-radius-circle);
+  background: var(--cc-accent);
   pointer-events: none;
-  animation: cc-badge-pop var(--cc-t-base) ease-out;
+  animation: cc-dot-ring 1.2s ease-out;
 }
 
-@keyframes cc-badge-pop {
+@keyframes cc-dot-ring {
   from {
-    transform: scale(1.5);
+    box-shadow: 0 0 0 0 var(--cc-accent-bg);
   }
   to {
-    transform: scale(1);
+    box-shadow: 0 0 0 7px transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-bar-dot {
+    animation: none;
   }
 }
 

--- a/app/src/layout/LeftSidebar/LeftSidebar.css
+++ b/app/src/layout/LeftSidebar/LeftSidebar.css
@@ -105,24 +105,28 @@
   animation: cc-dot-pulse 0.6s ease-out;
 }
 
-/* Bold scale bounce so a change is unmistakable at this size. */
+/* Bold scale bounce + a white flash at the peak so a change is unmistakable. */
 @keyframes cc-dot-pulse {
   0%,
   100% {
     transform: scale(1);
+    background-color: var(--cc-accent);
   }
   35% {
     transform: scale(2);
+    background-color: var(--cc-white);
   }
 }
 
-/* Reduced motion: keep a cue, but a quick opacity flash instead of scaling. */
+/* Reduced motion: keep the white flash (a color change, not vestibular motion)
+ * without the scale bounce. */
 @keyframes cc-dot-flash {
-  from {
-    opacity: 0.25;
+  0%,
+  100% {
+    background-color: var(--cc-accent);
   }
-  to {
-    opacity: 1;
+  50% {
+    background-color: var(--cc-white);
   }
 }
 

--- a/app/src/layout/LeftSidebar/LeftSidebar.tsx
+++ b/app/src/layout/LeftSidebar/LeftSidebar.tsx
@@ -60,30 +60,29 @@ function ActivityBar({ activeTab, collapsed, onIconClick }: ActivityBarProps) {
   const tabs = ACTIVITY_BAR_TABS;
   const topTabs = tabs.filter((t) => t.placement !== TabPlacement.Bottom);
   const bottomTabs = tabs.filter((t) => t.placement === TabPlacement.Bottom);
-  // Count of settings + excludes that differ from default; badged on the
-  // Settings icon so a customized render is discoverable from anywhere.
+  // Total settings + excludes that differ from default. The Settings icon shows
+  // a single dirty dot (the per-tab counts live on the subtabs); a customized
+  // render stays discoverable from anywhere.
   const changedCount = CHANGED_SETTINGS_COUNT.value;
 
   const renderTab = (tab: (typeof tabs)[number]) => {
     const isActive = !collapsed && tab.id === activeTab;
-    const showBadge = tab.id === SidebarTab.Controls && changedCount > 0;
+    const showDot = tab.id === SidebarTab.Controls && changedCount > 0;
     return (
       <button
         key={tab.id}
         type="button"
         class={`activity-bar-icon${isActive ? ' active' : ''}`}
         data-tab={tab.id}
-        title={showBadge ? `${tab.title} (${changedCount} changed from default)` : tab.title}
-        aria-label={showBadge ? `${tab.title}, ${changedCount} changed from default` : tab.title}
+        title={showDot ? `${tab.title} (${changedCount} changed from default)` : tab.title}
+        aria-label={showDot ? `${tab.title}, ${changedCount} changed from default` : tab.title}
         aria-pressed={isActive}
         onClick={() => onIconClick(tab.id)}
       >
         <tab.icon class="activity-bar-glyph" />
-        {showBadge && (
-          // key on the count so a change remounts the badge and replays its pulse.
-          <span key={changedCount} class="activity-bar-badge">
-            {changedCount}
-          </span>
+        {showDot && (
+          // key on the count so each change remounts the dot and replays its ring.
+          <span key={changedCount} class="activity-bar-dot" />
         )}
       </button>
     );

--- a/app/src/layout/LeftSidebar/LeftSidebar.tsx
+++ b/app/src/layout/LeftSidebar/LeftSidebar.tsx
@@ -16,6 +16,7 @@
 // they too are ported.
 
 import './LeftSidebar.css';
+import { useRef, useLayoutEffect } from 'preact/hooks';
 import { useComputed, useSignal, useSignalEffect } from '@preact/signals';
 import { ACTIVITY_BAR_TABS, DEFAULT_SIDEBAR_TAB, TabPlacement } from '@/constants/ui';
 import { CHANGED_SETTINGS_COUNT } from '@/state/stores/settingsIndicators';
@@ -46,6 +47,21 @@ function _pathOf(target: PickTarget | null): string | null {
   if (target.kind === NodeKind.File) return target.file?.path ?? null;
   if (target.kind === NodeKind.Directory) return target.dir?.path ?? null;
   return null;
+}
+
+// "Settings differ from default" dot. Replays its ring on every `count` change:
+// a keyed remount doesn't restart a CSS animation (Preact reuses the DOM node),
+// so we force it with the animation-reset + reflow trick.
+function SettingsChangeDot({ count }: { count: number }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.animation = 'none';
+    void el.offsetWidth; // reflow so the next assignment restarts the animation
+    el.style.animation = '';
+  }, [count]);
+  return <span ref={ref} class="activity-bar-dot" aria-hidden="true" />;
 }
 
 // ── ActivityBar sub-component ────────────────────────────────────────
@@ -80,10 +96,7 @@ function ActivityBar({ activeTab, collapsed, onIconClick }: ActivityBarProps) {
         onClick={() => onIconClick(tab.id)}
       >
         <tab.icon class="activity-bar-glyph" />
-        {showDot && (
-          // key on the count so each change remounts the dot and replays its ring.
-          <span key={changedCount} class="activity-bar-dot" />
-        )}
+        {showDot && <SettingsChangeDot count={changedCount} />}
       </button>
     );
   };

--- a/app/src/layout/LeftSidebar/LeftSidebar.tsx
+++ b/app/src/layout/LeftSidebar/LeftSidebar.tsx
@@ -18,6 +18,7 @@
 import './LeftSidebar.css';
 import { useComputed, useSignal, useSignalEffect } from '@preact/signals';
 import { ACTIVITY_BAR_TABS, DEFAULT_SIDEBAR_TAB, TabPlacement } from '@/constants/ui';
+import { CHANGED_SETTINGS_COUNT } from '@/state/stores/settingsIndicators';
 import { PERSISTED_KEYS } from '@/constants/storage';
 import { SidebarTab, NodeKind } from '@/types';
 import type { PickTarget, TreeNode } from '@/types';
@@ -59,21 +60,31 @@ function ActivityBar({ activeTab, collapsed, onIconClick }: ActivityBarProps) {
   const tabs = ACTIVITY_BAR_TABS;
   const topTabs = tabs.filter((t) => t.placement !== TabPlacement.Bottom);
   const bottomTabs = tabs.filter((t) => t.placement === TabPlacement.Bottom);
+  // Count of settings + excludes that differ from default; badged on the
+  // Settings icon so a customized render is discoverable from anywhere.
+  const changedCount = CHANGED_SETTINGS_COUNT.value;
 
   const renderTab = (tab: (typeof tabs)[number]) => {
     const isActive = !collapsed && tab.id === activeTab;
+    const showBadge = tab.id === SidebarTab.Controls && changedCount > 0;
     return (
       <button
         key={tab.id}
         type="button"
         class={`activity-bar-icon${isActive ? ' active' : ''}`}
         data-tab={tab.id}
-        title={tab.title}
-        aria-label={tab.title}
+        title={showBadge ? `${tab.title} (${changedCount} changed from default)` : tab.title}
+        aria-label={showBadge ? `${tab.title}, ${changedCount} changed from default` : tab.title}
         aria-pressed={isActive}
         onClick={() => onIconClick(tab.id)}
       >
         <tab.icon class="activity-bar-glyph" />
+        {showBadge && (
+          // key on the count so a change remounts the badge and replays its pulse.
+          <span key={changedCount} class="activity-bar-badge">
+            {changedCount}
+          </span>
+        )}
       </button>
     );
   };

--- a/app/src/layout/RightSidebar/RightSidebar.tsx
+++ b/app/src/layout/RightSidebar/RightSidebar.tsx
@@ -31,6 +31,7 @@ import {
   focusCommit,
 } from '@/state/stores/scene';
 import { MANIFEST } from '@/state/stores/manifest';
+import { addExclude } from '@/state/stores/excludes';
 import { FilePreviewPane } from '@/views/FilePreviewPane/FilePreviewPane';
 import type { FilePreviewPaneState } from '@/views/FilePreviewPane/FilePreviewPane';
 import { CommitPane } from '@/views/CommitPane/CommitPane';
@@ -135,6 +136,11 @@ export function RightSidebar() {
   const onCommitFocus = (commit: CommitEntry) => focusCommit(commit.sha);
   const onStreetFocus = (dir: DirNode) => focusPath(dir.path);
 
+  const onExcludeNode = (path: string) => {
+    addExclude(path);
+    clearSelection(); // the node is about to vanish from the re-fetched manifest
+  };
+
   const kind = activeKind.value;
   const open = isOpen.value;
 
@@ -147,13 +153,23 @@ export function RightSidebar() {
       widthSignal={RIGHT_SIDEBAR_WIDTH}
     >
       {kind === SidebarPaneKind.File && (
-        <FilePreviewPane state={fileState} onClose={onClose} onFocus={onFileFocus} />
+        <FilePreviewPane
+          state={fileState}
+          onClose={onClose}
+          onFocus={onFileFocus}
+          onExclude={(f) => onExcludeNode(f.path)}
+        />
       )}
       {kind === SidebarPaneKind.Commit && (
         <CommitPane state={commitState} onClose={onClose} onFocus={onCommitFocus} />
       )}
       {kind === SidebarPaneKind.Street && (
-        <StreetPane state={streetState} onClose={onClose} onFocus={onStreetFocus} />
+        <StreetPane
+          state={streetState}
+          onClose={onClose}
+          onFocus={onStreetFocus}
+          onExclude={(d) => onExcludeNode(d.path)}
+        />
       )}
     </Sidebar>
   );

--- a/app/src/state/persist.ts
+++ b/app/src/state/persist.ts
@@ -16,8 +16,13 @@ import { deepEqual, deepClone } from '@/utils/deep';
 // ── Registry ───────────────────────────────────────────────────────────────
 // One map keyed by the store signal itself; each entry holds the persisted
 // key name (localStorage suffix) and the pre-hydration default. Keying by the
-// signal (not the name) makes getDefault / HAS_ANY_NON_DEFAULT /
-// forEachRegisteredStore direct lookups — no reverse name↔signal scan.
+// signal (not the name) makes getDefault a direct lookup — no reverse
+// name↔signal scan. This is EVERY persisted store (e.g. EXCLUDES, recents,
+// sidebar width). The narrower "which of these are panel-owned settings"
+// registry (_SETTING_STORES, with its own HAS_ANY_NON_DEFAULT/
+// forEachSettingStore) lives in settingsSchema.ts — "Reset all settings"
+// iterates that one, so a store only in _STORES (like EXCLUDES) is untouched
+// by it.
 interface StoreEntry {
   name: string;
   default: any;

--- a/app/src/state/persist.ts
+++ b/app/src/state/persist.ts
@@ -111,10 +111,20 @@ function _serialize<T>(value: T, defaultValue: T): unknown {
  * storage immediately at module load. Writes back on every change (diff-vs-
  * default for object-valued signals; whole value for scalar/array).
  *
+ * `opts.whole` opts an object-valued signal out of diff-vs-default and stores
+ * the whole object instead. Required for dynamic-key `Record` stores whose keys
+ * are runtime values (not present in the default), which diff mode would drop:
+ * diff mode only emits/reads keys that exist in the default. An empty object
+ * still deep-equals the default and removes the slot, same as diff mode.
+ *
  * The `key` string is the localStorage suffix after `cc.` — keep it stable
  * across deploys so existing users don't lose their settings.
  */
-export function persistedSignal<T>(key: string, defaultValue: T): Signal<T> {
+export function persistedSignal<T>(
+  key: string,
+  defaultValue: T,
+  opts?: { whole?: boolean }
+): Signal<T> {
   if (typeof localStorage === 'undefined') {
     // SSR / test environment without localStorage — return a plain signal.
     const s = signal<T>(defaultValue);
@@ -122,13 +132,18 @@ export function persistedSignal<T>(key: string, defaultValue: T): Signal<T> {
     return s;
   }
   const saved = _safeGet(key);
-  const initial = saved !== null ? _hydrate(saved, defaultValue) : defaultValue;
+  const initial =
+    saved !== null ? (opts?.whole ? (saved as T) : _hydrate(saved, defaultValue)) : defaultValue;
   const s = signal<T>(initial);
   _STORES.set(s, { name: key, default: deepClone(defaultValue) });
 
   effect(() => {
     const v = s.value;
-    const serialized = _serialize(v, defaultValue);
+    const serialized = opts?.whole
+      ? deepEqual(v, defaultValue)
+        ? null
+        : v
+      : _serialize(v, defaultValue);
     if (serialized === null) _safeRemove(key);
     else _safeSet(key, serialized);
   });

--- a/app/src/state/stores/excludes.ts
+++ b/app/src/state/stores/excludes.ts
@@ -1,0 +1,61 @@
+// state/stores/excludes.ts — Per-repo UI excludes: rel-paths the user hides from
+// the rendered city. Persisted client-side (like recents) so remote URLs work
+// without a .codecityignore on disk. Repo-scoped (keyed by src, branch ignored)
+// so an exclude holds across branches. These are PREFERENCES only: the backend
+// re-derives the filtered manifest from them (see useManifestSource), so there
+// is no client-side manifest filtering here.
+
+import { computed, type ReadonlySignal } from '@preact/signals';
+import { persistedSignal } from '@/state/persist';
+import { PERSISTED_KEYS } from '@/constants/storage';
+import { CURRENT_SOURCE, sourceKey } from '@/state/stores/source';
+
+/** repo key -> sorted, de-duped rel-paths. One localStorage slot for all repos. */
+export const EXCLUDES = persistedSignal<Record<string, string[]>>(PERSISTED_KEYS.EXCLUDES, {});
+
+/** Repo-scoped key: src only (branch ignored) so excludes hold across branches. */
+function repoKeyFor(src: string): string {
+  return sourceKey(src);
+}
+
+function currentRepoKey(): string | null {
+  const cur = CURRENT_SOURCE.value;
+  return cur ? repoKeyFor(cur.src) : null;
+}
+
+/** The loaded repo's exclude list (empty when no source / none set). Reactive. */
+export const ACTIVE_EXCLUDES: ReadonlySignal<string[]> = computed(() => {
+  const key = currentRepoKey();
+  return key ? (EXCLUDES.value[key] ?? []) : [];
+});
+
+/** Peek the excludes for an explicit src — for the imperative fetch layer. */
+export function activeExcludePathsFor(src: string): string[] {
+  return EXCLUDES.peek()[repoKeyFor(src)] ?? [];
+}
+
+function setForCurrentRepo(next: string[]): void {
+  const cur = CURRENT_SOURCE.peek();
+  if (!cur) return; // no source loaded: nothing to key against
+  const key = repoKeyFor(cur.src);
+  const sorted = [...new Set(next)].sort();
+  const map = { ...EXCLUDES.peek() };
+  if (sorted.length === 0) delete map[key];
+  else map[key] = sorted;
+  EXCLUDES.value = map;
+}
+
+/** Hide `path` from the current repo's city. Sorted + de-duped. No-op if none. */
+export function addExclude(path: string): void {
+  setForCurrentRepo([...(EXCLUDES.peek()[currentRepoKey() ?? ''] ?? []), path]);
+}
+
+/** Restore `path` (remove from the current repo's excludes). */
+export function removeExclude(path: string): void {
+  setForCurrentRepo((EXCLUDES.peek()[currentRepoKey() ?? ''] ?? []).filter((p) => p !== path));
+}
+
+/** Restore everything for the current repo. */
+export function clearExcludes(): void {
+  setForCurrentRepo([]);
+}

--- a/app/src/state/stores/excludes.ts
+++ b/app/src/state/stores/excludes.ts
@@ -10,8 +10,14 @@ import { persistedSignal } from '@/state/persist';
 import { PERSISTED_KEYS } from '@/constants/storage';
 import { CURRENT_SOURCE, sourceKey } from '@/state/stores/source';
 
-/** repo key -> sorted, de-duped rel-paths. One localStorage slot for all repos. */
-export const EXCLUDES = persistedSignal<Record<string, string[]>>(PERSISTED_KEYS.EXCLUDES, {});
+/** repo key -> sorted, de-duped rel-paths. One localStorage slot for all repos.
+ *  Whole-object persistence: keys are runtime repo hashes, not in the default,
+ *  so diff-vs-default mode would drop every write. */
+export const EXCLUDES = persistedSignal<Record<string, string[]>>(
+  PERSISTED_KEYS.EXCLUDES,
+  {},
+  { whole: true }
+);
 
 /** Repo-scoped key: src only (branch ignored) so excludes hold across branches. */
 function repoKeyFor(src: string): string {

--- a/app/src/state/stores/settings/buildings.ts
+++ b/app/src/state/stores/settings/buildings.ts
@@ -59,6 +59,16 @@ const BUILDING_DIMENSIONS_FIELDS = {
     label: 'Max floors',
     tip: 'Floors for the largest file, the top of the height range. Above ~200 the tallest buildings dwarf the city.',
   },
+  FULL_HEIGHT_LINES: {
+    route: ChangeRoute.Rebuild,
+    kind: FieldKind.Slider,
+    default: 2000,
+    min: 100,
+    max: 10000,
+    step: 100,
+    label: 'Full height at (lines)',
+    tip: 'Line count that earns a max-floors building. A repo whose largest file is smaller stays proportionally shorter, so a repo of tiny files reads as a low-rise city rather than being stretched to full height.',
+  },
   FLOOR_HEIGHT: {
     route: ChangeRoute.Rebuild,
     kind: FieldKind.Slider,
@@ -88,6 +98,16 @@ const BUILDING_DIMENSIONS_FIELDS = {
     step: 1,
     label: 'Max width',
     tip: 'Footprint width for the largest file, the top of the width range.',
+  },
+  FULL_WIDTH_KB: {
+    route: ChangeRoute.Rebuild,
+    kind: FieldKind.Slider,
+    default: 64,
+    min: 1,
+    max: 1024,
+    step: 1,
+    label: 'Full width at (KB)',
+    tip: 'File size that earns a max-width footprint. A repo whose largest file is smaller keeps proportionally narrower footprints.',
   },
   DISTANCE_FROM_ROAD: {
     route: ChangeRoute.Rebuild,

--- a/app/src/state/stores/settingsIndicators.ts
+++ b/app/src/state/stores/settingsIndicators.ts
@@ -1,0 +1,76 @@
+// state/stores/settingsIndicators.ts — "how customized is this render" signals
+// that drive the Settings badge (a total count) and the per-tab change dots.
+//
+// A setting counts as changed when its committed value differs from its
+// registered default. Excludes aren't settings-draft stores, so they're folded
+// in explicitly against the Scan tab (and the total). Per-tab grouping mirrors
+// the ControlsPane subtabs: Scan = live-updates + excludes, Appearance = the
+// three theme pickers, World = every other registered store.
+
+import { computed } from '@preact/signals';
+import { forEachSettingStore, getFieldKeys } from '@/state/settingsSchema';
+import { getDefault } from '@/state/persist';
+import { deepEqual } from '@/utils/deep';
+import { LIVE_UPDATES } from '@/state/stores/settings/updates';
+import { ACCENT_THEME, SURFACE_THEME } from '@/state/stores/settings/theme';
+import { SYNTAX_THEME } from '@/state/stores/settings/syntaxTheme';
+import { ACTIVE_EXCLUDES } from '@/state/stores/excludes';
+
+type AnyStore = { value: unknown };
+
+const SCAN_STORES: AnyStore[] = [LIVE_UPDATES as AnyStore];
+const APPEARANCE_STORES: AnyStore[] = [
+  ACCENT_THEME as AnyStore,
+  SURFACE_THEME as AnyStore,
+  SYNTAX_THEME as AnyStore,
+];
+
+/** Number of a store's fields that differ from default. Scalar stores (the theme
+ *  pickers register no field map) count as one whole value; field-map stores
+ *  count per field. Reads `store.value`, so callers inside a computed track it. */
+function changedFieldCount(store: AnyStore): number {
+  const keys = getFieldKeys(store);
+  if (keys.length === 0) {
+    return deepEqual(store.value, getDefault(store)) ? 0 : 1;
+  }
+  const val = store.value as Record<string, unknown>;
+  let n = 0;
+  for (const k of keys) {
+    if (!deepEqual(val[k], getDefault(store, k))) n++;
+  }
+  return n;
+}
+
+function anyChanged(stores: AnyStore[]): boolean {
+  return stores.some((s) => changedFieldCount(s) > 0);
+}
+
+/** Total settings changed from default across every tab, plus the exclude count.
+ *  Drives the count badge on the Settings activity-bar entry. */
+export const CHANGED_SETTINGS_COUNT = computed(() => {
+  let n = 0;
+  forEachSettingStore((store) => {
+    n += changedFieldCount(store);
+  });
+  return n + ACTIVE_EXCLUDES.value.length;
+});
+
+/** Scan tab has a change: live-update settings differ, or something is excluded. */
+export const SCAN_CHANGED = computed(
+  () => anyChanged(SCAN_STORES) || ACTIVE_EXCLUDES.value.length > 0
+);
+
+/** Appearance tab has a change: any of the three theme pickers differ. */
+export const APPEARANCE_CHANGED = computed(() => anyChanged(APPEARANCE_STORES));
+
+/** World tab has a change: any registered store that isn't a Scan/Appearance
+ *  store differs. Derived from the registry so new World stores are covered
+ *  without listing them here. */
+export const WORLD_CHANGED = computed(() => {
+  let changed = false;
+  forEachSettingStore((store) => {
+    if (SCAN_STORES.includes(store) || APPEARANCE_STORES.includes(store)) return;
+    if (changedFieldCount(store) > 0) changed = true;
+  });
+  return changed;
+});

--- a/app/src/state/stores/settingsIndicators.ts
+++ b/app/src/state/stores/settingsIndicators.ts
@@ -1,11 +1,12 @@
-// state/stores/settingsIndicators.ts — "how customized is this render" signals
-// that drive the Settings badge (a total count) and the per-tab change dots.
+// state/stores/settingsIndicators.ts — "how customized is this render" signals.
+// Each subtab shows its own count of changed-from-default settings; the Settings
+// activity-bar icon shows a single dirty dot (CHANGED_SETTINGS_COUNT > 0).
 //
 // A setting counts as changed when its committed value differs from its
 // registered default. Excludes aren't settings-draft stores, so they're folded
-// in explicitly against the Scan tab (and the total). Per-tab grouping mirrors
-// the ControlsPane subtabs: Scan = live-updates + excludes, Appearance = the
-// three theme pickers, World = every other registered store.
+// into the Scan count explicitly. Per-tab grouping mirrors the ControlsPane
+// subtabs: Scan = live-updates + excludes, Appearance = the three theme pickers,
+// World = every other registered store.
 
 import { computed } from '@preact/signals';
 import { forEachSettingStore, getFieldKeys } from '@/state/settingsSchema';
@@ -41,36 +42,28 @@ function changedFieldCount(store: AnyStore): number {
   return n;
 }
 
-function anyChanged(stores: AnyStore[]): boolean {
-  return stores.some((s) => changedFieldCount(s) > 0);
+function countStores(stores: AnyStore[]): number {
+  return stores.reduce((n, s) => n + changedFieldCount(s), 0);
 }
 
-/** Total settings changed from default across every tab, plus the exclude count.
- *  Drives the count badge on the Settings activity-bar entry. */
-export const CHANGED_SETTINGS_COUNT = computed(() => {
+/** Scan tab: changed live-update settings + the number of excluded paths. */
+export const SCAN_COUNT = computed(() => countStores(SCAN_STORES) + ACTIVE_EXCLUDES.value.length);
+
+/** Appearance tab: changed theme pickers (accent / surface / syntax). */
+export const APPEARANCE_COUNT = computed(() => countStores(APPEARANCE_STORES));
+
+/** World tab: every registered store that isn't a Scan/Appearance store.
+ *  Derived from the registry so new World stores are covered automatically. */
+export const WORLD_COUNT = computed(() => {
   let n = 0;
   forEachSettingStore((store) => {
+    if (SCAN_STORES.includes(store) || APPEARANCE_STORES.includes(store)) return;
     n += changedFieldCount(store);
   });
-  return n + ACTIVE_EXCLUDES.value.length;
+  return n;
 });
 
-/** Scan tab has a change: live-update settings differ, or something is excluded. */
-export const SCAN_CHANGED = computed(
-  () => anyChanged(SCAN_STORES) || ACTIVE_EXCLUDES.value.length > 0
+/** Total across every tab. Drives the dirty dot on the Settings icon. */
+export const CHANGED_SETTINGS_COUNT = computed(
+  () => SCAN_COUNT.value + APPEARANCE_COUNT.value + WORLD_COUNT.value
 );
-
-/** Appearance tab has a change: any of the three theme pickers differ. */
-export const APPEARANCE_CHANGED = computed(() => anyChanged(APPEARANCE_STORES));
-
-/** World tab has a change: any registered store that isn't a Scan/Appearance
- *  store differs. Derived from the registry so new World stores are covered
- *  without listing them here. */
-export const WORLD_CHANGED = computed(() => {
-  let changed = false;
-  forEachSettingStore((store) => {
-    if (SCAN_STORES.includes(store) || APPEARANCE_STORES.includes(store)) return;
-    if (changedFieldCount(store) > 0) changed = true;
-  });
-  return changed;
-});

--- a/app/src/styles/buttons.css
+++ b/app/src/styles/buttons.css
@@ -5,8 +5,8 @@
    .btn-secondary     — outlined neutral (modifier on .btn-accent-outline).
    .btn-accent-outline — accent-tinted outlined (controls-pane Save / debug).
    .btn-icon          — 24x24 icon-only button.
-   .btn-toggle        — one-of-N option button (segmented / theme-select).
-   .btn-reset-inline  — tiny inline reset (controls-section + theme-row).
+   .btn-toggle        — one-of-N option button (segmented / setting-select).
+   .btn-reset-inline  — tiny inline reset (controls-section + setting-row).
    ═══════════════════════════════════════════════════════════════════════════ */
 
 /* .btn-primary — solid accent CTA. Used everywhere a "primary action"
@@ -189,7 +189,7 @@
    Base shell + active state. The `.is-active` class flips the option to
    the accent-tinted "selected" look. Modifiers:
      .btn-toggle--separated — adds vertical separator borders between
-       sibling options, used by the controls-pane theme-select where the
+       sibling options, used by the controls-pane setting-select where the
        buttons sit edge-to-edge inside a bordered shell. */
 .btn-toggle {
   appearance: none;
@@ -214,7 +214,7 @@
   color: var(--cc-text-strong);
 }
 /* .btn-toggle--separated — modifier that adds a vertical separator
-   between sibling options. Used inside .theme-select where the buttons
+   between sibling options. Used inside .setting-select where the buttons
    sit edge-to-edge. Also tightens the padding + font for the dense
    inline-flex shell, and adds a soft hover background. */
 .btn-toggle--separated {

--- a/app/src/styles/chevron.css
+++ b/app/src/styles/chevron.css
@@ -1,7 +1,7 @@
 /* ═══════════════════════════════════════════════════════════════════════════
    LAYER-2 COMPONENTS — Chevron
    ═══════════════════════════════════════════════════════════════════════════
-   Disclosure chevron — shared by the controls-section and theme-subgroup
+   Disclosure chevron — shared by the controls-section and setting-subgroup
    <details> summaries. Width matches the standard icon column so labels at all
    depths line up. The open state is driven purely by the parent <details open>
    (the rotate override lives with each owning component).

--- a/app/src/styles/empty-state.css
+++ b/app/src/styles/empty-state.css
@@ -19,14 +19,14 @@
   color: var(--cc-text-muted);
   text-align: center;
 }
-.empty-state .lucide-icon {
+.empty-state .icon {
   opacity: 0.55;
   font-size: var(--cc-font-xl);
   margin-bottom: var(--cc-space-1);
 }
 /* Large variant — bigger gap + padding + icon. Used by the file-preview
    pane and the info pane's empty / error states. */
-.empty-state--lg .lucide-icon {
+.empty-state--lg .icon {
   font-size: var(--cc-font-2xl);
   margin-bottom: var(--cc-space-2);
 }

--- a/app/src/styles/icons.css
+++ b/app/src/styles/icons.css
@@ -1,12 +1,13 @@
 /* ═══════════════════════════════════════════════════════════════════════════
-   LAYER-2 COMPONENTS — Lucide icon
+   LAYER-2 COMPONENTS — inline icon
    ═══════════════════════════════════════════════════════════════════════════
-   Lucide icons render as inline SVG (lucide-preact) with stroke=currentColor,
-   so they inherit the parent's text color — no mask needed. The smaller inline
-   default sizing for tree rows + buttons.
+   Library-neutral sizing hook for inline SVG icons: whatever icon set is in use
+   renders with stroke=currentColor, so icons inherit the parent's text color (no
+   mask needed). Keep this class name free of the icon library so swapping the
+   library never means touching every call site's markup.
    ═══════════════════════════════════════════════════════════════════════════ */
 
-.lucide-icon {
+.icon {
   display: inline-block;
   width: 1em;
   height: 1em;

--- a/app/src/types/manifest.generated.ts
+++ b/app/src/types/manifest.generated.ts
@@ -759,6 +759,7 @@ export interface operations {
                 src: string;
                 branch?: string | null;
                 no_cache?: boolean;
+                exclude?: string[];
             };
             header?: never;
             path?: never;
@@ -824,6 +825,7 @@ export interface operations {
                 src?: string;
                 branch?: string | null;
                 no_cache?: boolean;
+                exclude?: string[];
             };
             header?: never;
             path?: never;

--- a/app/src/views/CommitPane/CommitPane.tsx
+++ b/app/src/views/CommitPane/CommitPane.tsx
@@ -153,7 +153,7 @@ export function CommitPane({ state, onClose, onFocus }: CommitPaneProps) {
           title="Open this commit on the origin remote"
           aria-label="Open commit on origin"
         >
-          <ExternalLink class="lucide-icon" />
+          <ExternalLink class="icon" />
         </a>
       )}
     </>

--- a/app/src/views/ControlsPane/ActionsBar/ActionsBar.tsx
+++ b/app/src/views/ControlsPane/ActionsBar/ActionsBar.tsx
@@ -39,7 +39,7 @@ export function ActionsBar() {
           disabled={!canReset}
           onClick={() => stageResetAll()}
         >
-          <RotateCcw class="lucide-icon controls-button-icon" />
+          <RotateCcw class="icon controls-button-icon" />
           Reset all
         </button>
       </div>

--- a/app/src/views/ControlsPane/ControlsPane.css
+++ b/app/src/views/ControlsPane/ControlsPane.css
@@ -17,16 +17,16 @@
  * and the field rows / descriptions beneath them line up to the right of the
  * guide at each nesting level. */
 .controls-section-summary,
-.theme-subgroup-summary,
-.controls-pane .theme-row,
-.controls-pane .theme-subgroup > .text-label {
+.setting-subgroup-summary,
+.controls-pane .setting-row,
+.controls-pane .setting-subgroup > .text-label {
   padding-left: var(--cc-ctrl-inset);
 }
 /* Headers inherit .row's side padding; drop the right pad so their reset button
  * lines up with the field-row resets + slider readouts (which sit flush at the
  * content edge). */
 .controls-section-summary,
-.theme-subgroup-summary {
+.setting-subgroup-summary {
   padding-right: 0;
 }
 /* The nested body draws the guide: margin-left centers a 1px rule under the
@@ -75,7 +75,7 @@
  * stays fully visible inside the header rather than being clipped by the scroll
  * container or a stacked neighbor. */
 .controls-section > .controls-section-summary:hover,
-.theme-subgroup-collapsible > .theme-subgroup-summary:hover {
+.setting-subgroup-collapsible > .setting-subgroup-summary:hover {
   background: color-mix(in oklch, var(--cc-white) 4%, var(--cc-bg-sidebar));
 }
 .controls-disclosure-toggle:focus-visible {

--- a/app/src/views/ControlsPane/ControlsPane.tsx
+++ b/app/src/views/ControlsPane/ControlsPane.tsx
@@ -1,17 +1,15 @@
 // views/ControlsPane/ControlsPane.tsx — "Settings" tab in the left sidebar.
 //
-// Composition shell: World, Scan, Appearance subtabs. The active subtab's
-// sections render into the scrolling body. World is draft-backed (10
-// accordion sections + the sticky Reset all/Discard/Save ActionsBar);
-// Scan and Appearance autosave. Scan holds two collapsible sections (live
-// updates polling + the excluded-from-city list); Appearance holds two
-// (interface theme + syntax) rendered inline (no footer, no <details> — a
-// one-item accordion is pointless UI, and both are single-control pickers).
-// Shortcuts and Debug moved to header-triggered modals.
+// Composition shell: Scan, Appearance, World subtabs, each carrying a "changed
+// from default" dot. The active subtab's sections render into the scrolling
+// body. Scan + Appearance autosave (their sections open by default); World is
+// draft-backed (10 collapsed accordion sections + the sticky Reset all/Discard/
+// Save ActionsBar). Shortcuts and Debug moved to header-triggered modals.
 //
 // Section / subgroup open-state is intentionally NOT persisted: when the pane
-// hides we collapse every <details> and reset the active subtab to World, so
-// the panel always reopens fresh.
+// hides we remount every section (via collapseNonce) so each returns to its
+// default open-state, and reset the active subtab to Scan, so the panel always
+// reopens fresh.
 
 import './ControlsPane.css';
 import { useEffect, useState } from 'preact/hooks';
@@ -33,6 +31,7 @@ import { FIREFLIES_SECTION } from './partials/Fireflies';
 import { EFFECTS_SECTION } from './partials/Effects';
 import { UPDATES_SECTION } from './partials/Updates';
 import { ActionsBar } from './ActionsBar/ActionsBar';
+import { SCAN_CHANGED, APPEARANCE_CHANGED, WORLD_CHANGED } from '@/state/stores/settingsIndicators';
 import { Pane } from '@/components/Pane';
 import { PaneCloseButton } from '@/components/PaneHeader/PaneHeader';
 import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
@@ -41,6 +40,8 @@ interface Subtab {
   id: string;
   label: string;
   icon: LucideIcon;
+  /** Show the "something under here differs from default" dot on the tab. */
+  indicator?: boolean;
   /** Draftable subtabs get the Save/Discard/Reset footer. */
   draftable: boolean;
   sections: SectionNode[];
@@ -66,6 +67,7 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
       id: 'updates',
       label: 'Scan',
       icon: RefreshCw,
+      indicator: SCAN_CHANGED.value,
       draftable: false,
       sections: [
         UPDATES_SECTION,
@@ -76,6 +78,7 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
       id: 'appearance',
       label: 'Appearance',
       icon: Palette,
+      indicator: APPEARANCE_CHANGED.value,
       draftable: false,
       sections: [
         { key: 'interface-theme', render: <InterfaceThemeSection /> },
@@ -86,6 +89,7 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
       id: 'world',
       label: 'World',
       icon: Boxes,
+      indicator: WORLD_CHANGED.value,
       draftable: true,
       sections: [
         CAMERA_SECTION,

--- a/app/src/views/ControlsPane/ControlsPane.tsx
+++ b/app/src/views/ControlsPane/ControlsPane.tsx
@@ -1,12 +1,13 @@
 // views/ControlsPane/ControlsPane.tsx — "Settings" tab in the left sidebar.
 //
-// Composition shell: World, Updates, Appearance subtabs. The active subtab's
+// Composition shell: World, Scan, Appearance subtabs. The active subtab's
 // sections render into the scrolling body. World is draft-backed (10
 // accordion sections + the sticky Reset all/Discard/Save ActionsBar);
-// Updates and Appearance autosave. Updates holds one section; Appearance holds
-// two (interface theme + syntax), all rendered inline (no footer, no <details>
-// — a one-item accordion is pointless UI). Shortcuts and Debug moved to
-// header-triggered modals.
+// Scan and Appearance autosave. Scan holds two collapsible sections (live
+// updates polling + the excluded-from-city list); Appearance holds two
+// (interface theme + syntax) rendered inline (no footer, no <details> — a
+// one-item accordion is pointless UI, and both are single-control pickers).
+// Shortcuts and Debug moved to header-triggered modals.
 //
 // Section / subgroup open-state is intentionally NOT persisted: when the pane
 // hides we collapse every <details> and reset the active subtab to World, so
@@ -16,6 +17,7 @@ import './ControlsPane.css';
 import { useEffect, useState } from 'preact/hooks';
 import { Boxes, RefreshCw, Palette } from 'lucide-preact';
 import type { LucideIcon } from 'lucide-preact';
+import { ExcludesSection } from './partials/ExcludesSection';
 import { FilePreviewSection } from './partials/FilePreviewSection';
 import { InterfaceThemeSection } from './partials/InterfaceThemeSection';
 import { DynamicSection, type SectionNode } from './partials';
@@ -79,10 +81,13 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
     },
     {
       id: 'updates',
-      label: 'Live updates',
+      label: 'Scan',
       icon: RefreshCw,
       draftable: false,
-      sections: [{ ...UPDATES_SECTION, inline: true }],
+      sections: [
+        UPDATES_SECTION,
+        { key: 'excludes', label: 'Excluded from city', render: <ExcludesSection /> },
+      ],
     },
     {
       id: 'appearance',

--- a/app/src/views/ControlsPane/ControlsPane.tsx
+++ b/app/src/views/ControlsPane/ControlsPane.tsx
@@ -1,7 +1,7 @@
 // views/ControlsPane/ControlsPane.tsx — "Settings" tab in the left sidebar.
 //
-// Composition shell: Scan, Appearance, World subtabs, each carrying a "changed
-// from default" dot. The active subtab's sections render into the scrolling
+// Composition shell: Scan, Appearance, World subtabs, each carrying a count of
+// its changed-from-default items. The active subtab's sections render into the scrolling
 // body. Scan + Appearance autosave (their sections open by default); World is
 // draft-backed (10 collapsed accordion sections + the sticky Reset all/Discard/
 // Save ActionsBar). Shortcuts and Debug moved to header-triggered modals.
@@ -31,7 +31,7 @@ import { FIREFLIES_SECTION } from './partials/Fireflies';
 import { EFFECTS_SECTION } from './partials/Effects';
 import { UPDATES_SECTION } from './partials/Updates';
 import { ActionsBar } from './ActionsBar/ActionsBar';
-import { SCAN_CHANGED, APPEARANCE_CHANGED, WORLD_CHANGED } from '@/state/stores/settingsIndicators';
+import { SCAN_COUNT, APPEARANCE_COUNT, WORLD_COUNT } from '@/state/stores/settingsIndicators';
 import { Pane } from '@/components/Pane';
 import { PaneCloseButton } from '@/components/PaneHeader/PaneHeader';
 import { PaneTabs } from '@/components/PaneTabs/PaneTabs';
@@ -40,8 +40,8 @@ interface Subtab {
   id: string;
   label: string;
   icon: LucideIcon;
-  /** Show the "something under here differs from default" dot on the tab. */
-  indicator?: boolean;
+  /** Count of changed-from-default items under this tab; shown as a tab badge. */
+  badge?: number;
   /** Draftable subtabs get the Save/Discard/Reset footer. */
   draftable: boolean;
   sections: SectionNode[];
@@ -67,7 +67,7 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
       id: 'updates',
       label: 'Scan',
       icon: RefreshCw,
-      indicator: SCAN_CHANGED.value,
+      badge: SCAN_COUNT.value,
       draftable: false,
       sections: [
         UPDATES_SECTION,
@@ -78,7 +78,7 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
       id: 'appearance',
       label: 'Appearance',
       icon: Palette,
-      indicator: APPEARANCE_CHANGED.value,
+      badge: APPEARANCE_COUNT.value,
       draftable: false,
       sections: [
         { key: 'interface-theme', render: <InterfaceThemeSection /> },
@@ -89,7 +89,7 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
       id: 'world',
       label: 'World',
       icon: Boxes,
-      indicator: WORLD_CHANGED.value,
+      badge: WORLD_COUNT.value,
       draftable: true,
       sections: [
         CAMERA_SECTION,

--- a/app/src/views/ControlsPane/ControlsPane.tsx
+++ b/app/src/views/ControlsPane/ControlsPane.tsx
@@ -55,30 +55,12 @@ export interface ControlsPaneProps {
 }
 
 export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
-  const [activeId, setActiveId] = useState('world');
+  const [activeId, setActiveId] = useState('updates');
   // Sections/subgroups own their open-state locally; bumping this nonce on
   // collapse remounts them so they all reopen collapsed.
   const [collapseNonce, setCollapseNonce] = useState(0);
 
   const subtabs: Subtab[] = [
-    {
-      id: 'world',
-      label: 'World',
-      icon: Boxes,
-      draftable: true,
-      sections: [
-        CAMERA_SECTION,
-        SCENE_SECTION,
-        ISLAND_SECTION,
-        BUILDINGS_SECTION,
-        STREETS_SECTION,
-        FOOTPRINT_SECTION,
-        GEM_SECTION,
-        TREES_SECTION,
-        FIREFLIES_SECTION,
-        EFFECTS_SECTION,
-      ],
-    },
     {
       id: 'updates',
       label: 'Scan',
@@ -99,13 +81,31 @@ export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
         { key: 'file-preview', render: <FilePreviewSection /> },
       ],
     },
+    {
+      id: 'world',
+      label: 'World',
+      icon: Boxes,
+      draftable: true,
+      sections: [
+        CAMERA_SECTION,
+        SCENE_SECTION,
+        ISLAND_SECTION,
+        BUILDINGS_SECTION,
+        STREETS_SECTION,
+        FOOTPRINT_SECTION,
+        GEM_SECTION,
+        TREES_SECTION,
+        FIREFLIES_SECTION,
+        EFFECTS_SECTION,
+      ],
+    },
   ];
 
   const active = subtabs.find((t) => t.id === activeId) ?? subtabs[0];
 
   useEffect(() => {
     if (!collapsed) return;
-    setActiveId('world');
+    setActiveId('updates');
     setCollapseNonce((n) => n + 1);
   }, [collapsed]);
 

--- a/app/src/views/ControlsPane/ControlsPane.tsx
+++ b/app/src/views/ControlsPane/ControlsPane.tsx
@@ -57,7 +57,8 @@ export interface ControlsPaneProps {
 export function ControlsPane({ onClose, collapsed }: ControlsPaneProps) {
   const [activeId, setActiveId] = useState('updates');
   // Sections/subgroups own their open-state locally; bumping this nonce on
-  // collapse remounts them so they all reopen collapsed.
+  // collapse remounts them so each reopens at its default (World collapsed,
+  // Scan/Appearance expanded via defaultOpen).
   const [collapseNonce, setCollapseNonce] = useState(0);
 
   const subtabs: Subtab[] = [

--- a/app/src/views/ControlsPane/partials/Buildings.ts
+++ b/app/src/views/ControlsPane/partials/Buildings.ts
@@ -32,9 +32,11 @@ export const BUILDINGS_SECTION: SectionNode = {
       children: [
         field(BUILDING_DIMENSIONS, 'MIN_FLOORS'),
         field(BUILDING_DIMENSIONS, 'MAX_FLOORS'),
+        field(BUILDING_DIMENSIONS, 'FULL_HEIGHT_LINES'),
         field(BUILDING_DIMENSIONS, 'FLOOR_HEIGHT'),
         field(BUILDING_DIMENSIONS, 'MIN_WIDTH'),
         field(BUILDING_DIMENSIONS, 'MAX_WIDTH'),
+        field(BUILDING_DIMENSIONS, 'FULL_WIDTH_KB'),
         field(BUILDING_DIMENSIONS, 'DISTANCE_FROM_ROAD'),
       ],
     },

--- a/app/src/views/ControlsPane/partials/ExcludesSection.css
+++ b/app/src/views/ControlsPane/partials/ExcludesSection.css
@@ -8,11 +8,14 @@
   gap: var(--cc-space-1);
 }
 
+/* Left inset comes from the disclosure body's guide padding; keep the row flush
+   on the right so the per-row restore glyph lines up with the section header's
+   reset button (which sits at the content edge). */
 .excludes-row {
   display: flex;
   align-items: center;
   gap: var(--cc-space-2);
-  padding: var(--cc-space-2) var(--cc-space-4);
+  padding: var(--cc-space-2) 0;
 }
 
 .excludes-row-icon {
@@ -23,10 +26,6 @@
 .excludes-path {
   flex: 1 1 auto;
   min-width: 0;
-}
-
-.excludes-clear {
-  margin-top: var(--cc-space-3);
 }
 
 .excludes-empty {

--- a/app/src/views/ControlsPane/partials/ExcludesSection.css
+++ b/app/src/views/ControlsPane/partials/ExcludesSection.css
@@ -1,0 +1,34 @@
+/* ExcludesSection.css — Excluded-from-city list (Scan settings tab). Rows are
+   plain flex containers (not buttons): unlike RecentRow, nothing on the row
+   itself is clickable, only the restore control, so there's no row hover. */
+
+.excludes-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cc-space-1);
+}
+
+.excludes-row {
+  display: flex;
+  align-items: center;
+  gap: var(--cc-space-2);
+  padding: var(--cc-space-2) var(--cc-space-4);
+}
+
+.excludes-row-icon {
+  flex: 0 0 auto;
+  color: var(--cc-text-muted);
+}
+
+.excludes-path {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.excludes-clear {
+  margin-top: var(--cc-space-3);
+}
+
+.excludes-empty {
+  margin: 0;
+}

--- a/app/src/views/ControlsPane/partials/ExcludesSection.tsx
+++ b/app/src/views/ControlsPane/partials/ExcludesSection.tsx
@@ -1,9 +1,10 @@
 // ControlsPane/partials/ExcludesSection.tsx — the "Excluded from city" list in
 // the Scan settings tab. Shows the loaded repo's UI excludes (rel-paths hidden
-// from the city, saved in this browser), each individually restorable, with a
-// clear-all. Autosave: removeExclude/clearExcludes write straight through, no
-// draft/Save step. Renders its own Section chrome (a render-based SectionNode
-// supplies its own header) so it collapses like every other Scan/World section.
+// from the city, saved in this browser), each individually restorable. The
+// header reset button (same chrome as every other section) restores them all.
+// Autosave: removeExclude/clearExcludes write straight through, no draft/Save
+// step. Renders its own Section chrome (a render-based SectionNode supplies its
+// own header) so it collapses like every other Scan/World section.
 import './ExcludesSection.css';
 import { EyeOff, RotateCcw } from 'lucide-preact';
 import { ACTIVE_EXCLUDES, removeExclude, clearExcludes } from '@/state/stores/excludes';
@@ -15,40 +16,34 @@ export function ExcludesSection() {
     <Section
       name="Excluded from city"
       hint="Paths you hide from the city, saved in this browser. This does not change the repo."
+      onReset={clearExcludes}
+      resetEnabled={paths.length > 0}
+      resetTitle="Restore all excluded paths"
     >
       {paths.length === 0 ? (
         <p class="text-card-sub excludes-empty">
           Nothing excluded. Select a road or building and choose Exclude from city.
         </p>
       ) : (
-        <>
-          <ul class="excludes-list">
-            {paths.map((p) => (
-              <li key={p} class="excludes-row">
-                <EyeOff class="lucide-icon excludes-row-icon" aria-hidden="true" />
-                <span class="excludes-path text-mono text-truncate" title={p}>
-                  {p}
-                </span>
-                <button
-                  type="button"
-                  class="btn-icon"
-                  title={`Restore ${p}`}
-                  aria-label={`Restore ${p}`}
-                  onClick={() => removeExclude(p)}
-                >
-                  <RotateCcw class="lucide-icon" />
-                </button>
-              </li>
-            ))}
-          </ul>
-          <button
-            type="button"
-            class="btn-icon btn-icon--text excludes-clear"
-            onClick={() => clearExcludes()}
-          >
-            Clear all
-          </button>
-        </>
+        <ul class="excludes-list">
+          {paths.map((p) => (
+            <li key={p} class="excludes-row">
+              <EyeOff class="lucide-icon excludes-row-icon" aria-hidden="true" />
+              <span class="excludes-path text-mono text-truncate" title={p}>
+                {p}
+              </span>
+              <button
+                type="button"
+                class="theme-row-reset"
+                title={`Restore ${p}`}
+                aria-label={`Restore ${p}`}
+                onClick={() => removeExclude(p)}
+              >
+                <RotateCcw class="lucide-icon" />
+              </button>
+            </li>
+          ))}
+        </ul>
       )}
     </Section>
   );

--- a/app/src/views/ControlsPane/partials/ExcludesSection.tsx
+++ b/app/src/views/ControlsPane/partials/ExcludesSection.tsx
@@ -1,0 +1,55 @@
+// ControlsPane/partials/ExcludesSection.tsx — the "Excluded from city" list in
+// the Scan settings tab. Shows the loaded repo's UI excludes (rel-paths hidden
+// from the city, saved in this browser), each individually restorable, with a
+// clear-all. Autosave: removeExclude/clearExcludes write straight through, no
+// draft/Save step. Renders its own Section chrome (a render-based SectionNode
+// supplies its own header) so it collapses like every other Scan/World section.
+import './ExcludesSection.css';
+import { EyeOff, RotateCcw } from 'lucide-preact';
+import { ACTIVE_EXCLUDES, removeExclude, clearExcludes } from '@/state/stores/excludes';
+import { Section } from '@/components/Section/Section';
+
+export function ExcludesSection() {
+  const paths = ACTIVE_EXCLUDES.value;
+  return (
+    <Section
+      name="Excluded from city"
+      hint="Paths you hide from the city, saved in this browser. This does not change the repo."
+    >
+      {paths.length === 0 ? (
+        <p class="text-card-sub excludes-empty">
+          Nothing excluded. Select a road or building and choose Exclude from city.
+        </p>
+      ) : (
+        <>
+          <ul class="excludes-list">
+            {paths.map((p) => (
+              <li key={p} class="excludes-row">
+                <EyeOff class="lucide-icon excludes-row-icon" aria-hidden="true" />
+                <span class="excludes-path text-mono text-truncate" title={p}>
+                  {p}
+                </span>
+                <button
+                  type="button"
+                  class="btn-icon"
+                  title={`Restore ${p}`}
+                  aria-label={`Restore ${p}`}
+                  onClick={() => removeExclude(p)}
+                >
+                  <RotateCcw class="lucide-icon" />
+                </button>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            class="btn-icon btn-icon--text excludes-clear"
+            onClick={() => clearExcludes()}
+          >
+            Clear all
+          </button>
+        </>
+      )}
+    </Section>
+  );
+}

--- a/app/src/views/ControlsPane/partials/ExcludesSection.tsx
+++ b/app/src/views/ControlsPane/partials/ExcludesSection.tsx
@@ -35,7 +35,7 @@ export function ExcludesSection() {
               </span>
               <button
                 type="button"
-                class="theme-row-reset"
+                class="setting-row-reset"
                 title={`Restore ${p}`}
                 aria-label={`Restore ${p}`}
                 onClick={() => removeExclude(p)}

--- a/app/src/views/ControlsPane/partials/ExcludesSection.tsx
+++ b/app/src/views/ControlsPane/partials/ExcludesSection.tsx
@@ -28,7 +28,7 @@ export function ExcludesSection() {
         <ul class="excludes-list">
           {paths.map((p) => (
             <li key={p} class="excludes-row">
-              <EyeOff class="lucide-icon excludes-row-icon" aria-hidden="true" />
+              <EyeOff class="icon excludes-row-icon" aria-hidden="true" />
               <span class="excludes-path text-mono text-truncate" title={p}>
                 {p}
               </span>
@@ -39,7 +39,7 @@ export function ExcludesSection() {
                 aria-label={`Restore ${p}`}
                 onClick={() => removeExclude(p)}
               >
-                <RotateCcw class="lucide-icon" />
+                <RotateCcw class="icon" />
               </button>
             </li>
           ))}

--- a/app/src/views/ControlsPane/partials/ExcludesSection.tsx
+++ b/app/src/views/ControlsPane/partials/ExcludesSection.tsx
@@ -19,6 +19,7 @@ export function ExcludesSection() {
       onReset={clearExcludes}
       resetEnabled={paths.length > 0}
       resetTitle="Restore all excluded paths"
+      defaultOpen
     >
       {paths.length === 0 ? (
         <p class="text-card-sub excludes-empty">

--- a/app/src/views/ControlsPane/partials/FilePreviewSection.tsx
+++ b/app/src/views/ControlsPane/partials/FilePreviewSection.tsx
@@ -10,7 +10,7 @@ import {
   SYNTAX_THEME_OPTIONS,
 } from '@/state/stores/settings/syntaxTheme';
 import { RotateCcw } from 'lucide-preact';
-import { ThemeRow } from '@/components/ThemeRow/ThemeRow';
+import { SettingRow } from '@/components/SettingRow/SettingRow';
 import { Section } from '@/components/Section/Section';
 
 export function FilePreviewSection() {
@@ -45,7 +45,7 @@ export function FilePreviewSection() {
       resetEnabled={!isDefault}
       resetTitle="Reset file preview to default"
     >
-      <ThemeRow
+      <SettingRow
         label="Syntax theme"
         tip="Highlight theme for the file preview; applies immediately."
         inline
@@ -64,7 +64,7 @@ export function FilePreviewSection() {
             </option>
           ))}
         </select>
-      </ThemeRow>
+      </SettingRow>
     </Section>
   );
 }

--- a/app/src/views/ControlsPane/partials/FilePreviewSection.tsx
+++ b/app/src/views/ControlsPane/partials/FilePreviewSection.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/state/stores/settings/syntaxTheme';
 import { RotateCcw } from 'lucide-preact';
 import { ThemeRow } from '@/components/ThemeRow/ThemeRow';
+import { Section } from '@/components/Section/Section';
 
 export function FilePreviewSection() {
   void DRAFTS_REV.value; // re-render on draft/commit changes
@@ -20,12 +21,35 @@ export function FilePreviewSection() {
     SYNTAX_THEME_DEFAULT;
   const isDefault = current === SYNTAX_THEME_DEFAULT;
 
+  const resetBtn = (
+    <button
+      type="button"
+      class="theme-row-reset"
+      title={`Default: ${defaultLabel}`}
+      aria-label="Reset syntax theme to default"
+      disabled={isDefault}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        stageReset(SYNTAX_THEME, null);
+      }}
+    >
+      <RotateCcw class="icon" />
+    </button>
+  );
   return (
-    <div class="controls-inline-section">
+    <Section
+      name="File preview"
+      defaultOpen
+      onReset={() => stageReset(SYNTAX_THEME, null)}
+      resetEnabled={!isDefault}
+      resetTitle="Reset file preview to default"
+    >
       <ThemeRow
         label="Syntax theme"
         tip="Highlight theme for the file preview; applies immediately."
         inline
+        resetSlot={resetBtn}
       >
         <select
           class="form-input form-input--select"
@@ -40,21 +64,7 @@ export function FilePreviewSection() {
             </option>
           ))}
         </select>
-        <button
-          type="button"
-          class="theme-row-reset"
-          title={`Default: ${defaultLabel}`}
-          aria-label="Reset syntax theme to default"
-          disabled={isDefault}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            stageReset(SYNTAX_THEME, null);
-          }}
-        >
-          <RotateCcw class="icon" />
-        </button>
       </ThemeRow>
-    </div>
+    </Section>
   );
 }

--- a/app/src/views/ControlsPane/partials/FilePreviewSection.tsx
+++ b/app/src/views/ControlsPane/partials/FilePreviewSection.tsx
@@ -24,7 +24,7 @@ export function FilePreviewSection() {
   const resetBtn = (
     <button
       type="button"
-      class="theme-row-reset"
+      class="setting-row-reset"
       title={`Default: ${defaultLabel}`}
       aria-label="Reset syntax theme to default"
       disabled={isDefault}

--- a/app/src/views/ControlsPane/partials/FilePreviewSection.tsx
+++ b/app/src/views/ControlsPane/partials/FilePreviewSection.tsx
@@ -52,7 +52,7 @@ export function FilePreviewSection() {
             stageReset(SYNTAX_THEME, null);
           }}
         >
-          <RotateCcw class="lucide-icon" />
+          <RotateCcw class="icon" />
         </button>
       </ThemeRow>
     </div>

--- a/app/src/views/ControlsPane/partials/InterfaceThemeSection.css
+++ b/app/src/views/ControlsPane/partials/InterfaceThemeSection.css
@@ -1,11 +1,5 @@
 /* InterfaceThemeSection.css — accent/surface swatch pickers (Appearance tab). */
 
-.swatch-row {
-  display: flex;
-  align-items: center;
-  gap: var(--cc-space-4);
-}
-
 .swatch-group {
   display: flex;
   gap: var(--cc-space-3);

--- a/app/src/views/ControlsPane/partials/InterfaceThemeSection.tsx
+++ b/app/src/views/ControlsPane/partials/InterfaceThemeSection.tsx
@@ -22,7 +22,7 @@ import {
   SURFACE_PRESETS,
   type ThemePresetOption,
 } from '@/state/stores/settings/theme';
-import { ThemeRow } from '@/components/ThemeRow/ThemeRow';
+import { SettingRow } from '@/components/SettingRow/SettingRow';
 import { Section } from '@/components/Section/Section';
 
 interface SignalLike {
@@ -73,7 +73,7 @@ function SwatchRow({ label, tip, axis, store, options, defaultValue }: SwatchRow
     btnRefs.current[next]?.focus();
   };
 
-  // Per-row reset lives in ThemeRow's head slot (right of the label), the same
+  // Per-row reset lives in SettingRow's head slot (right of the label), the same
   // place every schema-driven row's reset sits, so all tabs line up.
   const resetBtn = (
     <button
@@ -92,7 +92,7 @@ function SwatchRow({ label, tip, axis, store, options, defaultValue }: SwatchRow
     </button>
   );
   return (
-    <ThemeRow label={label} tip={tip} resetSlot={resetBtn}>
+    <SettingRow label={label} tip={tip} resetSlot={resetBtn}>
       <span class="swatch-group" role="radiogroup" aria-label={label} onKeyDown={onKeyDown}>
         {options.map((opt, i) => {
           const checked = opt.value === current;
@@ -121,7 +121,7 @@ function SwatchRow({ label, tip, axis, store, options, defaultValue }: SwatchRow
           );
         })}
       </span>
-    </ThemeRow>
+    </SettingRow>
   );
 }
 

--- a/app/src/views/ControlsPane/partials/InterfaceThemeSection.tsx
+++ b/app/src/views/ControlsPane/partials/InterfaceThemeSection.tsx
@@ -115,7 +115,7 @@ function SwatchRow({ label, tip, axis, store, options, defaultValue }: SwatchRow
             stageReset(store, null);
           }}
         >
-          <RotateCcw class="lucide-icon" />
+          <RotateCcw class="icon" />
         </button>
       </span>
     </ThemeRow>

--- a/app/src/views/ControlsPane/partials/InterfaceThemeSection.tsx
+++ b/app/src/views/ControlsPane/partials/InterfaceThemeSection.tsx
@@ -78,7 +78,7 @@ function SwatchRow({ label, tip, axis, store, options, defaultValue }: SwatchRow
   const resetBtn = (
     <button
       type="button"
-      class="theme-row-reset"
+      class="setting-row-reset"
       title={`Default: ${defaultLabel}`}
       aria-label={`Reset ${label.toLowerCase()} to default`}
       disabled={current === defaultValue}

--- a/app/src/views/ControlsPane/partials/InterfaceThemeSection.tsx
+++ b/app/src/views/ControlsPane/partials/InterfaceThemeSection.tsx
@@ -23,6 +23,7 @@ import {
   type ThemePresetOption,
 } from '@/state/stores/settings/theme';
 import { ThemeRow } from '@/components/ThemeRow/ThemeRow';
+import { Section } from '@/components/Section/Section';
 
 interface SignalLike {
   get value(): string;
@@ -72,51 +73,53 @@ function SwatchRow({ label, tip, axis, store, options, defaultValue }: SwatchRow
     btnRefs.current[next]?.focus();
   };
 
+  // Per-row reset lives in ThemeRow's head slot (right of the label), the same
+  // place every schema-driven row's reset sits, so all tabs line up.
+  const resetBtn = (
+    <button
+      type="button"
+      class="theme-row-reset"
+      title={`Default: ${defaultLabel}`}
+      aria-label={`Reset ${label.toLowerCase()} to default`}
+      disabled={current === defaultValue}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        stageReset(store, null);
+      }}
+    >
+      <RotateCcw class="icon" />
+    </button>
+  );
   return (
-    <ThemeRow label={label} tip={tip}>
-      <span class="swatch-row">
-        <span class="swatch-group" role="radiogroup" aria-label={label} onKeyDown={onKeyDown}>
-          {options.map((opt, i) => {
-            const checked = opt.value === current;
-            return (
-              <button
-                key={opt.value}
-                ref={(el) => {
-                  btnRefs.current[i] = el;
-                }}
-                type="button"
-                role="radio"
-                aria-checked={checked}
-                aria-label={opt.label}
-                title={opt.label}
-                tabIndex={i === activeIndex ? 0 : -1}
-                class={checked ? 'swatch is-active' : 'swatch'}
-                onClick={() => select(opt.value)}
-              >
-                <span
-                  class="swatch-chip"
-                  style={{ background: chipVar }}
-                  {...{ [`data-cc-${axis}`]: opt.value }}
-                />
-                <span class="swatch-label">{opt.label}</span>
-              </button>
-            );
-          })}
-        </span>
-        <button
-          type="button"
-          class="theme-row-reset"
-          title={`Default: ${defaultLabel}`}
-          aria-label={`Reset ${label.toLowerCase()} to default`}
-          disabled={current === defaultValue}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            stageReset(store, null);
-          }}
-        >
-          <RotateCcw class="icon" />
-        </button>
+    <ThemeRow label={label} tip={tip} resetSlot={resetBtn}>
+      <span class="swatch-group" role="radiogroup" aria-label={label} onKeyDown={onKeyDown}>
+        {options.map((opt, i) => {
+          const checked = opt.value === current;
+          return (
+            <button
+              key={opt.value}
+              ref={(el) => {
+                btnRefs.current[i] = el;
+              }}
+              type="button"
+              role="radio"
+              aria-checked={checked}
+              aria-label={opt.label}
+              title={opt.label}
+              tabIndex={i === activeIndex ? 0 : -1}
+              class={checked ? 'swatch is-active' : 'swatch'}
+              onClick={() => select(opt.value)}
+            >
+              <span
+                class="swatch-chip"
+                style={{ background: chipVar }}
+                {...{ [`data-cc-${axis}`]: opt.value }}
+              />
+              <span class="swatch-label">{opt.label}</span>
+            </button>
+          );
+        })}
       </span>
     </ThemeRow>
   );
@@ -124,8 +127,19 @@ function SwatchRow({ label, tip, axis, store, options, defaultValue }: SwatchRow
 
 export function InterfaceThemeSection() {
   void DRAFTS_REV.value; // re-render on write-through / reset
+  const accentDiffers = getEffective(ACCENT_THEME, null) !== ACCENT_THEME_DEFAULT;
+  const surfaceDiffers = getEffective(SURFACE_THEME, null) !== SURFACE_THEME_DEFAULT;
   return (
-    <div class="controls-inline-section">
+    <Section
+      name="Interface theme"
+      defaultOpen
+      onReset={() => {
+        stageReset(ACCENT_THEME, null);
+        stageReset(SURFACE_THEME, null);
+      }}
+      resetEnabled={accentDiffers || surfaceDiffers}
+      resetTitle="Reset interface theme to defaults"
+    >
       <SwatchRow
         label="Accent"
         tip="Accent color for buttons, links, and highlights; applies immediately."
@@ -142,6 +156,6 @@ export function InterfaceThemeSection() {
         options={SURFACE_PRESETS}
         defaultValue={SURFACE_THEME_DEFAULT}
       />
-    </div>
+    </Section>
   );
 }

--- a/app/src/views/ControlsPane/partials/Updates.ts
+++ b/app/src/views/ControlsPane/partials/Updates.ts
@@ -6,5 +6,6 @@ import { LIVE_UPDATES } from '@/state/stores/settings/updates';
 export const UPDATES_SECTION: SectionNode = {
   key: 'updates',
   label: 'Live updates',
+  defaultOpen: true,
   children: [field(LIVE_UPDATES, 'ENABLED'), field(LIVE_UPDATES, 'POLL_SECONDS')],
 };

--- a/app/src/views/ControlsPane/partials/Updates.ts
+++ b/app/src/views/ControlsPane/partials/Updates.ts
@@ -1,9 +1,10 @@
-// views/ControlsPane/partials/Updates.ts — Scan & Updates section declaration.
+// views/ControlsPane/partials/Updates.ts — Live-updates polling section
+// declaration (one of two sections in the Scan settings tab).
 import { field, type SectionNode } from '.';
 import { LIVE_UPDATES } from '@/state/stores/settings/updates';
 
 export const UPDATES_SECTION: SectionNode = {
   key: 'updates',
-  label: 'Scan & Updates',
+  label: 'Live updates',
   children: [field(LIVE_UPDATES, 'ENABLED'), field(LIVE_UPDATES, 'POLL_SECONDS')],
 };

--- a/app/src/views/ControlsPane/partials/index.tsx
+++ b/app/src/views/ControlsPane/partials/index.tsx
@@ -55,10 +55,6 @@ export interface SectionNode {
   description?: string;
   children?: SectionChild[];
   render?: ComponentChildren;
-  /** Render flat (hint + children, no <details> chrome, no section reset).
-   *  For a subtab whose only section would otherwise be a one-item
-   *  accordion — collapsing a single section is pointless UI. */
-  inline?: boolean;
   /** Start the accordion expanded instead of collapsed. */
   defaultOpen?: boolean;
 }
@@ -119,14 +115,6 @@ function renderChild(child: SectionChild, depth: number): ComponentChildren {
 /** Render one section node into the panel shells. */
 export function DynamicSection({ node }: { node: SectionNode }) {
   if (node.render) return <>{node.render}</>;
-  if (node.inline) {
-    return (
-      <div class="controls-inline-section">
-        {node.description && <div class="controls-section-hint">{node.description}</div>}
-        {renderChildren(node.children ?? [])}
-      </div>
-    );
-  }
   return (
     <Section
       name={node.label ?? ''}

--- a/app/src/views/ControlsPane/partials/index.tsx
+++ b/app/src/views/ControlsPane/partials/index.tsx
@@ -59,6 +59,8 @@ export interface SectionNode {
    *  For a subtab whose only section would otherwise be a one-item
    *  accordion — collapsing a single section is pointless UI. */
   inline?: boolean;
+  /** Start the accordion expanded instead of collapsed. */
+  defaultOpen?: boolean;
 }
 
 function isGroup(child: SectionChild): child is GroupNode {
@@ -130,6 +132,7 @@ export function DynamicSection({ node }: { node: SectionNode }) {
       name={node.label ?? ''}
       hint={node.description}
       resetKeys={collectRefs(node.children ?? [])}
+      defaultOpen={node.defaultOpen}
     >
       {(node.children ?? []).map((c) => renderChild(c, 2))}
     </Section>

--- a/app/src/views/DebugModal/DebugModal.tsx
+++ b/app/src/views/DebugModal/DebugModal.tsx
@@ -53,7 +53,7 @@ export function DebugModal({ onRunCollisionCheck, onRunStemDiagnostic }: DebugMo
             aria-label="Close"
             onClick={closeDebug}
           >
-            <X class="lucide-icon" />
+            <X class="icon" />
           </button>
         </div>
         <div class="modal-body">

--- a/app/src/views/DebugModal/DebugModal.tsx
+++ b/app/src/views/DebugModal/DebugModal.tsx
@@ -59,7 +59,7 @@ export function DebugModal({ onRunCollisionCheck, onRunStemDiagnostic }: DebugMo
         <div class="modal-body">
           <p class="debug-hint">Developer-only diagnostics. Output goes to the browser console.</p>
           {onRunCollisionCheck && (
-            <div class="theme-row">
+            <div class="setting-row">
               <button
                 type="button"
                 class="btn-secondary"
@@ -71,7 +71,7 @@ export function DebugModal({ onRunCollisionCheck, onRunStemDiagnostic }: DebugMo
             </div>
           )}
           {onRunStemDiagnostic && (
-            <div class="theme-row">
+            <div class="setting-row">
               <button
                 type="button"
                 class="btn-secondary"

--- a/app/src/views/FilePreviewPane/FilePreviewPane.css
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.css
@@ -131,7 +131,7 @@
   font-size: var(--cc-font-xs);
   line-height: var(--cc-lh-base);
 }
-.code-editor-banner .lucide-icon {
+.code-editor-banner .icon {
   flex: 0 0 auto;
   font-size: var(--cc-font-md);
   opacity: 0.85;

--- a/app/src/views/FilePreviewPane/FilePreviewPane.tsx
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.tsx
@@ -67,6 +67,7 @@ export interface FilePreviewPaneProps {
   state: ReadonlySignal<FilePreviewPaneState>;
   onClose?: () => void;
   onFocus?: (file: FileNode) => void;
+  onExclude?: (file: FileNode) => void;
 }
 
 export function _previewKind(file: FileNode | { extension?: string }): PreviewKind {
@@ -463,7 +464,7 @@ function _previewBody(file: FileNode | null) {
 
 // ── Preact component ─────────────────────────────────────────────────────────
 
-export function FilePreviewPane({ state, onClose, onFocus }: FilePreviewPaneProps) {
+export function FilePreviewPane({ state, onClose, onFocus, onExclude }: FilePreviewPaneProps) {
   const { file } = state.value;
 
   const leaf = file
@@ -482,6 +483,8 @@ export function FilePreviewPane({ state, onClose, onFocus }: FilePreviewPaneProp
       onFocus={file && typeof onFocus === 'function' ? () => onFocus(file) : undefined}
       focusTitle={`Focus the camera on this file (${KEY_BINDINGS.FOCUS_SELECTION.label})`}
       onClose={onClose}
+      onExclude={file && typeof onExclude === 'function' ? () => onExclude(file) : undefined}
+      excludeTitle="Exclude this file from the city"
       bodyClass="editor-body surface-app"
     >
       {_previewBody(file)}

--- a/app/src/views/FilePreviewPane/FilePreviewPane.tsx
+++ b/app/src/views/FilePreviewPane/FilePreviewPane.tsx
@@ -196,7 +196,7 @@ function CodeEditor({ text, file }: CodeEditorProps) {
     <div class="code-editor-shell">
       {(skipHighlight || skipGutter) && (
         <div class="code-editor-banner card-banner">
-          <Info class="lucide-icon" />
+          <Info class="icon" />
           <span>{bannerText}</span>
         </div>
       )}

--- a/app/src/views/InfoPane/LegendPane.tsx
+++ b/app/src/views/InfoPane/LegendPane.tsx
@@ -42,7 +42,7 @@ function LayerBlock({ layerKey }: { layerKey: (typeof LAYER_LEGEND)[number]['key
   return (
     <section class="legend-layer" data-section={layer.key}>
       <h3 class="legend-layer-title text-label">
-        <Icon class="lucide-icon legend-layer-icon" aria-hidden="true" />
+        <Icon class="icon legend-layer-icon" aria-hidden="true" />
         {layer.title}
       </h3>
       <p class="legend-layer-lead">{layer.lead}</p>
@@ -69,7 +69,7 @@ export function LegendPane() {
       <ul class="legend-cue-list">
         {WORLD_CUES.map((c) => (
           <li key={c.title} class="legend-row">
-            <c.icon class="lucide-icon legend-row-icon" aria-hidden="true" />
+            <c.icon class="icon legend-row-icon" aria-hidden="true" />
             <div class="legend-row-text">
               <span class="legend-row-title">{c.title}</span>
               <span class="legend-row-rule">{c.rule}</span>

--- a/app/src/views/InfoPane/OverviewPane.tsx
+++ b/app/src/views/InfoPane/OverviewPane.tsx
@@ -66,7 +66,7 @@ function FactRow({ fact }: { fact: AlmanacFact }) {
       {fact.label && <span class="almanac-fact-label">{fact.label}</span>}
       <PrimaryValue fact={fact} />
       {fact.secondary && <span class="almanac-fact-metric">{fact.secondary}</span>}
-      {landmark && <Focus class="lucide-icon almanac-fact-focus" aria-hidden="true" />}
+      {landmark && <Focus class="icon almanac-fact-focus" aria-hidden="true" />}
     </>
   );
   if (!landmark) {
@@ -140,7 +140,7 @@ export function OverviewPane({ manifest }: OverviewPaneProps) {
         return (
           <section key={s.key} class="almanac-section" data-section={s.key}>
             <h3 class="almanac-section-title text-label" title={s.tip}>
-              <Icon class="lucide-icon almanac-section-icon" aria-hidden="true" />
+              <Icon class="icon almanac-section-icon" aria-hidden="true" />
               {s.title}
             </h3>
             {s.facts.length > 0 ? (

--- a/app/src/views/ProjectsView/ProjectsView.tsx
+++ b/app/src/views/ProjectsView/ProjectsView.tsx
@@ -70,7 +70,7 @@ export function ProjectsView({ onSubmit, onCancel, onClose }: ProjectsViewProps)
 
       {pv.opts.dismissible && !loading && (
         <button class="landing-close btn-icon btn-icon--lg" aria-label="Close" onClick={onClose}>
-          <X class="lucide-icon" />
+          <X class="icon" />
         </button>
       )}
 
@@ -85,25 +85,25 @@ export function ProjectsView({ onSubmit, onCancel, onClose }: ProjectsViewProps)
           <p class="landing-tagline">Turn any git repo into a 3D city</p>
           <ul class="landing-delights">
             <li class="landing-delight landing-delight--streets">
-              <Waypoints class="lucide-icon" aria-hidden="true" />
+              <Waypoints class="icon" aria-hidden="true" />
               <span>
                 Directories become <strong>streets</strong>
               </span>
             </li>
             <li class="landing-delight landing-delight--buildings">
-              <Building2 class="lucide-icon" aria-hidden="true" />
+              <Building2 class="icon" aria-hidden="true" />
               <span>
                 Files rise into <strong>buildings</strong>
               </span>
             </li>
             <li class="landing-delight landing-delight--trees">
-              <TreePine class="lucide-icon" aria-hidden="true" />
+              <TreePine class="icon" aria-hidden="true" />
               <span>
                 Every commit grows a <strong>tree</strong>
               </span>
             </li>
             <li class="landing-delight landing-delight--authors">
-              <Sparkles class="lucide-icon" aria-hidden="true" />
+              <Sparkles class="icon" aria-hidden="true" />
               <span>
                 Commit authors orbit trees as <strong>fireflies</strong>
               </span>

--- a/app/src/views/SearchPane/SearchPane.tsx
+++ b/app/src/views/SearchPane/SearchPane.tsx
@@ -98,7 +98,7 @@ export function SearchPane({ manifest, onClose, onSelect }: SearchPaneProps) {
       headerSlot={
         <div class="pane-header pane-header--search">
           <div class="search-input-wrap">
-            <Search class="lucide-icon search-input-icon" aria-hidden="true" />
+            <Search class="icon search-input-icon" aria-hidden="true" />
             <input
               ref={inputRef}
               type="search"

--- a/app/src/views/ShortcutsModal/ShortcutsModal.tsx
+++ b/app/src/views/ShortcutsModal/ShortcutsModal.tsx
@@ -121,7 +121,7 @@ export function ShortcutsModal() {
             aria-label="Close"
             onClick={closeShortcuts}
           >
-            <X class="lucide-icon" />
+            <X class="icon" />
           </button>
         </div>
         <div class="modal-body">

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -31,11 +31,12 @@ export interface StreetPaneProps {
   state: ReadonlySignal<StreetPaneState>;
   onClose?: () => void;
   onFocus?: (dir: DirNode) => void;
+  onExclude?: (dir: DirNode) => void;
 }
 
 // ── Preact component ─────────────────────────────────────────────────────────
 
-export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
+export function StreetPane({ state, onClose, onFocus, onExclude }: StreetPaneProps) {
   const { directory: d } = state.value;
 
   if (!d) {
@@ -75,6 +76,12 @@ export function StreetPane({ state, onClose, onFocus }: StreetPaneProps) {
       onFocus={typeof onFocus === 'function' ? () => onFocus(d) : undefined}
       focusTitle={`Focus the camera on this road (${KEY_BINDINGS.FOCUS_SELECTION.label})`}
       onClose={onClose}
+      onExclude={
+        typeof onExclude === 'function' && d.path && d.path !== ROOT_PATH
+          ? () => onExclude(d)
+          : undefined
+      }
+      excludeTitle="Exclude this road from the city"
       bodyClass="street-body pane-inset"
     >
       {dateRange && (

--- a/app/src/views/StreetPane/StreetPane.tsx
+++ b/app/src/views/StreetPane/StreetPane.tsx
@@ -86,14 +86,14 @@ export function StreetPane({ state, onClose, onFocus, onExclude }: StreetPanePro
     >
       {dateRange && (
         <div class="street-dates" title="Oldest file created → newest change">
-          <CalendarRange class="lucide-icon street-dates-icon" aria-hidden="true" />
+          <CalendarRange class="icon street-dates-icon" aria-hidden="true" />
           {dateRange}
         </div>
       )}
       {stats.length > 0 && (
         <>
           <div class="street-ext-h text-label">
-            <FileType class="lucide-icon street-ext-icon" aria-hidden="true" />
+            <FileType class="icon street-ext-icon" aria-hidden="true" />
             By extension
           </div>
           <div class="street-ext-list">

--- a/app/tests/_helpers/cityFixtures.ts
+++ b/app/tests/_helpers/cityFixtures.ts
@@ -145,9 +145,11 @@ export function resetBuildingsConfig(): void {
   BUILDING_DIMENSIONS.value = {
     MIN_FLOORS: 2,
     MAX_FLOORS: 96,
+    FULL_HEIGHT_LINES: 2000,
     FLOOR_HEIGHT: 16,
     MIN_WIDTH: 8,
     MAX_WIDTH: 8,
+    FULL_WIDTH_KB: 64,
     DISTANCE_FROM_ROAD: 8,
   };
 }

--- a/app/tests/api/apiUrl.test.ts
+++ b/app/tests/api/apiUrl.test.ts
@@ -14,6 +14,20 @@ describe('apiUrl', () => {
     expect(u).toContain('src=%2Ffoo%2Fbar');
     expect(u).not.toContain('branch=');
   });
+
+  it('emits repeated params for array values', () => {
+    const url = apiUrl('manifest', { src: 'x', exclude: ['a', 'b'] });
+    const params = new URL(url).searchParams;
+    expect(params.getAll('exclude')).toEqual(['a', 'b']);
+    expect(params.get('src')).toBe('x');
+  });
+
+  it('skips empty arrays and undefined', () => {
+    const url = apiUrl('manifest', { src: 'x', exclude: [], branch: undefined });
+    const params = new URL(url).searchParams;
+    expect(params.getAll('exclude')).toEqual([]);
+    expect(params.has('branch')).toBe(false);
+  });
 });
 
 // The live-update poll targets the committed CURRENT_SOURCE via these builders,
@@ -50,5 +64,15 @@ describe('explicit-source URL builders', () => {
     expect(u).toContain('src=https%3A%2F%2Fgithub.com%2Fo%2Fr');
     expect(u).toContain('branch=feat');
     expect(u).not.toContain('PAGE_SRC');
+  });
+
+  it('includes exclude params on the manifest url', () => {
+    const params = new URL(manifestUrlFor({ src: 's', exclude: ['sub', 'a.md'] })).searchParams;
+    expect(params.getAll('exclude')).toEqual(['sub', 'a.md']);
+  });
+
+  it('includes exclude params on the signature url', () => {
+    const params = new URL(signatureUrlFor('s', undefined, ['sub'])).searchParams;
+    expect(params.getAll('exclude')).toEqual(['sub']);
   });
 });

--- a/app/tests/city/components/onSettings.test.ts
+++ b/app/tests/city/components/onSettings.test.ts
@@ -1,6 +1,6 @@
 // app/tests/city/components/onSettings.test.ts
 //
-// onSettings(store, apply) is the shared theme-reactivity wrapper for the
+// onSettings(store, apply) is the shared setting-reactivity wrapper for the
 // city components. It must:
 //   - run `apply` once synchronously at wire time,
 //   - re-run `apply` on every Save (write) of `store`,

--- a/app/tests/city/layout/algorithm.test.ts
+++ b/app/tests/city/layout/algorithm.test.ts
@@ -171,17 +171,27 @@ describe('getBuildingDimensions', () => {
     expect(dim.floors).toBe(1);
   });
 
-  it('largest file in the project maps to max_floors', () => {
-    const dim = getBuildingDimensions({ lines: 1000, size: 10000 }, { min: 10, max: 1000 });
+  it('largest file maps to max_floors when the repo reaches the full-height line count', () => {
+    // Biggest file at FULL_HEIGHT_LINES (2000) → the absolute ceiling is the cap.
+    const dim = getBuildingDimensions({ lines: 2000, size: 10000 }, { min: 10, max: 2000 });
     expect(dim.floors).toBe(TEST_BUILDING_DIMS.MAX_FLOORS);
   });
 
-  it('midrange file uses sqrt-interpolated floors', () => {
+  it('caps the tallest building below max_floors when the biggest file is small', () => {
+    // Repo whose largest file is 1000 lines (< FULL_HEIGHT_LINES 2000): even its
+    // biggest file tops out below the cap at 1 + sqrt(1000/2000) * (30 - 1) ≈ 21.5.
+    const dim = getBuildingDimensions({ lines: 1000, size: 10000 }, { min: 10, max: 1000 });
+    expect(dim.floors).toBeLessThan(TEST_BUILDING_DIMS.MAX_FLOORS as number);
+    expect(dim.floors).toBe(22);
+  });
+
+  it('midrange file uses sqrt-interpolated floors within the repo ceiling', () => {
+    // Biggest file is 1000 lines (< 2000) → repo ceiling ≈ 21.5 floors.
     // sMin=sqrt(10)=3.162, sMax=sqrt(1000)=31.62, sLines=sqrt(100)=10
     // t = (10 - 3.162) / (31.62 - 3.162) ≈ 0.240
-    // floors ≈ round(1 + 0.240 * 29) = round(7.96) = 8
+    // floors ≈ round(1 + 0.240 * (21.5 - 1)) = round(5.93) = 6
     const dim = getBuildingDimensions({ lines: 100, size: 1000 }, { min: 10, max: 1000 });
-    expect(dim.floors).toBe(8);
+    expect(dim.floors).toBe(6);
   });
 
   it('without lineStats falls back to min_floors', () => {

--- a/app/tests/city/trees/treeRenderer.test.ts
+++ b/app/tests/city/trees/treeRenderer.test.ts
@@ -39,9 +39,11 @@ function resetStores() {
   BUILDING_DIMENSIONS.value = {
     MIN_FLOORS: 2,
     MAX_FLOORS: 96,
+    FULL_HEIGHT_LINES: 2000,
     FLOOR_HEIGHT: 16,
     MIN_WIDTH: 8,
     MAX_WIDTH: 8,
+    FULL_WIDTH_KB: 64,
     DISTANCE_FROM_ROAD: 8,
   };
 }

--- a/app/tests/city/trees/treeRendererCommitLookup.test.ts
+++ b/app/tests/city/trees/treeRendererCommitLookup.test.ts
@@ -38,9 +38,11 @@ function resetStores() {
   BUILDING_DIMENSIONS.value = {
     MIN_FLOORS: 2,
     MAX_FLOORS: 96,
+    FULL_HEIGHT_LINES: 2000,
     FLOOR_HEIGHT: 16,
     MIN_WIDTH: 8,
     MAX_WIDTH: 8,
+    FULL_WIDTH_KB: 64,
     DISTANCE_FROM_ROAD: 8,
   };
 }

--- a/app/tests/components/settingRow.test.tsx
+++ b/app/tests/components/settingRow.test.tsx
@@ -26,7 +26,7 @@ describe('SettingRow layout B', () => {
       </SettingRow>
     );
     await flush();
-    const desc = container.querySelector('.theme-row-desc');
+    const desc = container.querySelector('.setting-row-desc');
     expect(desc?.textContent).toBe('Floors for the largest file.');
   });
 
@@ -37,7 +37,7 @@ describe('SettingRow layout B', () => {
       </SettingRow>
     );
     await flush();
-    expect(container.querySelector('.theme-row-desc')).toBeNull();
+    expect(container.querySelector('.setting-row-desc')).toBeNull();
   });
 
   it('marks the row inline when inline is set (toggle/color)', async () => {
@@ -47,7 +47,7 @@ describe('SettingRow layout B', () => {
       </SettingRow>
     );
     await flush();
-    expect(container.querySelector('.theme-row')?.classList.contains('theme-row--inline')).toBe(
+    expect(container.querySelector('.setting-row')?.classList.contains('setting-row--inline')).toBe(
       true
     );
   });
@@ -59,7 +59,7 @@ describe('SettingRow layout B', () => {
       </SettingRow>
     );
     await flush();
-    expect(container.querySelector('.theme-row')?.classList.contains('theme-row--inline')).toBe(
+    expect(container.querySelector('.setting-row')?.classList.contains('setting-row--inline')).toBe(
       false
     );
   });
@@ -73,7 +73,7 @@ describe('SettingRow layout B', () => {
     await flush();
     const label = container.querySelector('label');
     expect(label?.textContent).not.toContain('Floors for the largest file.');
-    expect(container.querySelector('.theme-row-desc')?.textContent).toBe(
+    expect(container.querySelector('.setting-row-desc')?.textContent).toBe(
       'Floors for the largest file.'
     );
   });
@@ -97,7 +97,7 @@ describe('Field a11y wiring (description via aria-describedby)', () => {
     mount(<Field store={BUILDING_DIMENSIONS} fieldKey="MIN_FLOORS" />);
     await flush();
     const input = container.querySelector('input');
-    const desc = container.querySelector('.theme-row-desc');
+    const desc = container.querySelector('.setting-row-desc');
     expect(desc).not.toBeNull();
     expect(desc?.id).toBeTruthy();
     expect(input?.getAttribute('aria-describedby')).toBe(desc?.id);
@@ -107,7 +107,7 @@ describe('Field a11y wiring (description via aria-describedby)', () => {
     mount(<Field store={BUILDINGS} fieldKey="OUTLINE_HOVER_OPACITY" />);
     await flush();
     const input = container.querySelector('input');
-    expect(container.querySelector('.theme-row-desc')).toBeNull();
+    expect(container.querySelector('.setting-row-desc')).toBeNull();
     expect(input?.hasAttribute('aria-describedby')).toBe(false);
   });
 });

--- a/app/tests/components/settingRow.test.tsx
+++ b/app/tests/components/settingRow.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render } from 'preact';
-import { ThemeRow } from '@/components/ThemeRow/ThemeRow';
+import { SettingRow } from '@/components/SettingRow/SettingRow';
 import { Field } from '@/components/Field';
 import { BUILDING_DIMENSIONS, BUILDINGS } from '@/state/stores/settings/buildings';
 import { flush } from '../_helpers/preact';
 
-describe('ThemeRow layout B', () => {
+describe('SettingRow layout B', () => {
   let container: HTMLDivElement;
   afterEach(() => {
     if (container) {
@@ -21,9 +21,9 @@ describe('ThemeRow layout B', () => {
 
   it('shows the tip as an inline description when present', async () => {
     mount(
-      <ThemeRow label="Max floors" tip="Floors for the largest file.">
+      <SettingRow label="Max floors" tip="Floors for the largest file.">
         <input />
-      </ThemeRow>
+      </SettingRow>
     );
     await flush();
     const desc = container.querySelector('.theme-row-desc');
@@ -32,9 +32,9 @@ describe('ThemeRow layout B', () => {
 
   it('renders no description element when tip is absent', async () => {
     mount(
-      <ThemeRow label="Saturation">
+      <SettingRow label="Saturation">
         <input />
-      </ThemeRow>
+      </SettingRow>
     );
     await flush();
     expect(container.querySelector('.theme-row-desc')).toBeNull();
@@ -42,9 +42,9 @@ describe('ThemeRow layout B', () => {
 
   it('marks the row inline when inline is set (toggle/color)', async () => {
     mount(
-      <ThemeRow label="Enabled" inline>
+      <SettingRow label="Enabled" inline>
         <input type="checkbox" />
-      </ThemeRow>
+      </SettingRow>
     );
     await flush();
     expect(container.querySelector('.theme-row')?.classList.contains('theme-row--inline')).toBe(
@@ -54,9 +54,9 @@ describe('ThemeRow layout B', () => {
 
   it('is stacked (not inline) by default', async () => {
     mount(
-      <ThemeRow label="Speed">
+      <SettingRow label="Speed">
         <input />
-      </ThemeRow>
+      </SettingRow>
     );
     await flush();
     expect(container.querySelector('.theme-row')?.classList.contains('theme-row--inline')).toBe(
@@ -66,9 +66,9 @@ describe('ThemeRow layout B', () => {
 
   it('keeps the description out of the label (accessible name stays just the label text)', async () => {
     mount(
-      <ThemeRow label="Max floors" tip="Floors for the largest file.">
+      <SettingRow label="Max floors" tip="Floors for the largest file.">
         <input />
-      </ThemeRow>
+      </SettingRow>
     );
     await flush();
     const label = container.querySelector('label');

--- a/app/tests/hooks/useManifestSourceExcludes.test.ts
+++ b/app/tests/hooks/useManifestSourceExcludes.test.ts
@@ -69,10 +69,20 @@ describe('exclude-driven re-fetch', () => {
   });
 
   it('does not re-fetch merely because the source switched', async () => {
+    // Load s1 first so the reaction records a non-null key for it — otherwise
+    // the switch run exits on the `prev === null` branch and the actual
+    // switch-guard (`prevRepo !== repoKey`) is never exercised.
+    const load = loadSource({ src: 's1', branch: undefined });
+    await flush();
+    StubEventSource.instances[0].emit('manifest-complete', MANIFEST_JSON);
+    await load;
+    expect(CURRENT_SOURCE.value?.src).toBe('s1');
+
     const dispose = setupLiveUpdates();
     const before = StubEventSource.instances.length;
-    CURRENT_SOURCE.value = { src: 's2', branch: undefined }; // switch, no exclude edit
+    CURRENT_SOURCE.value = { src: 's2', branch: undefined }; // real repo-key change, no exclude edit
     await flush();
+    // The switch alone must NOT refetch — the load owns sending s2's excludes.
     expect(StubEventSource.instances.length).toBe(before);
     dispose();
   });

--- a/app/tests/hooks/useManifestSourceExcludes.test.ts
+++ b/app/tests/hooks/useManifestSourceExcludes.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadSource, setupLiveUpdates } from '@/hooks/useManifestSource';
+import { CURRENT_SOURCE } from '@/state/stores/source';
+import { MANIFEST } from '@/state/stores/manifest';
+import { EXCLUDES, addExclude } from '@/state/stores/excludes';
+
+// EventSource stub mirrors useManifestSource.test.ts: records listeners so a
+// test can emit a named SSE event and records instances for URL assertions.
+class StubEventSource {
+  static instances: StubEventSource[] = [];
+  closed = false;
+  private listeners: Record<string, ((e: unknown) => void)[]> = {};
+  constructor(public url: string) {
+    StubEventSource.instances.push(this);
+  }
+  addEventListener(name: string, handler: (e: unknown) => void): void {
+    (this.listeners[name] ??= []).push(handler);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  emit(name: string, data: string): void {
+    for (const h of this.listeners[name] ?? []) h({ data });
+  }
+}
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+// Minimal manifest-complete payload so loadSource commits the source. The
+// stream reader treats a `manifest-complete` event as terminal (it closes the
+// EventSource itself) — no separate "done" event exists on the wire.
+const MANIFEST_JSON = JSON.stringify({
+  manifest: {
+    signature: 'sig0',
+    tree_signature: 't0',
+    tree: { name: 'r', type: 'directory', path: '.', children: [] },
+    repo: {},
+  },
+});
+
+describe('exclude-driven re-fetch', () => {
+  let original: typeof EventSource;
+  beforeEach(() => {
+    original = globalThis.EventSource;
+    StubEventSource.instances = [];
+    (globalThis as unknown as { EventSource: unknown }).EventSource = StubEventSource;
+    EXCLUDES.value = {};
+    CURRENT_SOURCE.value = null;
+    MANIFEST.value = { tree: {} } as never;
+  });
+  afterEach(() => {
+    (globalThis as unknown as { EventSource: unknown }).EventSource = original;
+  });
+
+  it('re-fetches the loaded source with the exclude param when an exclude is added', async () => {
+    const load = loadSource({ src: 's', branch: undefined });
+    await flush();
+    StubEventSource.instances[0].emit('manifest-complete', MANIFEST_JSON);
+    await load;
+    expect(CURRENT_SOURCE.value?.src).toBe('s');
+
+    const dispose = setupLiveUpdates();
+    const before = StubEventSource.instances.length;
+    addExclude('vendor');
+    await flush();
+    const fresh = StubEventSource.instances.slice(before);
+    expect(fresh.length).toBeGreaterThan(0);
+    expect(new URL(fresh[0].url).searchParams.getAll('exclude')).toEqual(['vendor']);
+    dispose();
+  });
+
+  it('does not re-fetch merely because the source switched', async () => {
+    const dispose = setupLiveUpdates();
+    const before = StubEventSource.instances.length;
+    CURRENT_SOURCE.value = { src: 's2', branch: undefined }; // switch, no exclude edit
+    await flush();
+    expect(StubEventSource.instances.length).toBe(before);
+    dispose();
+  });
+});

--- a/app/tests/state/persist.test.ts
+++ b/app/tests/state/persist.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { persistedSignal } from '@/state/persist';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('persistedSignal — whole mode (dynamic-key Record)', () => {
+  it('persists a runtime key not present in the default', () => {
+    const s = persistedSignal<Record<string, string[]>>('wholeTest', {}, { whole: true });
+    s.value = { ...s.value, runtimeHash: ['a', 'b'] };
+
+    const raw = localStorage.getItem('cc.wholeTest');
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toEqual({ runtimeHash: ['a', 'b'] });
+  });
+
+  it('hydrates a runtime key back on reconstruction (survives reload)', () => {
+    // First "session": write then implicitly persist via the effect.
+    const first = persistedSignal<Record<string, string[]>>('wholeTest', {}, { whole: true });
+    first.value = { ...first.value, runtimeHash: ['x'] };
+
+    // Second "session": a fresh signal on the same key reads localStorage.
+    const second = persistedSignal<Record<string, string[]>>('wholeTest', {}, { whole: true });
+    expect(second.value).toEqual({ runtimeHash: ['x'] });
+  });
+
+  it('removes the slot when the value returns to the (empty) default', () => {
+    const s = persistedSignal<Record<string, string[]>>('wholeTest', {}, { whole: true });
+    s.value = { runtimeHash: ['x'] };
+    expect(localStorage.getItem('cc.wholeTest')).not.toBeNull();
+    s.value = {};
+    expect(localStorage.getItem('cc.wholeTest')).toBeNull();
+  });
+});
+
+describe('persistedSignal — diff mode (default, unchanged by whole-mode edit)', () => {
+  it('still persists only keys that differ from the default', () => {
+    const s = persistedSignal('diffTest', { a: 1, b: 2 });
+    s.value = { a: 1, b: 9 };
+
+    // Only the changed key is emitted; the default-valued key is omitted.
+    expect(JSON.parse(localStorage.getItem('cc.diffTest') as string)).toEqual({ b: 9 });
+  });
+
+  it('ignores keys absent from the default (the exact behavior whole mode fixes)', () => {
+    const s = persistedSignal<Record<string, number>>('diffTest', {});
+    s.value = { runtimeKey: 1 };
+
+    // Diff mode drops the runtime key -> no entry. This is why EXCLUDES needs
+    // whole mode; asserting it here pins the boundary between the two modes.
+    expect(localStorage.getItem('cc.diffTest')).toBeNull();
+  });
+});

--- a/app/tests/state/stores/excludes.test.ts
+++ b/app/tests/state/stores/excludes.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CURRENT_SOURCE } from '@/state/stores/source';
+import {
+  EXCLUDES,
+  ACTIVE_EXCLUDES,
+  addExclude,
+  removeExclude,
+  clearExcludes,
+  activeExcludePathsFor,
+} from '@/state/stores/excludes';
+
+beforeEach(() => {
+  EXCLUDES.value = {};
+  CURRENT_SOURCE.value = null;
+});
+
+describe('excludes store', () => {
+  it('adds, sorts, and dedupes per repo', () => {
+    CURRENT_SOURCE.value = { src: 'github.com/o/r', branch: 'main' };
+    addExclude('src/b');
+    addExclude('src/a');
+    addExclude('src/a'); // dupe
+    expect(ACTIVE_EXCLUDES.value).toEqual(['src/a', 'src/b']);
+  });
+
+  it('is repo-scoped and branch-invariant', () => {
+    CURRENT_SOURCE.value = { src: 'github.com/o/r', branch: 'main' };
+    addExclude('vendor');
+    CURRENT_SOURCE.value = { src: 'github.com/o/r', branch: 'dev' };
+    expect(ACTIVE_EXCLUDES.value).toEqual(['vendor']); // same repo, other branch
+    CURRENT_SOURCE.value = { src: 'github.com/o/other', branch: 'main' };
+    expect(ACTIVE_EXCLUDES.value).toEqual([]); // different repo
+  });
+
+  it('removes and clears', () => {
+    CURRENT_SOURCE.value = { src: 's', branch: undefined };
+    addExclude('a');
+    addExclude('b');
+    removeExclude('a');
+    expect(ACTIVE_EXCLUDES.value).toEqual(['b']);
+    clearExcludes();
+    expect(ACTIVE_EXCLUDES.value).toEqual([]);
+  });
+
+  it('no-ops when no source is loaded', () => {
+    addExclude('a');
+    expect(EXCLUDES.value).toEqual({});
+  });
+
+  it('activeExcludePathsFor reads by src ignoring branch', () => {
+    CURRENT_SOURCE.value = { src: 's', branch: 'main' };
+    addExclude('x');
+    expect(activeExcludePathsFor('s')).toEqual(['x']);
+    expect(activeExcludePathsFor('other')).toEqual([]);
+  });
+});

--- a/app/tests/state/stores/excludes.test.ts
+++ b/app/tests/state/stores/excludes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { CURRENT_SOURCE } from '@/state/stores/source';
+import { CURRENT_SOURCE, sourceKey } from '@/state/stores/source';
 import {
   EXCLUDES,
   ACTIVE_EXCLUDES,
@@ -52,5 +52,18 @@ describe('excludes store', () => {
     addExclude('x');
     expect(activeExcludePathsFor('s')).toEqual(['x']);
     expect(activeExcludePathsFor('other')).toEqual([]);
+  });
+
+  it('persists the whole map to localStorage (survives reload)', () => {
+    CURRENT_SOURCE.value = { src: 'github.com/o/r', branch: 'main' };
+    addExclude('vendor');
+
+    const raw = localStorage.getItem('cc.excludes');
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toEqual({ [sourceKey('github.com/o/r')]: ['vendor'] });
+
+    // Clearing the last path removes the slot entirely (empty map == default).
+    clearExcludes();
+    expect(localStorage.getItem('cc.excludes')).toBeNull();
   });
 });

--- a/app/tests/state/stores/settingsIndicators.test.ts
+++ b/app/tests/state/stores/settingsIndicators.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   CHANGED_SETTINGS_COUNT,
-  SCAN_CHANGED,
-  APPEARANCE_CHANGED,
-  WORLD_CHANGED,
+  SCAN_COUNT,
+  APPEARANCE_COUNT,
+  WORLD_COUNT,
 } from '@/state/stores/settingsIndicators';
 import { LIVE_UPDATES } from '@/state/stores/settings/updates';
 import { ACCENT_THEME, ACCENT_THEME_DEFAULT } from '@/state/stores/settings/theme';
@@ -22,29 +22,29 @@ beforeEach(() => {
 });
 
 describe('settings indicators', () => {
-  it('excludes count into the total and flag the Scan tab only', () => {
+  it('excludes count into the Scan total and the overall total only', () => {
     const base = CHANGED_SETTINGS_COUNT.value;
-    expect(SCAN_CHANGED.value).toBe(false);
+    expect(SCAN_COUNT.value).toBe(0);
     addExclude('vendor');
-    expect(SCAN_CHANGED.value).toBe(true);
-    expect(APPEARANCE_CHANGED.value).toBe(false);
+    expect(SCAN_COUNT.value).toBe(1);
+    expect(APPEARANCE_COUNT.value).toBe(0);
     expect(CHANGED_SETTINGS_COUNT.value).toBe(base + 1);
     clearExcludes();
-    expect(SCAN_CHANGED.value).toBe(false);
+    expect(SCAN_COUNT.value).toBe(0);
     expect(CHANGED_SETTINGS_COUNT.value).toBe(base);
   });
 
-  it('a changed theme flags Appearance and adds to the count', () => {
+  it('a changed theme counts on Appearance and the total', () => {
     const base = CHANGED_SETTINGS_COUNT.value;
-    expect(APPEARANCE_CHANGED.value).toBe(false);
+    expect(APPEARANCE_COUNT.value).toBe(0);
     ACCENT_THEME.value = (ACCENT_THEME_DEFAULT as string) === 'blue' ? 'green' : 'blue';
-    expect(APPEARANCE_CHANGED.value).toBe(true);
-    expect(WORLD_CHANGED.value).toBe(false);
+    expect(APPEARANCE_COUNT.value).toBe(1);
+    expect(WORLD_COUNT.value).toBe(0);
     expect(CHANGED_SETTINGS_COUNT.value).toBe(base + 1);
   });
 
-  it('a changed World field flags World', () => {
-    expect(WORLD_CHANGED.value).toBe(false);
+  it('a changed World field counts on World', () => {
+    expect(WORLD_COUNT.value).toBe(0);
     const key = getFieldKeys(BUILDINGS)[0];
     const cur = (BUILDINGS.value as Record<string, unknown>)[key];
     const next =
@@ -59,6 +59,6 @@ describe('settings indicators', () => {
       ...(BUILDINGS.value as Record<string, unknown>),
       [key]: next,
     } as typeof BUILDINGS.value;
-    expect(WORLD_CHANGED.value).toBe(true);
+    expect(WORLD_COUNT.value).toBeGreaterThan(0);
   });
 });

--- a/app/tests/state/stores/settingsIndicators.test.ts
+++ b/app/tests/state/stores/settingsIndicators.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  CHANGED_SETTINGS_COUNT,
+  SCAN_CHANGED,
+  APPEARANCE_CHANGED,
+  WORLD_CHANGED,
+} from '@/state/stores/settingsIndicators';
+import { LIVE_UPDATES } from '@/state/stores/settings/updates';
+import { ACCENT_THEME, ACCENT_THEME_DEFAULT } from '@/state/stores/settings/theme';
+import { BUILDINGS } from '@/state/stores/settings/buildings';
+import { CURRENT_SOURCE } from '@/state/stores/source';
+import { EXCLUDES, addExclude, clearExcludes } from '@/state/stores/excludes';
+import { getDefault } from '@/state/persist';
+import { getFieldKeys } from '@/state/settingsSchema';
+
+beforeEach(() => {
+  LIVE_UPDATES.value = getDefault(LIVE_UPDATES);
+  ACCENT_THEME.value = ACCENT_THEME_DEFAULT;
+  BUILDINGS.value = getDefault(BUILDINGS);
+  EXCLUDES.value = {};
+  CURRENT_SOURCE.value = { src: 's', branch: undefined };
+});
+
+describe('settings indicators', () => {
+  it('excludes count into the total and flag the Scan tab only', () => {
+    const base = CHANGED_SETTINGS_COUNT.value;
+    expect(SCAN_CHANGED.value).toBe(false);
+    addExclude('vendor');
+    expect(SCAN_CHANGED.value).toBe(true);
+    expect(APPEARANCE_CHANGED.value).toBe(false);
+    expect(CHANGED_SETTINGS_COUNT.value).toBe(base + 1);
+    clearExcludes();
+    expect(SCAN_CHANGED.value).toBe(false);
+    expect(CHANGED_SETTINGS_COUNT.value).toBe(base);
+  });
+
+  it('a changed theme flags Appearance and adds to the count', () => {
+    const base = CHANGED_SETTINGS_COUNT.value;
+    expect(APPEARANCE_CHANGED.value).toBe(false);
+    ACCENT_THEME.value = (ACCENT_THEME_DEFAULT as string) === 'blue' ? 'green' : 'blue';
+    expect(APPEARANCE_CHANGED.value).toBe(true);
+    expect(WORLD_CHANGED.value).toBe(false);
+    expect(CHANGED_SETTINGS_COUNT.value).toBe(base + 1);
+  });
+
+  it('a changed World field flags World', () => {
+    expect(WORLD_CHANGED.value).toBe(false);
+    const key = getFieldKeys(BUILDINGS)[0];
+    const cur = (BUILDINGS.value as Record<string, unknown>)[key];
+    const next =
+      typeof cur === 'boolean'
+        ? !cur
+        : typeof cur === 'number'
+          ? cur + 1
+          : Array.isArray(cur)
+            ? [...cur, 0]
+            : `${cur}__changed`;
+    BUILDINGS.value = {
+      ...(BUILDINGS.value as Record<string, unknown>),
+      [key]: next,
+    } as typeof BUILDINGS.value;
+    expect(WORLD_CHANGED.value).toBe(true);
+  });
+});

--- a/app/tests/views/ControlsPane/controlsPane.test.tsx
+++ b/app/tests/views/ControlsPane/controlsPane.test.tsx
@@ -78,7 +78,7 @@ describe('ControlsPane subtabs', () => {
       pane.querySelectorAll('.controls-section-summary .text-label')
     ).map((el) => el.textContent);
     expect(sectionLabels).toEqual(['Live updates', 'Excluded from city']);
-    expect(pane.querySelectorAll('.theme-row').length).toBeGreaterThan(0);
+    expect(pane.querySelectorAll('.setting-row').length).toBeGreaterThan(0);
   });
 
   it('renders three action-bar buttons; Save/Discard disabled when clean', () => {
@@ -100,7 +100,7 @@ describe('ControlsPane subtabs', () => {
 
   it('does not render any rebuild badges on rows', () => {
     const pane = mount();
-    expect(pane.querySelector('.theme-row-rebuild-badge')).toBeNull();
+    expect(pane.querySelector('.setting-row-rebuild-badge')).toBeNull();
   });
 
   it('collapsed=true remounts sections at their defaults and resets to the Scan subtab', async () => {
@@ -153,7 +153,7 @@ describe('subgroup group reset button', () => {
 
   it('renders a draft-driven group reset for collapsible World subgroups that have fields', () => {
     const pane = mount();
-    expect(pane.querySelectorAll('.theme-subgroup-collapsible').length).toBeGreaterThan(0);
+    expect(pane.querySelectorAll('.setting-subgroup-collapsible').length).toBeGreaterThan(0);
     expect(pane.querySelectorAll('.controls-subgroup-reset').length).toBeGreaterThan(0);
   });
 

--- a/app/tests/views/ControlsPane/controlsPane.test.tsx
+++ b/app/tests/views/ControlsPane/controlsPane.test.tsx
@@ -50,22 +50,23 @@ describe('ControlsPane subtabs', () => {
     container.remove();
   });
 
-  it('renders exactly three subtabs, World active by default', () => {
+  it('renders exactly three subtabs in Scan, Appearance, World order with Scan active by default', () => {
     const pane = mount();
     expect(pane.classList.contains('controls-pane')).toBe(true);
-    for (const label of ['World', 'Scan', 'Appearance']) {
-      expect(tab(pane, label)).toBeTruthy();
-    }
+    const labels = Array.from(pane.querySelectorAll('[role="tab"]')).map((t) =>
+      t.textContent?.trim()
+    );
+    expect(labels).toEqual(['Scan', 'Appearance', 'World']);
     expect(tab(pane, 'Shortcuts')).toBeUndefined();
     expect(tab(pane, 'Debug')).toBeUndefined();
-    expect(tab(pane, 'World').getAttribute('aria-selected')).toBe('true');
+    expect(tab(pane, 'Scan').getAttribute('aria-selected')).toBe('true');
   });
 
   it('shows the action bar only on World; Scan/Appearance autosave with no footer', () => {
     const pane = mount();
-    expect(pane.querySelector('.controls-actions')).toBeTruthy(); // World
-    clickTab(pane, 'Scan');
-    expect(pane.querySelector('.controls-actions')).toBeNull();
+    expect(pane.querySelector('.controls-actions')).toBeNull(); // Scan (default)
+    clickTab(pane, 'World');
+    expect(pane.querySelector('.controls-actions')).toBeTruthy();
     clickTab(pane, 'Appearance');
     expect(pane.querySelector('.controls-actions')).toBeNull();
   });
@@ -82,6 +83,7 @@ describe('ControlsPane subtabs', () => {
 
   it('renders three action-bar buttons; Save/Discard disabled when clean', () => {
     const pane = mount();
+    clickTab(pane, 'World'); // the action bar lives on the draftable World tab
     const buttons = Array.from(
       pane.querySelectorAll<HTMLButtonElement>('.controls-actions .controls-button')
     );
@@ -101,7 +103,7 @@ describe('ControlsPane subtabs', () => {
     expect(pane.querySelector('.theme-row-rebuild-badge')).toBeNull();
   });
 
-  it('collapsed=true collapses all sections and resets to the World subtab', async () => {
+  it('collapsed=true collapses all sections and resets to the Scan subtab', async () => {
     const pane = mount({ collapsed: false });
     // Open every disclosure, then confirm at least one is expanded.
     pane.querySelectorAll<HTMLButtonElement>('.controls-disclosure-toggle').forEach((b) => {
@@ -110,13 +112,13 @@ describe('ControlsPane subtabs', () => {
     await flush();
     expect(pane.querySelectorAll('.controls-section.is-open').length).toBeGreaterThan(0);
 
-    clickTab(pane, 'Scan');
+    clickTab(pane, 'World'); // move off the default so the reset-to-Scan is observable
     act(() => {
       render(<ControlsPane onClose={() => {}} collapsed={true} />, container);
     });
     await flush();
     const repane = container.querySelector('.pane') as HTMLElement;
-    expect(tab(repane, 'World').getAttribute('aria-selected')).toBe('true');
+    expect(tab(repane, 'Scan').getAttribute('aria-selected')).toBe('true');
     // Sections remounted collapsed: no expanded disclosure remains.
     expect(repane.querySelectorAll('.is-open').length).toBe(0);
     expect(repane.querySelectorAll('[aria-expanded="true"]').length).toBe(0);
@@ -130,7 +132,14 @@ describe('subgroup group reset button', () => {
     act(() => {
       render(<ControlsPane />, container);
     });
-    return container.querySelector('.pane') as HTMLElement;
+    const pane = container.querySelector('.pane') as HTMLElement;
+    // These tests inspect World-tab subgroups; Scan is the default tab now.
+    act(() => {
+      Array.from(pane.querySelectorAll<HTMLButtonElement>('[role="tab"]'))
+        .find((t) => t.textContent?.includes('World'))
+        ?.click();
+    });
+    return pane;
   }
 
   beforeEach(() => {

--- a/app/tests/views/ControlsPane/controlsPane.test.tsx
+++ b/app/tests/views/ControlsPane/controlsPane.test.tsx
@@ -53,7 +53,7 @@ describe('ControlsPane subtabs', () => {
   it('renders exactly three subtabs, World active by default', () => {
     const pane = mount();
     expect(pane.classList.contains('controls-pane')).toBe(true);
-    for (const label of ['World', 'Live updates', 'Appearance']) {
+    for (const label of ['World', 'Scan', 'Appearance']) {
       expect(tab(pane, label)).toBeTruthy();
     }
     expect(tab(pane, 'Shortcuts')).toBeUndefined();
@@ -61,19 +61,22 @@ describe('ControlsPane subtabs', () => {
     expect(tab(pane, 'World').getAttribute('aria-selected')).toBe('true');
   });
 
-  it('shows the action bar only on World; Updates/Appearance autosave with no footer', () => {
+  it('shows the action bar only on World; Scan/Appearance autosave with no footer', () => {
     const pane = mount();
     expect(pane.querySelector('.controls-actions')).toBeTruthy(); // World
-    clickTab(pane, 'Live updates');
+    clickTab(pane, 'Scan');
     expect(pane.querySelector('.controls-actions')).toBeNull();
     clickTab(pane, 'Appearance');
     expect(pane.querySelector('.controls-actions')).toBeNull();
   });
 
-  it('renders the Updates section inline, with no collapsible section wrapper', () => {
+  it('renders the Scan tab as two collapsible sections: Live updates and Excluded from city', () => {
     const pane = mount();
-    clickTab(pane, 'Live updates');
-    expect(pane.querySelector('.controls-section')).toBeNull();
+    clickTab(pane, 'Scan');
+    const sectionLabels = Array.from(
+      pane.querySelectorAll('.controls-section-summary .text-label')
+    ).map((el) => el.textContent);
+    expect(sectionLabels).toEqual(['Live updates', 'Excluded from city']);
     expect(pane.querySelectorAll('.theme-row').length).toBeGreaterThan(0);
   });
 
@@ -107,7 +110,7 @@ describe('ControlsPane subtabs', () => {
     await flush();
     expect(pane.querySelectorAll('.controls-section.is-open').length).toBeGreaterThan(0);
 
-    clickTab(pane, 'Live updates');
+    clickTab(pane, 'Scan');
     act(() => {
       render(<ControlsPane onClose={() => {}} collapsed={true} />, container);
     });

--- a/app/tests/views/ControlsPane/controlsPane.test.tsx
+++ b/app/tests/views/ControlsPane/controlsPane.test.tsx
@@ -103,25 +103,25 @@ describe('ControlsPane subtabs', () => {
     expect(pane.querySelector('.theme-row-rebuild-badge')).toBeNull();
   });
 
-  it('collapsed=true collapses all sections and resets to the Scan subtab', async () => {
+  it('collapsed=true remounts sections at their defaults and resets to the Scan subtab', async () => {
     const pane = mount({ collapsed: false });
-    // Open every disclosure, then confirm at least one is expanded.
+    // Move to World and expand its (default-collapsed) sections — a non-default
+    // state that the remount-on-collapse must discard.
+    clickTab(pane, 'World');
     pane.querySelectorAll<HTMLButtonElement>('.controls-disclosure-toggle').forEach((b) => {
       if (b.getAttribute('aria-expanded') === 'false') b.click();
     });
     await flush();
     expect(pane.querySelectorAll('.controls-section.is-open').length).toBeGreaterThan(0);
 
-    clickTab(pane, 'World'); // move off the default so the reset-to-Scan is observable
     act(() => {
       render(<ControlsPane onClose={() => {}} collapsed={true} />, container);
     });
     await flush();
     const repane = container.querySelector('.pane') as HTMLElement;
+    // Reset to Scan, whose two sections are defaultOpen — so exactly those reopen.
     expect(tab(repane, 'Scan').getAttribute('aria-selected')).toBe('true');
-    // Sections remounted collapsed: no expanded disclosure remains.
-    expect(repane.querySelectorAll('.is-open').length).toBe(0);
-    expect(repane.querySelectorAll('[aria-expanded="true"]').length).toBe(0);
+    expect(repane.querySelectorAll('.controls-section.is-open').length).toBe(2);
   });
 });
 

--- a/app/tests/views/ControlsPane/interfaceThemeSection.test.tsx
+++ b/app/tests/views/ControlsPane/interfaceThemeSection.test.tsx
@@ -70,7 +70,7 @@ describe('InterfaceThemeSection', () => {
     act(() => radio('Warm').click());
     await flush();
     expect(SURFACE_THEME.value).toBe('warm');
-    const surfaceReset = container.querySelectorAll<HTMLButtonElement>('.theme-row-reset')[1];
+    const surfaceReset = container.querySelectorAll<HTMLButtonElement>('.setting-row-reset')[1];
     act(() => surfaceReset.click());
     await flush();
     expect(SURFACE_THEME.value).toBe(SURFACE_THEME_DEFAULT);

--- a/app/tests/views/ControlsPane/sections.test.tsx
+++ b/app/tests/views/ControlsPane/sections.test.tsx
@@ -98,9 +98,9 @@ describe('DynamicSection rendering', () => {
     expect(container.textContent).toContain('Height by age');
     expect(container.textContent).toContain('Outlines');
 
-    // One .theme-row per placed field (RangePair counts as one row).
+    // One .setting-row per placed field (RangePair counts as one row).
     const placed = collectRefs(TREES_SECTION.children ?? []).length;
-    expect(container.querySelectorAll('.theme-row').length).toBe(placed);
+    expect(container.querySelectorAll('.setting-row').length).toBe(placed);
   });
 
   it('caps collapsible nesting at MAX_COLLAPSE_DEPTH: deeper groups render flat', async () => {

--- a/app/tests/views/ExcludesSection.test.tsx
+++ b/app/tests/views/ExcludesSection.test.tsx
@@ -24,7 +24,9 @@ describe('ExcludesSection', () => {
     const host = mount(<ExcludesSection />);
     expect(host.textContent).toContain('vendor');
     expect(host.textContent).toContain('a.md');
-    const removeVendor = host.querySelector<HTMLButtonElement>('button[aria-label="Restore vendor"]');
+    const removeVendor = host.querySelector<HTMLButtonElement>(
+      'button[aria-label="Restore vendor"]'
+    );
     removeVendor!.click();
     await flush(); // signal-driven re-render is microtask-scheduled
     expect(host.textContent).not.toContain('vendor');

--- a/app/tests/views/ExcludesSection.test.tsx
+++ b/app/tests/views/ExcludesSection.test.tsx
@@ -36,4 +36,23 @@ describe('ExcludesSection', () => {
     const host = mount(<ExcludesSection />);
     expect(host.textContent).toMatch(/nothing excluded/i);
   });
+
+  it('clears every exclude via the section header reset button', async () => {
+    addExclude('vendor');
+    addExclude('a.md');
+    const host = mount(<ExcludesSection />);
+    const reset = host.querySelector<HTMLButtonElement>('button.controls-section-reset');
+    expect(reset).not.toBeNull();
+    expect(reset!.disabled).toBe(false); // enabled while there are excludes
+    reset!.click();
+    await flush();
+    expect(host.textContent).toMatch(/nothing excluded/i);
+  });
+
+  it('disables the header reset button when nothing is excluded', () => {
+    const host = mount(<ExcludesSection />);
+    const reset = host.querySelector<HTMLButtonElement>('button.controls-section-reset');
+    expect(reset).not.toBeNull();
+    expect(reset!.disabled).toBe(true);
+  });
 });

--- a/app/tests/views/ExcludesSection.test.tsx
+++ b/app/tests/views/ExcludesSection.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from 'preact';
+import { ExcludesSection } from '@/views/ControlsPane/partials/ExcludesSection';
+import { CURRENT_SOURCE } from '@/state/stores/source';
+import { EXCLUDES, addExclude } from '@/state/stores/excludes';
+import { flush } from '../_helpers/preact';
+
+function mount(ui: preact.VNode) {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  render(ui, host);
+  return host;
+}
+
+beforeEach(() => {
+  EXCLUDES.value = {};
+  CURRENT_SOURCE.value = { src: 's', branch: undefined };
+});
+
+describe('ExcludesSection', () => {
+  it('lists active excludes and removes on click', async () => {
+    addExclude('vendor');
+    addExclude('a.md');
+    const host = mount(<ExcludesSection />);
+    expect(host.textContent).toContain('vendor');
+    expect(host.textContent).toContain('a.md');
+    const removeVendor = host.querySelector<HTMLButtonElement>('button[aria-label="Restore vendor"]');
+    removeVendor!.click();
+    await flush(); // signal-driven re-render is microtask-scheduled
+    expect(host.textContent).not.toContain('vendor');
+  });
+
+  it('shows an empty state when nothing is excluded', () => {
+    const host = mount(<ExcludesSection />);
+    expect(host.textContent).toMatch(/nothing excluded/i);
+  });
+});

--- a/app/tests/views/StreetPaneExclude.test.tsx
+++ b/app/tests/views/StreetPaneExclude.test.tsx
@@ -3,6 +3,7 @@ import { render } from 'preact';
 import { signal } from '@preact/signals';
 import { StreetPane, type StreetPaneState } from '@/views/StreetPane/StreetPane';
 import { NodeKind } from '@/types';
+import { ROOT_PATH } from '@/constants/manifest';
 
 function mount(ui: preact.VNode) {
   const host = document.createElement('div');
@@ -19,6 +20,14 @@ const dir = {
   descendants_ext_breakdown: [],
 } as never;
 
+const rootDir = {
+  name: 'repo',
+  type: NodeKind.Directory,
+  path: ROOT_PATH,
+  children: [],
+  descendants_ext_breakdown: [],
+} as never;
+
 describe('StreetPane exclude action', () => {
   it('calls onExclude with the directory when the exclude button is clicked', () => {
     const onExclude = vi.fn();
@@ -28,5 +37,13 @@ describe('StreetPane exclude action', () => {
     expect(btn).not.toBeNull();
     btn!.click();
     expect(onExclude).toHaveBeenCalledWith(dir);
+  });
+
+  it('does not render the exclude button for the repo root', () => {
+    const onExclude = vi.fn();
+    const state = signal<StreetPaneState>({ directory: rootDir });
+    const host = mount(<StreetPane state={state} onExclude={onExclude} />);
+    const btn = host.querySelector<HTMLButtonElement>('button[aria-label*="Exclude"]');
+    expect(btn).toBeNull();
   });
 });

--- a/app/tests/views/StreetPaneExclude.test.tsx
+++ b/app/tests/views/StreetPaneExclude.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'preact';
+import { signal } from '@preact/signals';
+import { StreetPane, type StreetPaneState } from '@/views/StreetPane/StreetPane';
+import { NodeKind } from '@/types';
+
+function mount(ui: preact.VNode) {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  render(ui, host);
+  return host;
+}
+
+const dir = {
+  name: 'vendor',
+  type: NodeKind.Directory,
+  path: 'vendor',
+  children: [],
+  descendants_ext_breakdown: [],
+} as never;
+
+describe('StreetPane exclude action', () => {
+  it('calls onExclude with the directory when the exclude button is clicked', () => {
+    const onExclude = vi.fn();
+    const state = signal<StreetPaneState>({ directory: dir });
+    const host = mount(<StreetPane state={state} onExclude={onExclude} />);
+    const btn = host.querySelector<HTMLButtonElement>('button[aria-label*="Exclude"]');
+    expect(btn).not.toBeNull();
+    btn!.click();
+    expect(onExclude).toHaveBeenCalledWith(dir);
+  });
+});


### PR DESCRIPTION
Closes #98

**Hide files and directories from the city through the UI**, instead of only via a `.codecityignore` on disk. Select a road or building, click "Exclude from city" in the right pane, and it is gone. Works on remote URLs too, since nothing is written to the repo.

This branch grew past the core feature into the settings pane it touches, plus a building-height fix that came out of QA. Details below.

## Excludes (the #98 core)

Excludes go through the existing scan pipeline, not a separate client-side filter. The frontend keeps your per-repo exclude list in localStorage and sends it as `?exclude=` params; the backend feeds those paths into the same `_should_skip` logic that already handles `.codecityignore` and the built-in skip list. So the manifest stays backend-authored: every rollup, stat, and signature is computed once, over the already-filtered tree, and the city, tree, search, and overview all drop the excluded path.

- **Backend:** `extra_exclude_paths` threaded through `scan_tree` / `signature_tree`, plus a repeated `?exclude=` param on `/api/manifest` and `/api/manifest/signature`. Additive only, layered after `ALWAYS_SKIP` + `.codecityignore` (can't resurrect a default or reach `.git`).
- **State:** a per-repo `EXCLUDES` store (keyed by src, branch-invariant) + a new `{ whole: true }` mode on `persistedSignal` so a dynamic-key map actually persists.
- **Fetch:** excludes on load + poll; an in-place re-fetch when the loaded repo's set changes (each set caches its own manifest via the signature, so repeats are instant).
- **UI:** an "Exclude from city" button in the road/building panes (never on the repo root) + an "Excluded from city" list in a renamed "Scan" settings tab.

## Settings pane

The excludes list needed a home, which turned into consistency work across the Settings pane:

- Tabs reordered to **Scan, Appearance, World** (opens on Scan). Scan + Appearance sections are accordions, expanded by default; Appearance was converted from flat blocks to real accordions so every tab has the same header-reset + per-row-reset chrome. Only the save logic differs per tab.
- **Customization indicators:** a dirty dot (with a white pulse) on the Settings activity-bar icon when anything differs from default, and a per-tab count badge showing how many changed items live under each tab. Excludes fold into the Scan count.

## Refactors (folded in per review/feedback)

- `.lucide-icon` class renamed to a library-neutral `.icon` across the app (call sites no longer name the icon library). Full `<Icon>` wrapper for the remaining `lucide-preact` imports is filed as #105.
- `ThemeRow` component renamed to `SettingRow`, and the whole `theme-*` settings-control class vocabulary to `setting-*` (the real theme system is untouched).
- Removed the dead `inline` section variant.

## Building heights + widths (from QA)

Heights/widths were min-max normalized per repo, so the largest file always hit MAX regardless of its real size: a repo of tiny files became a cluster of similar tall buildings. Added a per-repo ceiling anchored to the absolute size of the biggest file, tunable via two new Buildings sliders (**Full height at (lines)**, **Full width at (KB)**). Small-file repos read as a low-rise/narrow city; repos whose biggest file is at/above the reference are unchanged. Layout + decoration golden baselines recaptured (counts identical, only dimensions shifted).

## Testing

`just test` (api pytest + full app suite) and `just lint` green. New coverage across the exclude flow (backend precedence/signature, persistence round-trip, the switch-guard, URL builders, store, pane/settings UI), the settings indicators, and the building-dimension ceiling. Still wants a manual pass in the running app: exclude a dir and a file, confirm live re-render + persistence across reload on a remote URL and a local path; and eyeball the height scaling on a small-file vs large-file repo.

## Out of scope

Editing the on-disk `.codecityignore` from the UI, glob patterns (exact path only), and un-ignoring backend defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
